### PR TITLE
feat: shareable result snapshots, query force-refresh, and refresh cooldown

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -54,4 +54,4 @@ jobs:
 
             - name: Tests
               working-directory: ${{ env.working-directory }}
-              run: pnpm run test
+              run: pnpm run test:coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [#245](https://github.com/thatmattlove/hyperglass/issues/245): v2.0.0 Vyos version platforms - Moved to latest LTS command set. - @ServerForge
 - [#292](https://github.com/thatmattlove/hyperglass/pull/292): Updates Mikrotik BGP route command so supernets are selected as well as exact matches. - @GrandArcher
+- `cache.timeout` default raised from 120s → 600s. End-user refresh behavior is preserved by `cache.refresh_min_interval` (UI cooldown, default 120s) and the new query `force` flag. Operators relying on 2-minute cache staleness should set `cache.timeout: 120` explicitly.
 
 ### Added
 
 - [#304](https://github.com/thatmattlove/hyperglass/pull/304): Add FRR structured output for BGP Routes - @chriswiggins
+- Sharable result snapshots: clicking the new Share button on a result mints a `/result/<id>` URL (default 7-day TTL, operator-tunable via `cache.share_timeout`).
+- `params.public_url` (optional): when set, share URLs use this base; otherwise derived from request headers.
 
 ## 2.0.4 - 2024-06-30
 

--- a/biome.json
+++ b/biome.json
@@ -9,6 +9,7 @@
             "dist",
             ".next/",
             "out/",
+            "coverage/",
             "favicon-formats.ts",
             "custom.*[js, html]",
             "hyperglass.json"

--- a/docs/pages/configuration/config.mdx
+++ b/docs/pages/configuration/config.mdx
@@ -7,14 +7,15 @@ The `config.yaml` file is broken into multiple sections:
 
 ## Top Level Parameters
 
-| Parameter          | Type            | Default Value                    | Description                                                   |
-| :----------------- | :-------------- | :------------------------------- | :------------------------------------------------------------ |
-| `org_name`         | String          | Beloved Hyperglass User          | Your organization's name.                                     |
-| `plugins`          | List of Strings |                                  | List of hyperglass [plugins](/plugins) to load.               |
-| `primary_asn`      | String          | 65000                            | Your organization's primary ASN. Used to set default UI text. |
-| `request_timeout`  | Number          | 90                               | Global timeout in seconds for all requests.                   |
-| `site_description` | String          | `org_name` Network Looking Glass | `<meta>` description, also used in the API documentation.     |
-| `site_title`       | String          | `org_name`                       | Browser title, also used in the default terms & conditions.   |
+| Parameter          | Type            | Default Value                    | Description                                                                                                                                                            |
+| :----------------- | :-------------- | :------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `org_name`         | String          | Beloved Hyperglass User          | Your organization's name.                                                                                                                                              |
+| `plugins`          | List of Strings |                                  | List of hyperglass [plugins](/plugins) to load.                                                                                                                        |
+| `primary_asn`      | String          | 65000                            | Your organization's primary ASN. Used to set default UI text.                                                                                                          |
+| `public_url`       | URL             | (unset)                          | Public-facing base URL for the looking glass. When set, share links use this base; otherwise derived from request `Host` / `X-Forwarded-Proto` headers. Set this when running behind a reverse proxy. |
+| `request_timeout`  | Number          | 90                               | Global timeout in seconds for all requests.                                                                                                                            |
+| `site_description` | String          | `org_name` Network Looking Glass | `<meta>` description, also used in the API documentation.                                                                                                              |
+| `site_title`       | String          | `org_name`                       | Browser title, also used in the default terms & conditions.                                                                                                            |
 
 #### Example with Defaults
 

--- a/docs/pages/configuration/config/caching.mdx
+++ b/docs/pages/configuration/config/caching.mdx
@@ -1,16 +1,30 @@
+import { Callout } from "nextra/components";
+
 ## Cache
 
 hyperglass automatically caches responses to reduce the number of times devices are queried for the same information.
 
-| Parameter         | Type    | Default Value | Description                                                                     |
-| :---------------- | :------ | :------------ | :------------------------------------------------------------------------------ |
-| `cache.timeout`   | Number  | 120           | Number of seconds for which to cache device responses.                          |
-| `cache.show_text` | Boolean | True          | If true, an indication that a user is viewing cached information will be shown. |
+| Parameter                    | Type    | Default Value | Description                                                                                         |
+| :--------------------------- | :------ | :------------ | :-------------------------------------------------------------------------------------------------- |
+| `cache.timeout`              | Number  | 600           | Number of seconds for which to cache device responses.                                              |
+| `cache.show_text`            | Boolean | True          | If true, an indication that a user is viewing cached information will be shown.                     |
+| `cache.share_enabled`        | Boolean | True          | Enable the shareable-result feature. Disabling requires a UI rebuild.                               |
+| `cache.share_timeout`        | Number  | 604800        | Seconds to retain a shared snapshot (default 7 days).                                               |
+| `cache.share_sliding`        | Boolean | False         | If true, viewing a share extends its TTL by another `share_timeout`.                                |
+| `cache.refresh_min_interval` | Number  | 120           | Minimum seconds between manual refreshes from the UI.                                               |
+
+<Callout type="warning">
+    Disabling `share_enabled` (or changing any cache UI knob) requires a UI rebuild — the values are baked into the static `hyperglass.json` at build time.
+</Callout>
 
 ### Example with Defaults
 
 ```yaml filename="config.yaml"
 cache:
-    timeout: 120
+    timeout: 600
     show_text: true
+    share_enabled: true
+    share_timeout: 604800
+    share_sliding: false
+    refresh_min_interval: 120
 ```

--- a/docs/superpowers/plans/2026-05-01-share-results.md
+++ b/docs/superpowers/plans/2026-05-01-share-results.md
@@ -72,7 +72,7 @@ This chunk introduces the test infrastructure (no API tests exist today) and upd
 
 The canonical state-fixture pattern lives in `hyperglass/state/tests/test_hooks.py:32-89`. Move it up to a top-level `conftest.py` so the API tests can reuse it.
 
-- [ ] **Step 1: Create the conftest with shared fixtures**
+- [x] **Step 1: Create the conftest with shared fixtures**
 
 ```python
 """Top-level pytest fixtures shared across hyperglass test modules."""
@@ -152,12 +152,12 @@ def state(
     _state.clear()
 ```
 
-- [ ] **Step 2: Verify existing tests still pass**
+- [x] **Step 2: Verify existing tests still pass**
 
 Run: `task test -- hyperglass/state/tests/`
 Expected: all green. (We didn't break the duplicated fixtures in `state/tests/test_hooks.py` — pytest resolves the closer one.)
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add hyperglass/conftest.py
@@ -171,14 +171,14 @@ git commit -m "test: add top-level conftest with shared state fixtures"
 - Create: `hyperglass/api/tests/conftest.py`
 - Create: `hyperglass/api/tests/test_smoke.py`
 
-- [ ] **Step 1: Create the `__init__.py` package marker**
+- [x] **Step 1: Create the `__init__.py` package marker**
 
 Empty file:
 
 ```python
 ```
 
-- [ ] **Step 2: Create the API conftest**
+- [x] **Step 2: Create the API conftest**
 
 ```python
 """API-specific test fixtures."""
@@ -206,7 +206,7 @@ def client(state) -> t.Generator[TestClient, None, None]:
         yield test_client
 ```
 
-- [ ] **Step 3: Write a smoke test**
+- [x] **Step 3: Write a smoke test**
 
 ```python
 """Smoke test that the API test scaffolding works."""
@@ -219,12 +219,12 @@ def test_devices_endpoint_returns_seeded_device(client):
     assert any(d.get("name") == "test1" for d in payload)
 ```
 
-- [ ] **Step 4: Run the smoke test**
+- [x] **Step 4: Run the smoke test**
 
 Run: `task test -- hyperglass/api/tests/test_smoke.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/api/tests/
@@ -237,7 +237,7 @@ git commit -m "test(api): add TestClient fixture and smoke test"
 - Modify: `hyperglass/models/config/cache.py`
 - Test: `hyperglass/models/config/tests/test_cache.py` (create if absent)
 
-- [ ] **Step 1: Write failing tests for the new fields**
+- [x] **Step 1: Write failing tests for the new fields**
 
 Create `hyperglass/models/config/tests/__init__.py` (empty) if needed, then `hyperglass/models/config/tests/test_cache.py`:
 
@@ -268,12 +268,12 @@ def test_cache_share_disabled():
     assert cache.share_enabled is False
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run: `pytest hyperglass/models/config/tests/test_cache.py -v`
 Expected: FAIL — fields don't exist yet.
 
-- [ ] **Step 3: Add the fields**
+- [x] **Step 3: Add the fields**
 
 Replace `hyperglass/models/config/cache.py`:
 
@@ -295,17 +295,17 @@ class Cache(HyperglassModel):
     refresh_min_interval: int = 120
 ```
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run: `pytest hyperglass/models/config/tests/test_cache.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Run lint**
+- [x] **Step 5: Run lint**
 
 Run: `task lint`
 Expected: clean.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add hyperglass/models/config/cache.py hyperglass/models/config/tests/
@@ -318,7 +318,7 @@ git commit -m "feat(config): add share_timeout/share_enabled/share_sliding/refre
 - Modify: `hyperglass/models/api/query.py`
 - Test: `hyperglass/models/api/tests/test_query_force.py` (create)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `hyperglass/models/api/tests/__init__.py` (empty) if needed, then `hyperglass/models/api/tests/test_query_force.py`:
 
@@ -350,12 +350,12 @@ def test_query_force_does_not_affect_digest(state):
     assert q1.digest() == q2.digest()
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run: `pytest hyperglass/models/api/tests/test_query_force.py -v`
 Expected: FAIL on `q.force is False` (attribute doesn't exist).
 
-- [ ] **Step 3: Add the field**
+- [x] **Step 3: Add the field**
 
 In `hyperglass/models/api/query.py`, in the `Query` class — **after `query_type` (line 53) and BEFORE `_kwargs: t.Dict[str, t.Any]` (line 54)** — add:
 
@@ -366,17 +366,17 @@ In `hyperglass/models/api/query.py`, in the `Query` class — **after `query_typ
 
 `Query.__repr__` currently returns `repr_from_attrs(self, ("query_location", "query_type", "query_target"))` (line 91). Do **not** add `force` to that tuple — it must not affect the digest.
 
-- [ ] **Step 4: Run the test to verify it passes**
+- [x] **Step 4: Run the test to verify it passes**
 
 Run: `pytest hyperglass/models/api/tests/test_query_force.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Run full test suite to confirm no regressions**
+- [x] **Step 5: Run full test suite to confirm no regressions**
 
 Run: `task test`
 Expected: all green.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add hyperglass/models/api/query.py hyperglass/models/api/tests/
@@ -389,7 +389,7 @@ git commit -m "feat(api): add Query.force flag to bypass cache; excluded from di
 - Modify: `hyperglass/models/config/params.py`
 - Test: `hyperglass/models/config/tests/test_params_public_url.py` (create)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```python
 """Tests for Params.public_url."""
@@ -411,12 +411,12 @@ def test_public_url_set_to_https_url():
     assert str(p.public_url).startswith("https://lg.example.com")
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run: `pytest hyperglass/models/config/tests/test_params_public_url.py -v`
 Expected: FAIL.
 
-- [ ] **Step 3: Add the field**
+- [x] **Step 3: Add the field**
 
 In `hyperglass/models/config/params.py`, near the top of the `Params` class (after existing fields), add:
 
@@ -426,12 +426,12 @@ In `hyperglass/models/config/params.py`, near the top of the `Params` class (aft
 
 Add `from pydantic import AnyHttpUrl` to the imports if not already present.
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Run: `pytest hyperglass/models/config/tests/test_params_public_url.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/models/config/params.py hyperglass/models/config/tests/test_params_public_url.py
@@ -444,7 +444,7 @@ git commit -m "feat(config): add optional Params.public_url for share URL buildi
 - Modify: `hyperglass/models/config/params.py:153-168`
 - Test: `hyperglass/models/config/tests/test_params_frontend.py` (create)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```python
 """Tests for Params.frontend() projection."""
@@ -469,12 +469,12 @@ def test_frontend_excludes_private_share_sliding():
     assert "share_sliding" not in cache
 ```
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `pytest hyperglass/models/config/tests/test_params_frontend.py -v`
 Expected: FAIL (fields not yet projected).
 
-- [ ] **Step 3: Modify the include set**
+- [x] **Step 3: Modify the include set**
 
 In `hyperglass/models/config/params.py`, update `frontend()`:
 
@@ -502,12 +502,12 @@ def frontend(self) -> t.Dict[str, t.Any]:
     )
 ```
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Run: `pytest hyperglass/models/config/tests/test_params_frontend.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/models/config/params.py hyperglass/models/config/tests/test_params_frontend.py
@@ -520,7 +520,7 @@ git commit -m "feat(config): project share UI knobs through Params.frontend()"
 - Modify: `hyperglass/models/api/response.py`
 - Test: `hyperglass/models/api/tests/test_response_models.py` (create)
 
-- [ ] **Step 1: Read the existing response module to learn its conventions**
+- [x] **Step 1: Read the existing response module to learn its conventions**
 
 Run: `cat hyperglass/models/api/response.py`
 
@@ -533,7 +533,7 @@ The existing module does **not** import `datetime` or `snake_to_camel`. Add them
 
 For wire-format consistency with the spec ("camelCase on the wire"), the new share models will use `alias_generator=snake_to_camel`. `QueryResponse`'s existing fields are all single-word (`cached`, `runtime`, `timestamp`, `format`, `random`, `level`, `keywords`, plus the new `id`), so we also add the same `alias_generator` to it for consistency — single-word field aliases are no-ops, so behavior is unchanged. **Do not change `QueryResponse.timestamp`'s type from `str` to `datetime`** — that's a separate decision out of scope here.
 
-- [ ] **Step 2: Write failing tests**
+- [x] **Step 2: Write failing tests**
 
 Create `hyperglass/models/api/tests/__init__.py` (empty) if needed, then `test_response_models.py`:
 
@@ -602,12 +602,12 @@ def test_share_response_shape():
     assert dumped["query"]["query_location"] == "test1"
 ```
 
-- [ ] **Step 3: Run the test**
+- [x] **Step 3: Run the test**
 
 Run: `pytest hyperglass/models/api/tests/test_response_models.py -v`
 Expected: FAIL — `id`, `ShareCreateResponse`, `ShareResponse` don't exist yet.
 
-- [ ] **Step 4: Add imports and update `QueryResponse`**
+- [x] **Step 4: Add imports and update `QueryResponse`**
 
 In `hyperglass/models/api/response.py`, add to the imports:
 
@@ -621,7 +621,7 @@ from hyperglass.util import snake_to_camel
 
 Add `alias_generator=snake_to_camel, populate_by_name=True` to `QueryResponse.model_config`, and add `id: str` to its fields. The existing fields are unchanged; the alias generator is a no-op for single-word names.
 
-- [ ] **Step 5: Add the new models**
+- [x] **Step 5: Add the new models**
 
 Append to `hyperglass/models/api/response.py`:
 
@@ -659,12 +659,12 @@ class ShareResponse(BaseModel):
 
 `query` and `query_labels` are typed `t.Dict[str, t.Any]` / `t.Dict[str, str]` — generic dicts. **The `alias_generator` does NOT camelCase keys inside these nested dicts.** On the wire, `response.query.query_location` stays as `query_location`, not `queryLocation`. Tests in Chunk 2 assert against this snake_case shape.
 
-- [ ] **Step 6: Run the test**
+- [x] **Step 6: Run the test**
 
 Run: `pytest hyperglass/models/api/tests/test_response_models.py -v`
 Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add hyperglass/models/api/response.py hyperglass/models/api/tests/test_response_models.py
@@ -683,7 +683,7 @@ git commit -m "feat(api): add id to QueryResponse, add ShareCreateResponse and S
 
 The current cache write only stores `output` and `timestamp` (lines 130-131). Expand it so the entry carries everything the share endpoint will need.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```python
 """Tests for /api/query cache-write expansion and force flag."""
@@ -730,12 +730,12 @@ def params() -> dict:
 
 Add this fixture override **at the top of the test module** (`hyperglass/api/tests/test_routes_query.py`).
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `task test -- hyperglass/api/tests/test_routes_query.py -v`
 Expected: FAIL — `query`, `query_labels`, `format`, `runtime`, `level` are not in the cache map.
 
-- [ ] **Step 3: Implement the cache-write expansion**
+- [x] **Step 3: Implement the cache-write expansion**
 
 This change has three parts: (a) compute `response_format` and `query_labels` BEFORE the cache write, (b) write the expanded fields, (c) **remove the now-redundant post-write re-read** at lines 138-145.
 
@@ -783,17 +783,17 @@ The cache-hit branch (lines 81-95) still needs `response_format` set; on a cache
 
 The `response = {...}` literal (lines 148-158) keeps its existing shape; `cache_response` (the output to return) is now `raw_output` on miss or `cache.get_map(cache_key, "output")` on hit — adjust the dict assembly to use whichever is in scope.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `task test -- hyperglass/api/tests/test_routes_query.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Run full backend test suite**
+- [x] **Step 5: Run full backend test suite**
 
 Run: `task test`
 Expected: green.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add hyperglass/api/routes.py hyperglass/api/tests/test_routes_query.py
@@ -806,7 +806,7 @@ git commit -m "feat(api): expand /api/query cache write with full snapshot field
 - Modify: `hyperglass/api/routes.py:81-95` (the cache-hit branch)
 - Test: `hyperglass/api/tests/test_routes_query.py` (extend)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Append to `test_routes_query.py`:
 
@@ -828,12 +828,12 @@ def test_force_skips_cache_hit(client, state):
     assert r3.json()["cached"] is False
 ```
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `task test -- hyperglass/api/tests/test_routes_query.py::test_force_skips_cache_hit -v`
 Expected: FAIL — third call is reported as cached.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `hyperglass/api/routes.py`, replace the start of the cache-hit branch:
 
@@ -849,12 +849,12 @@ cache_response = None if data.force else cache.get_map(cache_key, "output")
 
 Do not pre-delete the cache key; on execution failure, the existing entry stays intact.
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Run: `task test -- hyperglass/api/tests/test_routes_query.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/api/routes.py hyperglass/api/tests/test_routes_query.py
@@ -867,7 +867,7 @@ git commit -m "feat(api): /api/query honors force flag to bypass cache"
 - Modify: `hyperglass/api/routes.py` (add helper near top)
 - Test: `hyperglass/api/tests/test_share_helpers.py` (create)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```python
 """Tests for share helper functions."""
@@ -910,12 +910,12 @@ def test_generate_share_id_collision_retry(state, monkeypatch):
     assert sid == "BBBBBBBBBBB"
 ```
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `task test -- hyperglass/api/tests/test_share_helpers.py -v`
 Expected: FAIL — helper doesn't exist.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `hyperglass/api/routes.py`, near the top after imports, add:
 
@@ -937,12 +937,12 @@ def _generate_share_id(cache, max_attempts: int = 3) -> str:
     raise RuntimeError("Failed to generate a unique share ID after retries.")
 ```
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Run: `task test -- hyperglass/api/tests/test_share_helpers.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/api/routes.py hyperglass/api/tests/test_share_helpers.py
@@ -955,7 +955,7 @@ git commit -m "feat(api): add _generate_share_id helper with collision retry"
 - Modify: `hyperglass/api/routes.py`
 - Test: `hyperglass/api/tests/test_share_helpers.py` (extend)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Append to `test_share_helpers.py`:
 
@@ -1004,12 +1004,12 @@ def test_build_share_url_request_no_proxy_headers():
         "http://127.0.0.1:8001/result/abc"
 ```
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `task test -- hyperglass/api/tests/test_share_helpers.py -v`
 Expected: FAIL.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `hyperglass/api/routes.py`, add:
 
@@ -1031,12 +1031,12 @@ def _build_share_url(params, request, share_id: str) -> str:
     return f"{base}/result/{share_id}"
 ```
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Run: `task test -- hyperglass/api/tests/test_share_helpers.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/api/routes.py hyperglass/api/tests/test_share_helpers.py
@@ -1050,7 +1050,7 @@ git commit -m "feat(api): add _build_share_url helper with public_url and proxy 
 - Modify: `hyperglass/api/__init__.py` (register the new handler)
 - Test: `hyperglass/api/tests/test_routes_share.py` (create)
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```python
 """Tests for share-related routes."""
@@ -1112,12 +1112,12 @@ class TestShareDisabled:
         assert r.status_code == 404
 ```
 
-- [ ] **Step 2: Run the tests**
+- [x] **Step 2: Run the tests**
 
 Run: `task test -- hyperglass/api/tests/test_routes_share.py -v`
 Expected: FAIL — endpoint doesn't exist (returns 404 for routing reasons, but the body assertions fail).
 
-- [ ] **Step 3: Implement the endpoint**
+- [x] **Step 3: Implement the endpoint**
 
 In `hyperglass/api/routes.py`, add the imports:
 
@@ -1171,16 +1171,16 @@ async def share_create(
 
 Add `share_create` to the `__all__` tuple at the top of `routes.py`.
 
-- [ ] **Step 4: Register the route**
+- [x] **Step 4: Register the route**
 
 In `hyperglass/api/__init__.py`, the `HANDLERS` list lives at lines 39-45 (initial) and 47-56 (with UI handlers). Add `share_create` to the imports from `hyperglass.api.routes` near line 38 and append it to the `HANDLERS` list before the `if not STATE.settings.disable_ui:` block.
 
-- [ ] **Step 5: Run the tests**
+- [x] **Step 5: Run the tests**
 
 Run: `task test -- hyperglass/api/tests/test_routes_share.py -v`
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add hyperglass/api/routes.py hyperglass/api/__init__.py hyperglass/api/tests/test_routes_share.py
@@ -1194,7 +1194,7 @@ git commit -m "feat(api): add POST /api/query/share/{cache_id} for share creatio
 - Modify: `hyperglass/api/__init__.py`
 - Test: `hyperglass/api/tests/test_routes_share.py` (extend)
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Append to `test_routes_share.py`:
 
@@ -1268,12 +1268,12 @@ class TestShareFixed:
 
 `RedisManager` (see `hyperglass/state/redis.py`) does not expose `.ttl()` directly and `.expire(...)` is keyword-only (`expire_in=` / `expire_at=`). For tests that need raw Redis operations, drop down to `state.redis.instance` (the underlying `redis.Redis` client) and use `state.redis.key(<logical_key>)` to get the namespaced full key.
 
-- [ ] **Step 2: Run the tests**
+- [x] **Step 2: Run the tests**
 
 Run: `task test -- hyperglass/api/tests/test_routes_share.py -v`
 Expected: FAIL — endpoint not yet defined.
 
-- [ ] **Step 3: Implement the endpoint**
+- [x] **Step 3: Implement the endpoint**
 
 In `hyperglass/api/routes.py`:
 
@@ -1312,12 +1312,12 @@ async def share_get(_state: HyperglassState, share_id: str) -> ShareResponse:
 
 Add `share_get` to `__all__` and register it in `hyperglass/api/__init__.py`.
 
-- [ ] **Step 4: Run the tests**
+- [x] **Step 4: Run the tests**
 
 Run: `task test -- hyperglass/api/tests/test_routes_share.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/api/routes.py hyperglass/api/__init__.py hyperglass/api/tests/test_routes_share.py
@@ -1326,22 +1326,22 @@ git commit -m "feat(api): add GET /api/query/share/{share_id} with optional slid
 
 ### Task 2.7: Lint and full backend regression
 
-- [ ] **Step 1: Run Ruff**
+- [x] **Step 1: Run Ruff**
 
 Run: `task lint`
 Expected: clean (zero errors per CONTRIBUTING.md).
 
-- [ ] **Step 2: Run Black + isort**
+- [x] **Step 2: Run Black + isort**
 
 Run: `task format && task sort`
 Expected: no changes (or stage and commit any formatting deltas).
 
-- [ ] **Step 3: Run full test suite**
+- [x] **Step 3: Run full test suite**
 
 Run: `task test`
 Expected: all green.
 
-- [ ] **Step 4: Commit any formatting deltas**
+- [x] **Step 4: Commit any formatting deltas**
 
 ```bash
 git add -A
@@ -1359,12 +1359,12 @@ git commit -m "style: apply ruff/black/isort to share feature"  # only if needed
 
 **Important:** the underscore-prefixed interfaces (`_Cache`, `_Text`, etc.) hold the **raw snake_case shape** that mirrors the backend JSON (`hyperglass.json`). The exported camelCase types (`Cache`, `Text`, …) are derived via `type-fest`'s `CamelCasedPropertiesDeep` at the export boundary (line ~175). Add new fields in **snake_case**, matching backend field names.
 
-- [ ] **Step 1: Read the existing `_Cache` and `_Text` interfaces**
+- [x] **Step 1: Read the existing `_Cache` and `_Text` interfaces**
 
 Run: `grep -n "_Cache\|_Text" hyperglass/ui/types/config.ts`
 Expected: `_Cache` around line 137; `_Text` around line 25.
 
-- [ ] **Step 2: Update `_Cache`**
+- [x] **Step 2: Update `_Cache`**
 
 In `hyperglass/ui/types/config.ts`, replace:
 
@@ -1387,7 +1387,7 @@ interface _Cache {
 }
 ```
 
-- [ ] **Step 3: Add new fields to `_Text`** in snake_case (will be populated by Task 4.1 backend Text model fields)
+- [x] **Step 3: Add new fields to `_Text`** in snake_case (will be populated by Task 4.1 backend Text model fields)
 
 Add to `_Text` (existing fields are all snake_case — match the convention):
 
@@ -1407,12 +1407,12 @@ Add to `_Text` (existing fields are all snake_case — match the convention):
 
 When consumers do `useConfig().web.text.shareButton`, the `CamelCasedProperties` transform converts these to camelCase access automatically.
 
-- [ ] **Step 4: Typecheck**
+- [x] **Step 4: Typecheck**
 
 Run: `task ui-typecheck`
 Expected: PASS — but note this won't catch missing backend fields until the JSON config is rebuilt; that's fine.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/ui/types/config.ts
@@ -1426,12 +1426,12 @@ git commit -m "feat(ui): extend Config types with share knobs and text strings"
 
 **Important context:** `globals.d.ts` is wrapped in a `declare global { ... }` block (line 1). All new global types must be added INSIDE that block, otherwise hooks in Task 3.3 cannot reference `ShareResponse` / `ShareCreateResponse` without explicit imports. The existing `QueryResponse` is a `type` alias (not `interface`) and currently has fields `random`, `cached`, `runtime`, `level`, `timestamp`, `keywords`, `output`, `format`. It does NOT have `id` today — the backend route returns `id` in the response dict (see `routes.py:148-150`) but the type is missing it.
 
-- [ ] **Step 1: Locate the existing types**
+- [x] **Step 1: Locate the existing types**
 
 Run: `grep -n "type QueryResponse\|declare global" hyperglass/ui/types/globals.d.ts`
 Expected: `declare global` near line 1; `type QueryResponse` near line 44.
 
-- [ ] **Step 2: Add `id` to the existing `QueryResponse` type alias**
+- [x] **Step 2: Add `id` to the existing `QueryResponse` type alias**
 
 In `hyperglass/ui/types/globals.d.ts`, find:
 
@@ -1464,7 +1464,7 @@ Add `id: string;` as the first field:
   };
 ```
 
-- [ ] **Step 3: Add `ShareResponse` and `ShareCreateResponse` inside the `declare global { ... }` block**
+- [x] **Step 3: Add `ShareResponse` and `ShareCreateResponse` inside the `declare global { ... }` block**
 
 Add immediately after `type QueryResponse = { ... };`:
 
@@ -1493,7 +1493,7 @@ Add immediately after `type QueryResponse = { ... };`:
   };
 ```
 
-- [ ] **Step 4: Add `force?: boolean` to `FormQuery`**
+- [x] **Step 4: Add `force?: boolean` to `FormQuery`**
 
 `FormQuery` is defined in `hyperglass/ui/types/data.ts:7` as `Swap<FormData, 'queryLocation', string>`. Adding `force` to `FormData` would propagate to the form schema (undesirable). Cleanest approach: extend `FormQuery` directly:
 
@@ -1504,12 +1504,12 @@ export type FormQuery = Swap<FormData, 'queryLocation', string> & { force?: bool
 
 Verify the change compiles by running `task ui-typecheck` (Step 5 below).
 
-- [ ] **Step 5: Typecheck**
+- [x] **Step 5: Typecheck**
 
 Run: `task ui-typecheck`
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add hyperglass/ui/types/globals.d.ts hyperglass/ui/types/data.ts
@@ -1524,7 +1524,7 @@ git commit -m "feat(ui): add id to QueryResponse, add ShareResponse, add force? 
 
 **Note on test pattern:** there is no existing `fetch` mock pattern in this codebase (`use-dns-query.test.tsx` hits real network). This task introduces a new pattern: monkeypatch `global.fetch` per-test via `vi.fn()`. Document this choice in the test file's docstring so future contributors recognize the pattern.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```tsx
 /**
@@ -1600,12 +1600,12 @@ describe('useShareGet', () => {
 
 The `mockResponse` helper provides both `.json()` and `.text()` so error paths that read the body don't trip on a missing method.
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `task pnpm test -- hooks/use-share.test.tsx`
 Expected: FAIL — module doesn't exist.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```ts
 // hyperglass/ui/hooks/use-share.ts
@@ -1655,12 +1655,12 @@ export const useShareGet = (shareId: string | undefined) =>
 
 Note: this hook uses bare `fetch` rather than `useLGQuery`'s `fetchWithTimeout`. Share fetches are short-lived control-plane requests (Redis read, no device interaction) so the global `request_timeout` knob is over-kill here. If this becomes a problem in production, switch to `fetchWithTimeout` with a small fixed timeout (e.g. 10s) and add a follow-up.
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Run: `task pnpm test -- hooks/use-share.test.tsx`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/ui/hooks/use-share.ts hyperglass/ui/hooks/use-share.test.tsx
@@ -1673,13 +1673,13 @@ git commit -m "feat(ui): add useShareCreate (POST) and useShareGet (GET) hooks"
 - Modify: `hyperglass/ui/hooks/use-lg-query.ts`
 - Create: `hyperglass/ui/hooks/use-lg-query.test.tsx`
 
-- [ ] **Step 1: Read the current hook**
+- [x] **Step 1: Read the current hook**
 
 Run: `cat hyperglass/ui/hooks/use-lg-query.ts`
 
 Note `LGQueryKey = [string, FormQuery]` (line 14) and the `useQuery` call at line 72. Because Task 3.2 Step 4 already extended `FormQuery` with optional `force?: boolean`, the existing tuple typing already accepts `force`; no `LGQueryKey` change is needed.
 
-- [ ] **Step 2: Extend the body and queryKey**
+- [x] **Step 2: Extend the body and queryKey**
 
 In `useLGQuery`'s `runQuery` (around line 36), the POST body is constructed from the query object. The hook currently sends **camelCase** keys (`queryLocation`, `queryTarget`, `queryType`) because the backend `Query` Pydantic model uses `alias_generator=snake_to_camel` and `populate_by_name=True`. Inside `runQuery`, the destructured tuple is `[, data]` from `ctx.queryKey` (the second element of `LGQueryKey`). Adapt the existing body literal to also include `force`:
 
@@ -1696,7 +1696,7 @@ Use `data.force` (not `query.force`) — `data` is the destructured queryKey ele
 
 The `queryKey` at line ~72 already uses the query object as the second tuple element. Because `force` is now a field of `FormQuery`, React Query will naturally treat `{...same..., force: true}` as a different key from `{...same..., force: undefined}` — no explicit change to `LGQueryKey` is needed.
 
-- [ ] **Step 3: Add a unit test**
+- [x] **Step 3: Add a unit test**
 
 Create `hyperglass/ui/hooks/use-lg-query.test.tsx`:
 
@@ -1758,12 +1758,12 @@ describe('useLGQuery force flag', () => {
 
 (Adapt the `config` mock fields to whatever `useLGQuery` actually reads — read the hook source to know.)
 
-- [ ] **Step 4: Run UI tests**
+- [x] **Step 4: Run UI tests**
 
 Run: `task pnpm test -- hooks/use-lg-query.test.tsx`
 Expected: pass.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/ui/hooks/
@@ -1780,7 +1780,7 @@ git commit -m "feat(ui): pass-through force flag in useLGQuery"
 - Modify: `hyperglass/models/config/web.py:100-129` (the `Text` class)
 - Test: `hyperglass/models/tests/test_web.py` (note: `hyperglass/models/tests/` already exists with other model tests; `hyperglass/models/config/tests/` does NOT exist — use the existing dir)
 
-- [ ] **Step 1: Write failing test**
+- [x] **Step 1: Write failing test**
 
 Create `hyperglass/models/tests/test_web.py` (this directory already exists with other model tests). Tasks 1.3, 1.5, and 1.6 create `hyperglass/models/config/tests/` for cache- and params-specific tests; we keep web tests under `hyperglass/models/tests/` since `web.py` is the model the test exercises and that's where existing model tests live:
 
@@ -1800,12 +1800,12 @@ def test_text_share_defaults():
     assert t.refresh_cooldown
 ```
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `pytest hyperglass/models/tests/test_web.py -v`
 Expected: FAIL.
 
-- [ ] **Step 3: Add fields to `Text`**
+- [x] **Step 3: Add fields to `Text`**
 
 Append to `Text` in `hyperglass/models/config/web.py`:
 
@@ -1823,12 +1823,12 @@ Append to `Text` in `hyperglass/models/config/web.py`:
     refresh_cooldown: str = "Refresh available in {seconds}s"  # JS-formatted
 ```
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Run: `pytest hyperglass/models/tests/test_web.py -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/models/config/web.py hyperglass/models/tests/test_web.py
@@ -1844,7 +1844,7 @@ git commit -m "feat(config): add share/refresh string fields to Text"
 
 **Design note:** React Query's `refetch()` does NOT accept arbitrary args that propagate to `queryFn`. Per Task 3.4, `force` is part of the `query` object passed to `useLGQuery`, which makes it part of the React Query key — flipping `query.force` from `undefined` to `true` and then calling `refetch()` (or letting React Query auto-fetch the new key) is the mechanism. So `RequeryButton` doesn't directly invoke `force`; instead it asks the parent (or a Zustand action) to **toggle the force state**. The cleanest API: `RequeryButton` accepts an `onRequery: () => void` callback that the parent wires to a state setter that flips `force` to `true` and triggers refetch.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Wrapper pattern is from `hyperglass/ui/hooks/use-dns-query.test.tsx:15-26`. Reproduce here:
 
@@ -1905,18 +1905,18 @@ describe('RequeryButton', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `task pnpm test -- requery-button.test.tsx`
 Expected: FAIL.
 
-- [ ] **Step 3: Implement `RequeryButton`**
+- [x] **Step 3: Implement `RequeryButton`**
 
 Replace the prop signature: instead of `requery: refetch`, accept `{ onRequery: () => void; lastResponseAt: number; isDisabled?: boolean }`. Read `cache.refreshMinInterval` from `useConfig()`. Compute remaining cooldown from `(lastResponseAt + refreshMinInterval * 1000) - Date.now()`. Use a `setInterval` ticking each second to trigger re-render until cooldown elapses. Disable button when cooldown > 0; enabled otherwise.
 
 On click, call `onRequery()` and update parent state to record the new `lastResponseAt` (the parent owns the state).
 
-- [ ] **Step 4: Wire the parent**
+- [x] **Step 4: Wire the parent**
 
 In `hyperglass/ui/components/results/individual.tsx` (where `<RequeryButton requery={refetch} ...>` lives at line 221), refactor so the parent:
 1. Holds `force` state (e.g. `useState<boolean>(false)`).
@@ -1925,11 +1925,11 @@ In `hyperglass/ui/components/results/individual.tsx` (where `<RequeryButton requ
 4. Defines `onRequery` that sets `force=true` and calls `refetch()` (React Query will see the key change and refetch with the new body).
 5. After the response settles, resets `force` back to `false` so the next refetch isn't sticky-forced. (Or leave it; the cache key stability is preserved either way.)
 
-- [ ] **Step 5: Run the test**
+- [x] **Step 5: Run the test**
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add hyperglass/ui/components/results/
@@ -1952,7 +1952,7 @@ interface ShareButtonProps {
 
 The parent (`individual.tsx`) passes `data?.id` from the React Query result. The button is gated on `cacheId` truthiness AND on `config.cache.shareEnabled`.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```tsx
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -2055,12 +2055,12 @@ describe('ShareButton', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `task pnpm test -- share-button.test.tsx`
 Expected: FAIL.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```tsx
 // hyperglass/ui/components/results/share-button.tsx
@@ -2071,11 +2071,11 @@ Expected: FAIL.
 
 Pattern reference: `hyperglass/ui/components/results/header.tsx:34-35` for `useStrf()`/`useConfig()` usage.
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/ui/components/results/share-button.tsx hyperglass/ui/components/results/share-button.test.tsx
@@ -2087,12 +2087,12 @@ git commit -m "feat(ui): add ShareButton with copy-to-clipboard popover"
 **Files:**
 - Modify: `hyperglass/ui/components/results/individual.tsx`
 
-- [ ] **Step 1: Locate the existing button placement**
+- [x] **Step 1: Locate the existing button placement**
 
 Run: `grep -n "RequeryButton\|<Requery" hyperglass/ui/components/results/individual.tsx`
 Expected: `<RequeryButton requery={refetch} isDisabled={isLoading} />` around line 221.
 
-- [ ] **Step 2: Add `<ShareButton>` next to it**
+- [x] **Step 2: Add `<ShareButton>` next to it**
 
 Render conditionally on `data?.id` truthiness. The React Query result variable is named `data` (and `refetch`, `isLoading`) per the existing destructuring in this file:
 
@@ -2103,12 +2103,12 @@ Render conditionally on `data?.id` truthiness. The React Query result variable i
 
 (`onRequery` and `lastResponseAt` come from the parent state added in Task 4.2 Step 4.)
 
-- [ ] **Step 3: Typecheck and lint**
+- [x] **Step 3: Typecheck and lint**
 
 Run: `task ui-typecheck && task ui-lint`
 Expected: clean.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add hyperglass/ui/components/results/individual.tsx
@@ -2131,7 +2131,7 @@ git commit -m "feat(ui): place ShareButton next to RequeryButton in result heade
 
 The form's `defaultValues.queryLocation` is `[]` (array), so a single-string URL param must be wrapped in an array via `setValue('queryLocation', [value])`. Calling `setValue('queryLocation', value)` with a string would fail Vest validation.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```tsx
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -2174,12 +2174,12 @@ it('pre-fills location/target/type from query string on mount', async () => {
 
 (The mock `config` needs to provide enough fields to let the form render. Read `looking-glass-form.tsx` and provide the minimum.)
 
-- [ ] **Step 2: Run the test**
+- [x] **Step 2: Run the test**
 
 Run: `task pnpm test -- looking-glass-form.test.tsx`
 Expected: FAIL.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `looking-glass-form.tsx`, after the `useForm` setup:
 
@@ -2196,11 +2196,11 @@ useEffect(() => {
 }, [router.isReady, router.query, setValue]);
 ```
 
-- [ ] **Step 4: Run the test**
+- [x] **Step 4: Run the test**
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add hyperglass/ui/components/looking-glass-form.tsx hyperglass/ui/components/looking-glass-form.test.tsx
@@ -2229,7 +2229,7 @@ Keep `Results` (`components/results/group.tsx`) as the form-driven path. For the
 
 This refactor is bounded to `individual.tsx` and the share page; `Results`, `LookingGlassForm`, `useFormState`, etc. stay untouched.
 
-- [ ] **Step 1: Add `snapshot` and `readOnly` props to `individual.tsx`**
+- [x] **Step 1: Add `snapshot` and `readOnly` props to `individual.tsx`**
 
 In `hyperglass/ui/components/results/individual.tsx`, change the props type:
 
@@ -2243,7 +2243,7 @@ interface ResultProps {
 
 When `snapshot` is provided: skip the React Query fetch, render directly from `snapshot.output` and `snapshot.queryLabels.location` / `snapshot.queryLabels.type` for the header. When `readOnly`: omit `<ShareButton>` and `<RequeryButton>` from the header.
 
-- [ ] **Step 2: Write the failing page test**
+- [x] **Step 2: Write the failing page test**
 
 ```tsx
 // hyperglass/ui/pages/result/[id].test.tsx
@@ -2332,12 +2332,12 @@ it('exposes a "Run a fresh query" link with prefilled query string', async () =>
 });
 ```
 
-- [ ] **Step 3: Run the test**
+- [x] **Step 3: Run the test**
 
 Run: `task pnpm test -- pages/result/`
 Expected: FAIL.
 
-- [ ] **Step 4: Implement the page**
+- [x] **Step 4: Implement the page**
 
 ```tsx
 // hyperglass/ui/pages/result/[id].tsx
@@ -2372,15 +2372,15 @@ export default function ResultPage() {
 }
 ```
 
-- [ ] **Step 5: Run the test**
+- [x] **Step 5: Run the test**
 
 Expected: PASS.
 
-- [ ] **Step 6: Typecheck, lint, format**
+- [x] **Step 6: Typecheck, lint, format**
 
 Run: `task ui-typecheck && task ui-lint && task ui-format`
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add hyperglass/ui/pages/result/ hyperglass/ui/components/results/individual.tsx
@@ -2392,17 +2392,17 @@ git commit -m "feat(ui): add /result/[id] share view; Result component accepts s
 **Files:**
 - (Possibly) Modify: `hyperglass/api/__init__.py` if `html_mode=True` does not cover the case.
 
-- [ ] **Step 1: Build the UI**
+- [x] **Step 1: Build the UI**
 
 Run: `task ui-build`
 Expected: build succeeds, output under `hyperglass/static/ui/`.
 
-- [ ] **Step 2: Start the backend**
+- [x] **Step 2: Start the backend**
 
 Run: `task start`
 Expected: server up on port 8001 (or configured port).
 
-- [ ] **Step 3: Test the SPA fallback**
+- [x] **Step 3: Test the SPA fallback**
 
 In another shell:
 
@@ -2412,7 +2412,7 @@ curl -i http://127.0.0.1:8001/result/aB3kF9pQ2x_
 
 Expected: 200 OK with `Content-Type: text/html` returning the SPA's `index.html`.
 
-- [ ] **Step 4 (only if Step 3 returned 404):** Add explicit Litestar route handler
+- [x] **Step 4 (only if Step 3 returned 404):** Add explicit Litestar route handler
 
 In `hyperglass/api/__init__.py`, add the imports near the top (alongside existing Litestar imports):
 
@@ -2437,7 +2437,7 @@ Add `share_view_html` to the `HANDLERS` list at line 39, **before** the `if not 
 
 Then re-run Step 3 and confirm 200.
 
-- [ ] **Step 5: Commit (if changes made)**
+- [x] **Step 5: Commit (if changes made)**
 
 ```bash
 git add hyperglass/api/__init__.py
@@ -2453,7 +2453,7 @@ git commit -m "feat(api): explicit /result/<id> route handler when html_mode is 
 - Modify: `docs/pages/configuration/config/caching.mdx` (the existing cache docs page; uses a markdown table format we extend)
 - Modify: `docs/pages/configuration/config.mdx` (the params index — gets the `public_url` row, since `public_url` is a top-level `params.*` field, not under `params.cache.*`)
 
-- [ ] **Step 1: Document the share feature in CHANGELOG**
+- [x] **Step 1: Document the share feature in CHANGELOG**
 
 In `CHANGELOG.md`, under the `## [Unreleased]` section, the existing subsections are `Fixed`, `Security`, `Updated`, `Added`. Add the share feature under `Added` and the cache.timeout default change under `Updated`:
 
@@ -2466,7 +2466,7 @@ In `CHANGELOG.md`, under the `## [Unreleased]` section, the existing subsections
 - `cache.timeout` default raised from 120s → 600s. End-user refresh behavior is preserved by `cache.refresh_min_interval` (UI cooldown, default 120s) and the new query `force` flag. Operators relying on 2-minute cache staleness should set `cache.timeout: 120` explicitly.
 ```
 
-- [ ] **Step 2: Document cache fields in `caching.mdx`**
+- [x] **Step 2: Document cache fields in `caching.mdx`**
 
 In `docs/pages/configuration/config/caching.mdx`, the existing parameter table looks like:
 
@@ -2492,7 +2492,7 @@ Also update the example-with-defaults YAML block to include the new fields with 
 
 Add a callout below the table: "Disabling `share_enabled` (or changing any cache UI knob) requires a UI rebuild — the values are baked into the static `hyperglass.json` at build time."
 
-- [ ] **Step 3: Document `public_url` on the params index page**
+- [x] **Step 3: Document `public_url` on the params index page**
 
 `public_url` is a top-level `params` field, not a cache subfield. In `docs/pages/configuration/config.mdx`, add it to the appropriate `params.*` reference table (or example block) — match the existing format. Suggested row:
 
@@ -2500,7 +2500,7 @@ Add a callout below the table: "Disabling `share_enabled` (or changing any cache
 | `public_url` | URL    | (unset) | Public-facing base URL for the looking glass. When set, share links use this base; otherwise derived from request `Host` / `X-Forwarded-Proto` headers. Set this when running behind a reverse proxy. |
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add CHANGELOG.md docs/pages/configuration/config/caching.mdx docs/pages/configuration/config.mdx
@@ -2509,32 +2509,32 @@ git commit -m "docs: document share-results feature and cache.timeout default ch
 
 ### Task 5.4: End-to-end smoke test
 
-- [ ] **Step 1: Boot stack against fake_output**
+- [x] **Step 1: Boot stack against fake_output**
 
 Set `params.fake_output: true` in your dev config, then `task start`.
 
-- [ ] **Step 2: Run a query in the browser**
+- [x] **Step 2: Run a query in the browser**
 
 - Open `http://127.0.0.1:8001/`
 - Submit a real-shaped query (any device + target + type your seed config has)
 
-- [ ] **Step 3: Verify Share button**
+- [x] **Step 3: Verify Share button**
 
 - Confirm Share button is visible in the result header
 - Click Share → confirm popover opens with a `/result/<id>` URL
 - Click Copy → confirm clipboard contains the URL
 
-- [ ] **Step 4: Open the share URL incognito**
+- [x] **Step 4: Open the share URL incognito**
 
 - Confirm the snapshot renders with the banner
 - Confirm output matches what you saw in the original result
 
-- [ ] **Step 5: Verify refresh cooldown**
+- [x] **Step 5: Verify refresh cooldown**
 
 - Click Refresh < 120s after submitting → confirm disabled with cooldown message
 - Wait > 120s → confirm enabled, click → confirm new query result and a new shareable id
 
-- [ ] **Step 6: Verify expired-cache 410 path**
+- [x] **Step 6: Verify expired-cache 410 path**
 
 Find the redis-cli command appropriate to your environment:
 - **Local Redis (native):** `redis-cli` connects to localhost:6379 by default.
@@ -2554,7 +2554,7 @@ sleep 2
 
 Click Share in the UI → confirm the configured `share_create_expired` message.
 
-- [ ] **Step 7: Verify share survives query-cache expiry (the headline guarantee)**
+- [x] **Step 7: Verify share survives query-cache expiry (the headline guarantee)**
 
 - Run a fresh query (Step 2)
 - Click Share, copy the `/result/<id>` URL
@@ -2563,18 +2563,18 @@ Click Share in the UI → confirm the configured `share_create_expired` message.
 - Open the share URL in a fresh incognito window
 - **Expect:** snapshot still renders correctly. The share has its own TTL (`cache.share_timeout`, default 7 days) independent of the query cache.
 
-- [ ] **Step 8: Verify share-not-found**
+- [x] **Step 8: Verify share-not-found**
 
 - Open `http://127.0.0.1:8001/result/notarealid` → confirm the configured `share_not_found` message
 
-- [ ] **Step 9: Verify `params.public_url` shaping (optional)**
+- [x] **Step 9: Verify `params.public_url` shaping (optional)**
 
 - Set `public_url: https://lg.example.test` in the dev config; restart
 - Run a query, click Share
 - Confirm the popover URL is `https://lg.example.test/result/<id>` (not the local `127.0.0.1` URL)
 - Unset and restart; confirm derived URL returns
 
-- [ ] **Step 10: Sign-off commit (if any deltas surfaced)**
+- [x] **Step 10: Sign-off commit (if any deltas surfaced)**
 
 ```bash
 git add -A
@@ -2583,22 +2583,22 @@ git commit -m "test: smoke test fixes for share-results"  # if needed
 
 ### Task 5.5: Final lint / format / typecheck
 
-- [ ] **Step 1: Backend**
+- [x] **Step 1: Backend**
 
 Run: `task lint && task format && task sort && task test`
 Expected: all clean and green.
 
-- [ ] **Step 2: Frontend**
+- [x] **Step 2: Frontend**
 
 Run: `task ui-typecheck && task ui-lint && task ui-format && task pnpm test`
 Expected: all clean and green.
 
-- [ ] **Step 3: Combined check**
+- [x] **Step 3: Combined check**
 
 Run: `task check`
 Expected: clean.
 
-- [ ] **Step 4: Final commit (if needed)**
+- [x] **Step 4: Final commit (if needed)**
 
 ```bash
 git add -A

--- a/hyperglass/api/__init__.py
+++ b/hyperglass/api/__init__.py
@@ -16,7 +16,7 @@ from hyperglass.exceptions import HyperglassError
 
 # Local
 from .events import check_redis
-from .routes import info, query, device, devices, queries, share_create, share_get
+from .routes import info, query, device, devices, queries, share_get, share_create
 from .middleware import COMPRESSION_CONFIG, create_cors_config
 from .error_handlers import app_handler, http_handler, default_handler, validation_handler
 

--- a/hyperglass/api/__init__.py
+++ b/hyperglass/api/__init__.py
@@ -1,12 +1,14 @@
 """hyperglass API."""
 
 # Standard Library
+import re
 import logging
 
 # Third Party
-from litestar import Litestar
+from litestar import Litestar, get
+from litestar.response import File
 from litestar.openapi import OpenAPIConfig
-from litestar.exceptions import HTTPException, ValidationException
+from litestar.exceptions import HTTPException, ValidationException, NotFoundException
 from litestar.static_files import create_static_files_router
 
 # Project
@@ -22,6 +24,8 @@ from .error_handlers import app_handler, http_handler, default_handler, validati
 
 __all__ = ("app",)
 
+_SHARE_ID_RE = re.compile(r"^[A-Za-z0-9_\-]{11}$")
+
 STATE = use_state()
 
 UI_DIR = STATE.settings.static_path / "ui"
@@ -36,6 +40,24 @@ OPEN_API = OpenAPIConfig(
     root_schema_site="elements",
 )
 
+
+@get("/result/{share_id:str}", include_in_schema=False)
+async def share_view_html(share_id: str) -> File:
+    """Serve the SPA shell (index.html) for share result URLs.
+
+    Litestar's static-files html_mode serves 404.html (the Next.js error
+    page) for unknown paths rather than index.html, which breaks client-side
+    routing to /result/<id>. This explicit handler ensures the SPA shell is
+    returned so the Next.js client router can hydrate the correct page.
+    """
+    if not _SHARE_ID_RE.match(share_id):
+        raise NotFoundException(detail="Invalid share ID format.")
+    index = UI_DIR / "index.html"
+    if not index.exists():
+        raise NotFoundException(detail="UI not built.")
+    return File(path=index, media_type="text/html")
+
+
 HANDLERS = [
     device,
     devices,
@@ -44,6 +66,7 @@ HANDLERS = [
     query,
     share_create,
     share_get,
+    share_view_html,
 ]
 
 if not STATE.settings.disable_ui:

--- a/hyperglass/api/__init__.py
+++ b/hyperglass/api/__init__.py
@@ -6,9 +6,9 @@ import logging
 
 # Third Party
 from litestar import Litestar, get
-from litestar.response import File
 from litestar.openapi import OpenAPIConfig
-from litestar.exceptions import HTTPException, ValidationException, NotFoundException
+from litestar.response import File
+from litestar.exceptions import HTTPException, NotFoundException, ValidationException
 from litestar.static_files import create_static_files_router
 
 # Project

--- a/hyperglass/api/__init__.py
+++ b/hyperglass/api/__init__.py
@@ -16,7 +16,7 @@ from hyperglass.exceptions import HyperglassError
 
 # Local
 from .events import check_redis
-from .routes import info, query, device, devices, queries, share_create
+from .routes import info, query, device, devices, queries, share_create, share_get
 from .middleware import COMPRESSION_CONFIG, create_cors_config
 from .error_handlers import app_handler, http_handler, default_handler, validation_handler
 
@@ -43,6 +43,7 @@ HANDLERS = [
     info,
     query,
     share_create,
+    share_get,
 ]
 
 if not STATE.settings.disable_ui:

--- a/hyperglass/api/__init__.py
+++ b/hyperglass/api/__init__.py
@@ -16,7 +16,7 @@ from hyperglass.exceptions import HyperglassError
 
 # Local
 from .events import check_redis
-from .routes import info, query, device, devices, queries
+from .routes import info, query, device, devices, queries, share_create
 from .middleware import COMPRESSION_CONFIG, create_cors_config
 from .error_handlers import app_handler, http_handler, default_handler, validation_handler
 
@@ -42,6 +42,7 @@ HANDLERS = [
     queries,
     info,
     query,
+    share_create,
 ]
 
 if not STATE.settings.disable_ui:

--- a/hyperglass/api/routes.py
+++ b/hyperglass/api/routes.py
@@ -21,7 +21,7 @@ from hyperglass.models.api import Query
 from hyperglass.models.data import OutputDataModel
 from hyperglass.util.typing import is_type
 from hyperglass.execution.main import execute
-from hyperglass.models.api.response import QueryResponse, ShareCreateResponse
+from hyperglass.models.api.response import QueryResponse, ShareCreateResponse, ShareResponse
 from hyperglass.models.config.params import Params, APIParams
 from hyperglass.models.config.devices import Devices, APIDevice
 
@@ -37,6 +37,7 @@ __all__ = (
     "info",
     "query",
     "share_create",
+    "share_get",
 )
 
 
@@ -222,7 +223,7 @@ async def share_create(
     _state: HyperglassState,
     request: Request,
     cache_id: str,
-) -> ShareCreateResponse:
+) -> Response:
     """Promote a cached query result to a long-lived shareable snapshot."""
     # TODO: make configurable via params.messages (no existing precedent for
     # messages-driven HTTP 404/410 detail strings in this file).
@@ -255,8 +256,42 @@ async def share_create(
         pipe.set_map_item(share_key, "expires_at", expires_at)
         pipe.expire(share_key, expire_in=_state.params.cache.share_timeout)
 
-    return ShareCreateResponse(
+    resp = ShareCreateResponse(
         id=share_id,
         url=_build_share_url(_state.params, request, share_id),
         expires_at=expires_at,
     )
+    return Response(resp.model_dump(by_alias=True, mode="json"), status_code=201)
+
+
+@get("/api/query/share/{share_id:str}", dependencies={"_state": Provide(get_state)})
+async def share_get(_state: HyperglassState, share_id: str) -> Response:
+    """Read a shared snapshot."""
+    if not _state.params.cache.share_enabled:
+        raise NotFoundException()
+
+    cache = _state.redis
+    share_key = f"hyperglass.share.{share_id}"
+    output = cache.get_map(share_key, "output")
+    if output is None:
+        raise NotFoundException("Share not found or expired.")
+
+    if _state.params.cache.share_sliding:
+        cache.expire(share_key, expire_in=_state.params.cache.share_timeout)
+
+    resp = ShareResponse(
+        id=share_id,
+        output=output,
+        cached=True,
+        shared=True,
+        runtime=cache.get_map(share_key, "runtime"),
+        timestamp=cache.get_map(share_key, "timestamp"),
+        format=cache.get_map(share_key, "format"),
+        level=cache.get_map(share_key, "level"),
+        keywords=cache.get_map(share_key, "keywords") or [],
+        query=cache.get_map(share_key, "query"),
+        query_labels=cache.get_map(share_key, "query_labels"),
+        created_at=cache.get_map(share_key, "created_at"),
+        expires_at=cache.get_map(share_key, "expires_at"),
+    )
+    return Response(resp.model_dump(by_alias=True, mode="json"))

--- a/hyperglass/api/routes.py
+++ b/hyperglass/api/routes.py
@@ -5,12 +5,13 @@ import json
 import secrets
 import time
 import typing as t
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 # Third Party
 from litestar import Request, Response, get, post
 from litestar.di import Provide
 from litestar.background_tasks import BackgroundTask
+from litestar.exceptions import HTTPException, NotFoundException
 
 # Project
 from hyperglass.log import log
@@ -20,7 +21,7 @@ from hyperglass.models.api import Query
 from hyperglass.models.data import OutputDataModel
 from hyperglass.util.typing import is_type
 from hyperglass.execution.main import execute
-from hyperglass.models.api.response import QueryResponse
+from hyperglass.models.api.response import QueryResponse, ShareCreateResponse
 from hyperglass.models.config.params import Params, APIParams
 from hyperglass.models.config.devices import Devices, APIDevice
 
@@ -35,6 +36,7 @@ __all__ = (
     "queries",
     "info",
     "query",
+    "share_create",
 )
 
 
@@ -212,4 +214,49 @@ async def query(_state: HyperglassState, request: Request, data: Query) -> Query
             request=request,
             timestamp=timestamp,
         ),
+    )
+
+
+@post("/api/query/share/{cache_id:str}", dependencies={"_state": Provide(get_state)})
+async def share_create(
+    _state: HyperglassState,
+    request: Request,
+    cache_id: str,
+) -> ShareCreateResponse:
+    """Promote a cached query result to a long-lived shareable snapshot."""
+    # TODO: make configurable via params.messages (no existing precedent for
+    # messages-driven HTTP 404/410 detail strings in this file).
+    if not _state.params.cache.share_enabled:
+        raise NotFoundException("Sharing is disabled.")
+
+    digest = cache_id.removeprefix("hyperglass.query.")
+    cache_key = f"hyperglass.query.{digest}"
+
+    cache = _state.redis
+    # Reads must happen on the live manager (not the pipeline) so values are
+    # returned immediately rather than queued.
+    output = cache.get_map(cache_key, "output")
+    if output is None:
+        raise HTTPException(
+            status_code=410,
+            detail="Result has expired. Refresh the query and try again.",
+        )
+
+    share_id = _generate_share_id(cache)
+    share_key = f"hyperglass.share.{share_id}"
+    now = datetime.now(UTC)
+    expires_at = now + timedelta(seconds=_state.params.cache.share_timeout)
+
+    with cache.pipeline() as pipe:
+        for field in ("output", "timestamp", "query", "query_labels",
+                      "format", "runtime", "level", "keywords"):
+            pipe.set_map_item(share_key, field, cache.get_map(cache_key, field))
+        pipe.set_map_item(share_key, "created_at", now)
+        pipe.set_map_item(share_key, "expires_at", expires_at)
+        pipe.expire(share_key, expire_in=_state.params.cache.share_timeout)
+
+    return ShareCreateResponse(
+        id=share_id,
+        url=_build_share_url(_state.params, request, share_id),
+        expires_at=expires_at,
     )

--- a/hyperglass/api/routes.py
+++ b/hyperglass/api/routes.py
@@ -53,6 +53,23 @@ def _generate_share_id(cache, max_attempts: int = 3) -> str:
     raise RuntimeError("Failed to generate a unique share ID after retries.")
 
 
+def _build_share_url(params, request, share_id: str) -> str:
+    """Build the public share URL.
+
+    Prefers `params.public_url` when set; otherwise derives from request
+    headers. `X-Forwarded-Proto` and `Host` take precedence over the
+    direct connection URL so reverse-proxied deployments produce correct
+    public URLs without explicit configuration.
+    """
+    if params.public_url is not None:
+        base = str(params.public_url).rstrip("/")
+    else:
+        host = request.headers.get("host") or request.url.netloc
+        scheme = request.headers.get("x-forwarded-proto") or request.url.scheme
+        base = f"{scheme}://{host}"
+    return f"{base}/result/{share_id}"
+
+
 @get("/api/devices/{id:str}", dependencies={"devices": Provide(get_devices)})
 async def device(devices: Devices, id: str) -> APIDevice:
     """Retrieve a device by ID."""

--- a/hyperglass/api/routes.py
+++ b/hyperglass/api/routes.py
@@ -127,22 +127,35 @@ async def query(_state: HyperglassState, request: Request, data: Query) -> Query
         else:
             raw_output = str(output)
 
-        cache.set_map_item(cache_key, "output", raw_output)
-        cache.set_map_item(cache_key, "timestamp", timestamp)
-        cache.expire(cache_key, expire_in=_state.params.cache.timeout)
+        runtime = int(round(elapsedtime, 0))
+
+        response_format = "application/json" if json_output else "text/plain"
+        query_labels = {
+            "location": data.device.display_name or data.device.name,
+            "type": data.directive.name,
+        }
+
+        with cache.pipeline() as pipe:
+            pipe.set_map_item(cache_key, "output", raw_output)
+            pipe.set_map_item(cache_key, "timestamp", timestamp)
+            pipe.set_map_item(cache_key, "query", data.dict())
+            pipe.set_map_item(cache_key, "query_labels", query_labels)
+            pipe.set_map_item(cache_key, "format", response_format)
+            pipe.set_map_item(cache_key, "runtime", runtime)
+            pipe.set_map_item(cache_key, "level", "success")
+            pipe.set_map_item(cache_key, "keywords", [])
+            pipe.expire(cache_key, expire_in=_state.params.cache.timeout)
 
         _log.bind(cache_timeout=_state.params.cache.timeout).debug("Response cached")
-
-        runtime = int(round(elapsedtime, 0))
 
     # If it does, return the cached entry
     cache_response = cache.get_map(cache_key, "output")
 
-    json_output = is_type(cache_response, t.Dict)
-    response_format = "text/plain"
-
-    if json_output:
-        response_format = "application/json"
+    if cached:
+        # Read format from cache; fall back to detecting from output type for old entries.
+        response_format = cache.get_map(cache_key, "format") or (
+            "application/json" if is_type(cache_response, t.Dict) else "text/plain"
+        )
     _log.info("Execution completed")
 
     response = {

--- a/hyperglass/api/routes.py
+++ b/hyperglass/api/routes.py
@@ -2,16 +2,16 @@
 
 # Standard Library
 import json
-import secrets
 import time
 import typing as t
+import secrets
 from datetime import UTC, datetime, timedelta
 
 # Third Party
 from litestar import Request, Response, get, post
 from litestar.di import Provide
-from litestar.background_tasks import BackgroundTask
 from litestar.exceptions import HTTPException, NotFoundException
+from litestar.background_tasks import BackgroundTask
 
 # Project
 from hyperglass.log import log
@@ -21,7 +21,7 @@ from hyperglass.models.api import Query
 from hyperglass.models.data import OutputDataModel
 from hyperglass.util.typing import is_type
 from hyperglass.execution.main import execute
-from hyperglass.models.api.response import QueryResponse, ShareCreateResponse, ShareResponse
+from hyperglass.models.api.response import QueryResponse, ShareResponse, ShareCreateResponse
 from hyperglass.models.config.params import Params, APIParams
 from hyperglass.models.config.devices import Devices, APIDevice
 
@@ -249,8 +249,16 @@ async def share_create(
     expires_at = now + timedelta(seconds=_state.params.cache.share_timeout)
 
     with cache.pipeline() as pipe:
-        for field in ("output", "timestamp", "query", "query_labels",
-                      "format", "runtime", "level", "keywords"):
+        for field in (
+            "output",
+            "timestamp",
+            "query",
+            "query_labels",
+            "format",
+            "runtime",
+            "level",
+            "keywords",
+        ):
             pipe.set_map_item(share_key, field, cache.get_map(cache_key, field))
         pipe.set_map_item(share_key, "created_at", now)
         pipe.set_map_item(share_key, "expires_at", expires_at)

--- a/hyperglass/api/routes.py
+++ b/hyperglass/api/routes.py
@@ -78,7 +78,7 @@ async def query(_state: HyperglassState, request: Request, data: Query) -> Query
 
     _log.info("Starting query execution")
 
-    cache_response = cache.get_map(cache_key, "output")
+    cache_response = None if data.force else cache.get_map(cache_key, "output")
     json_output = False
     cached = False
     runtime = 65535

--- a/hyperglass/api/routes.py
+++ b/hyperglass/api/routes.py
@@ -2,6 +2,7 @@
 
 # Standard Library
 import json
+import secrets
 import time
 import typing as t
 from datetime import UTC, datetime
@@ -35,6 +36,21 @@ __all__ = (
     "info",
     "query",
 )
+
+
+def _generate_share_id(cache, max_attempts: int = 3) -> str:
+    """Generate an opaque, unique share ID.
+
+    Returns an 11-char URL-safe-base64 token (64 bits of entropy from
+    `secrets.token_urlsafe(8)`). Verifies non-collision against existing
+    `hyperglass.share.*` keys; collision is astronomically unlikely but
+    the check is cheap.
+    """
+    for _ in range(max_attempts):
+        candidate = secrets.token_urlsafe(8)
+        if cache.get_map(f"hyperglass.share.{candidate}", "output") is None:
+            return candidate
+    raise RuntimeError("Failed to generate a unique share ID after retries.")
 
 
 @get("/api/devices/{id:str}", dependencies={"devices": Provide(get_devices)})

--- a/hyperglass/api/tests/conftest.py
+++ b/hyperglass/api/tests/conftest.py
@@ -18,6 +18,7 @@ def client(state) -> t.Generator[TestClient, None, None]:
     # Import here so seeding precedes the FIRST IMPORT of hyperglass.api: the
     # module reads state at import time (STATE = use_state(), OpenAPI config),
     # not merely in startup hooks.
+    # Project
     from hyperglass.api import app
 
     with TestClient(app=app) as test_client:

--- a/hyperglass/api/tests/conftest.py
+++ b/hyperglass/api/tests/conftest.py
@@ -1,0 +1,24 @@
+"""API-specific test fixtures."""
+
+# Standard Library
+import typing as t
+
+# Third Party
+import pytest
+from litestar.testing import TestClient
+
+
+@pytest.fixture
+def client(state) -> t.Generator[TestClient, None, None]:
+    """Litestar TestClient for hitting hyperglass routes.
+
+    Depends on the `state` fixture from the top-level conftest, which
+    populates Redis with params/devices/directives/ui_params.
+    """
+    # Import here so seeding precedes the FIRST IMPORT of hyperglass.api: the
+    # module reads state at import time (STATE = use_state(), OpenAPI config),
+    # not merely in startup hooks.
+    from hyperglass.api import app
+
+    with TestClient(app=app) as test_client:
+        yield test_client

--- a/hyperglass/api/tests/test_routes_query.py
+++ b/hyperglass/api/tests/test_routes_query.py
@@ -1,4 +1,4 @@
-"""Tests for /api/query cache-write expansion."""
+"""Tests for /api/query cache-write expansion and force flag."""
 
 # Third Party
 import pytest
@@ -59,3 +59,21 @@ def test_query_hit_path_returns_cached(client, state):
     assert body["cached"] is True
     # format field must be present and non-empty (no 500 on format handling).
     assert body.get("format") in ("application/json", "text/plain")
+
+
+def test_force_skips_cache_hit(client, state):
+    """Force flag must bypass cache and re-execute the query."""
+    body = {"queryLocation": "test1", "queryTarget": "192.0.2.0/24",
+            "queryType": "juniper_bgp_route"}
+    r1 = client.post("/api/query", json=body)
+    assert r1.status_code == 201
+    assert r1.json()["cached"] is False
+
+    # Second call without force: cache hit.
+    r2 = client.post("/api/query", json=body)
+    assert r2.json()["cached"] is True
+
+    # Third call with force: cache must be skipped (re-execution).
+    r3 = client.post("/api/query", json={**body, "force": True})
+    assert r3.status_code == 201
+    assert r3.json()["cached"] is False

--- a/hyperglass/api/tests/test_routes_query.py
+++ b/hyperglass/api/tests/test_routes_query.py
@@ -12,11 +12,14 @@ def params() -> dict:
 
 def test_query_caches_all_snapshot_fields(client, state):
     # First call seeds cache.
-    r1 = client.post("/api/query", json={
-        "queryLocation": "test1",
-        "queryTarget": "192.0.2.0/24",
-        "queryType": "juniper_bgp_route",
-    })
+    r1 = client.post(
+        "/api/query",
+        json={
+            "queryLocation": "test1",
+            "queryTarget": "192.0.2.0/24",
+            "queryType": "juniper_bgp_route",
+        },
+    )
     assert r1.status_code == 201
     cache_id = r1.json()["id"]
 
@@ -63,8 +66,11 @@ def test_query_hit_path_returns_cached(client, state):
 
 def test_force_skips_cache_hit(client, state):
     """Force flag must bypass cache and re-execute the query."""
-    body = {"queryLocation": "test1", "queryTarget": "192.0.2.0/24",
-            "queryType": "juniper_bgp_route"}
+    body = {
+        "queryLocation": "test1",
+        "queryTarget": "192.0.2.0/24",
+        "queryType": "juniper_bgp_route",
+    }
     r1 = client.post("/api/query", json=body)
     assert r1.status_code == 201
     assert r1.json()["cached"] is False

--- a/hyperglass/api/tests/test_routes_query.py
+++ b/hyperglass/api/tests/test_routes_query.py
@@ -1,0 +1,61 @@
+"""Tests for /api/query cache-write expansion."""
+
+# Third Party
+import pytest
+
+
+@pytest.fixture
+def params() -> dict:
+    # fake_output enables routes to return without hitting real devices.
+    return {"fake_output": True}
+
+
+def test_query_caches_all_snapshot_fields(client, state):
+    # First call seeds cache.
+    r1 = client.post("/api/query", json={
+        "queryLocation": "test1",
+        "queryTarget": "192.0.2.0/24",
+        "queryType": "juniper_bgp_route",
+    })
+    assert r1.status_code == 201
+    cache_id = r1.json()["id"]
+
+    cache = state.redis
+    digest = cache_id.removeprefix("hyperglass.query.")
+    cache_key = f"hyperglass.query.{digest}"
+
+    assert cache.get_map(cache_key, "output") is not None
+    assert cache.get_map(cache_key, "timestamp") is not None
+    assert cache.get_map(cache_key, "query") is not None
+    assert cache.get_map(cache_key, "query_labels") is not None
+    assert cache.get_map(cache_key, "format") is not None
+    assert cache.get_map(cache_key, "runtime") is not None
+    assert cache.get_map(cache_key, "level") is not None
+    assert cache.get_map(cache_key, "keywords") == []
+
+    qmap = cache.get_map(cache_key, "query")
+    assert qmap["query_location"] == "test1"
+
+    labels = cache.get_map(cache_key, "query_labels")
+    assert "location" in labels
+    assert "type" in labels
+    assert labels["type"] == "BGP Route"
+
+
+def test_query_hit_path_returns_cached(client, state):
+    """Second POST of the same query must return a 201 with cached=True."""
+    payload = {
+        "queryLocation": "test1",
+        "queryTarget": "192.0.2.0/24",
+        "queryType": "juniper_bgp_route",
+    }
+
+    r1 = client.post("/api/query", json=payload)
+    assert r1.status_code == 201
+
+    r2 = client.post("/api/query", json=payload)
+    assert r2.status_code == 201
+    body = r2.json()
+    assert body["cached"] is True
+    # format field must be present and non-empty (no 500 on format handling).
+    assert body.get("format") in ("application/json", "text/plain")

--- a/hyperglass/api/tests/test_routes_share.py
+++ b/hyperglass/api/tests/test_routes_share.py
@@ -16,11 +16,14 @@ def params() -> dict:
 
 def _seed_query(client) -> str:
     """Run a query and return the cache_id."""
-    r = client.post("/api/query", json={
-        "queryLocation": "test1",
-        "queryTarget": "192.0.2.0/24",
-        "queryType": "juniper_bgp_route",
-    })
+    r = client.post(
+        "/api/query",
+        json={
+            "queryLocation": "test1",
+            "queryTarget": "192.0.2.0/24",
+            "queryType": "juniper_bgp_route",
+        },
+    )
     assert r.status_code == 201
     return r.json()["id"]
 

--- a/hyperglass/api/tests/test_routes_share.py
+++ b/hyperglass/api/tests/test_routes_share.py
@@ -1,0 +1,63 @@
+"""Tests for share-related routes."""
+
+# Standard Library
+import re
+
+# Third Party
+import pytest
+
+
+@pytest.fixture
+def params() -> dict:
+    # fake_output enables routes to return without hitting real devices.
+    return {"fake_output": True}
+
+
+def _seed_query(client) -> str:
+    """Run a query and return the cache_id."""
+    r = client.post("/api/query", json={
+        "queryLocation": "test1",
+        "queryTarget": "192.0.2.0/24",
+        "queryType": "juniper_bgp_route",
+    })
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+def test_share_create_returns_opaque_id(client):
+    cache_id = _seed_query(client)
+    r = client.post(f"/api/query/share/{cache_id}")
+    assert r.status_code in (200, 201)
+    body = r.json()
+    assert "id" in body
+    # 11-char URL-safe base64
+    assert re.fullmatch(r"[A-Za-z0-9_-]{11}", body["id"])
+    assert body["url"].endswith(f"/result/{body['id']}")
+
+
+def test_share_create_410_when_cache_expired(client, state):
+    cache_id = _seed_query(client)
+    digest = cache_id.removeprefix("hyperglass.query.")
+    # state.redis.delete() applies the namespace prefix via _key_join.
+    state.redis.delete(f"hyperglass.query.{digest}")
+
+    r = client.post(f"/api/query/share/{cache_id}")
+    assert r.status_code == 410
+
+
+class TestShareDisabled:
+    """Verify the disabled-feature kill switch.
+
+    Overrides the module-level ``params`` fixture so ``share_enabled`` is False.
+    """
+
+    @pytest.fixture
+    def params(self) -> dict:
+        """Return params with sharing disabled."""
+        return {"fake_output": True, "cache": {"share_enabled": False}}
+
+    def test_share_create_404(self, client):
+        """Return 404 when sharing is disabled, even without a cache entry."""
+        # The disabled gate fires before any cache lookup.
+        r = client.post("/api/query/share/hyperglass.query.deadbeef")
+        assert r.status_code == 404

--- a/hyperglass/api/tests/test_routes_share.py
+++ b/hyperglass/api/tests/test_routes_share.py
@@ -2,6 +2,7 @@
 
 # Standard Library
 import re
+from pathlib import Path
 from datetime import datetime
 
 # Third Party
@@ -146,3 +147,33 @@ class TestShareFixed:
         client.get(f"/api/query/share/{share_id}")
         ttl = state.redis.instance.ttl(full_key)
         assert ttl <= 60  # not extended
+
+
+class TestShareViewHtml:
+    """GET /result/<share_id> serves the SPA shell when index.html is present.
+
+    Also verifies that invalid-format IDs are rejected with 404.
+    """
+
+    # Locate the exported index.html relative to this file.
+    _INDEX = Path(__file__).parent.parent.parent / "static" / "ui" / "index.html"
+
+    @pytest.mark.skipif(
+        not (_INDEX.exists()),
+        reason="static/ui/index.html not present; run `task ui-build` first",
+    )
+    def test_valid_id_serves_index_html(self, client):
+        """A well-formed 11-char share ID must return 200 text/html (the SPA shell)."""
+        r = client.get("/result/AAAAAAAAAAA")
+        assert r.status_code == 200
+        assert "text/html" in r.headers.get("content-type", "")
+
+    def test_invalid_id_returns_404(self, client):
+        """An ID that doesn't match [A-Za-z0-9_-]{11} must be rejected with 404."""
+        r = client.get("/result/toolong12345")
+        assert r.status_code == 404
+
+    def test_short_id_returns_404(self, client):
+        """An ID shorter than 11 characters must be rejected with 404."""
+        r = client.get("/result/short")
+        assert r.status_code == 404

--- a/hyperglass/api/tests/test_routes_share.py
+++ b/hyperglass/api/tests/test_routes_share.py
@@ -2,6 +2,7 @@
 
 # Standard Library
 import re
+from datetime import datetime
 
 # Third Party
 import pytest
@@ -27,12 +28,14 @@ def _seed_query(client) -> str:
 def test_share_create_returns_opaque_id(client):
     cache_id = _seed_query(client)
     r = client.post(f"/api/query/share/{cache_id}")
-    assert r.status_code in (200, 201)
+    assert r.status_code == 201
     body = r.json()
     assert "id" in body
     # 11-char URL-safe base64
     assert re.fullmatch(r"[A-Za-z0-9_-]{11}", body["id"])
     assert body["url"].endswith(f"/result/{body['id']}")
+    assert "expiresAt" in body
+    datetime.fromisoformat(body["expiresAt"].replace("Z", "+00:00"))
 
 
 def test_share_create_410_when_cache_expired(client, state):
@@ -61,3 +64,82 @@ class TestShareDisabled:
         # The disabled gate fires before any cache lookup.
         r = client.post("/api/query/share/hyperglass.query.deadbeef")
         assert r.status_code == 404
+
+    def test_share_get_404(self, client):
+        """GET also 404s when sharing is disabled."""
+        r = client.get("/api/query/share/AAAAAAAAAAA")
+        assert r.status_code == 404
+
+
+def test_share_get_returns_full_snapshot(client):
+    cache_id = _seed_query(client)
+    create_resp = client.post(f"/api/query/share/{cache_id}").json()
+
+    r = client.get(f"/api/query/share/{create_resp['id']}")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["shared"] is True
+    # The model's own fields are aliased to camelCase. Keys inside the
+    # nested `query` dict are NOT aliased (generic dict). They stay snake_case.
+    assert body["query"]["query_location"] == "test1"
+    assert body["queryLabels"]["type"] == "BGP Route"
+    assert "createdAt" in body
+    assert "expiresAt" in body
+
+
+def test_share_get_404_when_missing(client):
+    r = client.get("/api/query/share/nonexistent1")
+    assert r.status_code == 404
+
+
+class TestShareSliding:
+    """GET extends the share TTL when share_sliding is enabled."""
+
+    @pytest.fixture
+    def params(self) -> dict:
+        """Enable sliding TTL with a short share timeout."""
+        return {
+            "fake_output": True,
+            "cache": {"share_sliding": True, "share_timeout": 600},
+        }
+
+    def test_get_resets_ttl(self, client, state):
+        """A GET on a share must extend its TTL back toward share_timeout."""
+        cache_id = _seed_query(client)
+        share_id = client.post(f"/api/query/share/{cache_id}").json()["id"]
+        share_key = f"hyperglass.share.{share_id}"
+        full_key = state.redis.key(share_key)
+
+        # Manually shorten the TTL to verify GET extends it back.
+        # RedisManager.expire is keyword-only; use the underlying redis-py
+        # client (state.redis.instance) for raw operations not in the
+        # manager's API.
+        state.redis.instance.expire(full_key, 60)
+        r = client.get(f"/api/query/share/{share_id}")
+        assert r.status_code == 200
+
+        ttl = state.redis.instance.ttl(full_key)
+        assert ttl > 60  # extended back toward share_timeout
+
+
+class TestShareFixed:
+    """GET must NOT extend the share TTL when share_sliding is disabled."""
+
+    @pytest.fixture
+    def params(self) -> dict:
+        """Disable sliding TTL with a short share timeout."""
+        return {
+            "fake_output": True,
+            "cache": {"share_sliding": False, "share_timeout": 600},
+        }
+
+    def test_get_does_not_extend_ttl(self, client, state):
+        """A GET on a share must leave its TTL untouched."""
+        cache_id = _seed_query(client)
+        share_id = client.post(f"/api/query/share/{cache_id}").json()["id"]
+        full_key = state.redis.key(f"hyperglass.share.{share_id}")
+
+        state.redis.instance.expire(full_key, 60)
+        client.get(f"/api/query/share/{share_id}")
+        ttl = state.redis.instance.ttl(full_key)
+        assert ttl <= 60  # not extended

--- a/hyperglass/api/tests/test_share_helpers.py
+++ b/hyperglass/api/tests/test_share_helpers.py
@@ -33,3 +33,47 @@ def test_generate_share_id_collision_retry(state, monkeypatch):
     )
     sid = routes._generate_share_id(cache)
     assert sid == "BBBBBBBBBBB"
+
+
+def test_build_share_url_uses_params_public_url():
+    from hyperglass.api.routes import _build_share_url
+    from hyperglass.models.config.params import Params
+
+    params = Params(public_url="https://lg.example.com")
+    # Pass None for request — params.public_url wins.
+    assert _build_share_url(params, None, "abc123") == \
+        "https://lg.example.com/result/abc123"
+
+
+def test_build_share_url_falls_back_to_request():
+    from hyperglass.api.routes import _build_share_url
+    from hyperglass.models.config.params import Params
+
+    class FakeURL:
+        scheme = "http"
+        netloc = "127.0.0.1:8001"
+
+    class FakeRequest:
+        headers = {"host": "lg.example.com", "x-forwarded-proto": "https"}
+        url = FakeURL()
+
+    params = Params()  # public_url unset
+    assert _build_share_url(params, FakeRequest(), "abc123") == \
+        "https://lg.example.com/result/abc123"
+
+
+def test_build_share_url_request_no_proxy_headers():
+    from hyperglass.api.routes import _build_share_url
+    from hyperglass.models.config.params import Params
+
+    class FakeURL:
+        scheme = "http"
+        netloc = "127.0.0.1:8001"
+
+    class FakeRequest:
+        headers = {}
+        url = FakeURL()
+
+    params = Params()
+    assert _build_share_url(params, FakeRequest(), "abc") == \
+        "http://127.0.0.1:8001/result/abc"

--- a/hyperglass/api/tests/test_share_helpers.py
+++ b/hyperglass/api/tests/test_share_helpers.py
@@ -5,7 +5,9 @@ import re
 
 
 def test_generate_share_id_format(state):
+    # Project
     from hyperglass.api.routes import _generate_share_id
+
     cache = state.redis
     sid = _generate_share_id(cache)
     assert isinstance(sid, str)
@@ -14,7 +16,9 @@ def test_generate_share_id_format(state):
 
 
 def test_generate_share_id_unique(state):
+    # Project
     from hyperglass.api.routes import _generate_share_id
+
     cache = state.redis
     seen = {_generate_share_id(cache) for _ in range(100)}
     assert len(seen) == 100
@@ -22,30 +26,31 @@ def test_generate_share_id_unique(state):
 
 def test_generate_share_id_collision_retry(state, monkeypatch):
     """If the first ID exists, the helper retries."""
+    # Project
     from hyperglass.api import routes
+
     cache = state.redis
 
     cache.set_map_item("hyperglass.share.AAAAAAAAAAA", "output", "x")
 
     sequence = iter(["AAAAAAAAAAA", "BBBBBBBBBBB"])
-    monkeypatch.setattr(
-        routes.secrets, "token_urlsafe", lambda n: next(sequence)
-    )
+    monkeypatch.setattr(routes.secrets, "token_urlsafe", lambda n: next(sequence))
     sid = routes._generate_share_id(cache)
     assert sid == "BBBBBBBBBBB"
 
 
 def test_build_share_url_uses_params_public_url():
+    # Project
     from hyperglass.api.routes import _build_share_url
     from hyperglass.models.config.params import Params
 
     params = Params(public_url="https://lg.example.com")
     # Pass None for request — params.public_url wins.
-    assert _build_share_url(params, None, "abc123") == \
-        "https://lg.example.com/result/abc123"
+    assert _build_share_url(params, None, "abc123") == "https://lg.example.com/result/abc123"
 
 
 def test_build_share_url_falls_back_to_request():
+    # Project
     from hyperglass.api.routes import _build_share_url
     from hyperglass.models.config.params import Params
 
@@ -58,11 +63,13 @@ def test_build_share_url_falls_back_to_request():
         url = FakeURL()
 
     params = Params()  # public_url unset
-    assert _build_share_url(params, FakeRequest(), "abc123") == \
-        "https://lg.example.com/result/abc123"
+    assert (
+        _build_share_url(params, FakeRequest(), "abc123") == "https://lg.example.com/result/abc123"
+    )
 
 
 def test_build_share_url_request_no_proxy_headers():
+    # Project
     from hyperglass.api.routes import _build_share_url
     from hyperglass.models.config.params import Params
 
@@ -75,5 +82,4 @@ def test_build_share_url_request_no_proxy_headers():
         url = FakeURL()
 
     params = Params()
-    assert _build_share_url(params, FakeRequest(), "abc") == \
-        "http://127.0.0.1:8001/result/abc"
+    assert _build_share_url(params, FakeRequest(), "abc") == "http://127.0.0.1:8001/result/abc"

--- a/hyperglass/api/tests/test_share_helpers.py
+++ b/hyperglass/api/tests/test_share_helpers.py
@@ -39,6 +39,25 @@ def test_generate_share_id_collision_retry(state, monkeypatch):
     assert sid == "BBBBBBBBBBB"
 
 
+def test_generate_share_id_exhausts_attempts(state, monkeypatch):
+    """If every attempt collides, the helper raises after max_attempts."""
+    # Standard Library
+    import pytest
+
+    # Project
+    from hyperglass.api import routes
+
+    cache = state.redis
+
+    # Seed the single ID the patched generator always returns so every
+    # attempt collides.
+    cache.set_map_item("hyperglass.share.AAAAAAAAAAA", "output", "x")
+    monkeypatch.setattr(routes.secrets, "token_urlsafe", lambda n: "AAAAAAAAAAA")
+
+    with pytest.raises(RuntimeError, match="unique share ID"):
+        routes._generate_share_id(cache, max_attempts=3)
+
+
 def test_build_share_url_uses_params_public_url():
     # Project
     from hyperglass.api.routes import _build_share_url

--- a/hyperglass/api/tests/test_share_helpers.py
+++ b/hyperglass/api/tests/test_share_helpers.py
@@ -1,0 +1,35 @@
+"""Tests for share helper functions."""
+
+# Standard Library
+import re
+
+
+def test_generate_share_id_format(state):
+    from hyperglass.api.routes import _generate_share_id
+    cache = state.redis
+    sid = _generate_share_id(cache)
+    assert isinstance(sid, str)
+    # secrets.token_urlsafe(8) -> 11 chars, [A-Za-z0-9_-]
+    assert re.fullmatch(r"[A-Za-z0-9_-]{11}", sid)
+
+
+def test_generate_share_id_unique(state):
+    from hyperglass.api.routes import _generate_share_id
+    cache = state.redis
+    seen = {_generate_share_id(cache) for _ in range(100)}
+    assert len(seen) == 100
+
+
+def test_generate_share_id_collision_retry(state, monkeypatch):
+    """If the first ID exists, the helper retries."""
+    from hyperglass.api import routes
+    cache = state.redis
+
+    cache.set_map_item("hyperglass.share.AAAAAAAAAAA", "output", "x")
+
+    sequence = iter(["AAAAAAAAAAA", "BBBBBBBBBBB"])
+    monkeypatch.setattr(
+        routes.secrets, "token_urlsafe", lambda n: next(sequence)
+    )
+    sid = routes._generate_share_id(cache)
+    assert sid == "BBBBBBBBBBB"

--- a/hyperglass/api/tests/test_smoke.py
+++ b/hyperglass/api/tests/test_smoke.py
@@ -1,0 +1,8 @@
+"""Smoke test that the API test scaffolding works."""
+
+
+def test_devices_endpoint_returns_seeded_device(client):
+    response = client.get("/api/devices")
+    assert response.status_code == 200
+    payload = response.json()
+    assert any(d.get("name") == "test1" for d in payload)

--- a/hyperglass/conftest.py
+++ b/hyperglass/conftest.py
@@ -17,6 +17,43 @@ if t.TYPE_CHECKING:
     from hyperglass.state import HyperglassState
 
 
+def _seed_stub_state() -> None:
+    """Seed Redis with minimal stub state so api modules can be imported during collection.
+
+    hyperglass.api reads Redis at module import time. pytest loads this
+    top-level conftest before any nested conftest in both
+    path-targeted and directory runs, so module-level seeding here is
+    guaranteed to precede the first ``import hyperglass.api``. A
+    ``pytest_configure`` hook defined in this conftest would NOT be sufficient:
+    it fires after this module body, and on direct test-file invocations
+    (``pytest hyperglass/api/tests/test_x.py``) nested conftests are imported
+    during initial conftest loading — before any configure hook — triggering the
+    ``hyperglass.api`` import with unseeded Redis.
+
+    This overwrites the params/directives/devices/ui_params keys unconditionally —
+    never point the test suite at a Redis instance holding real configuration
+    (the ``state`` fixture teardown flushes the whole DB anyway, so a disposable
+    Redis is already a hard requirement).
+    """
+    _state = use_state()
+    _params = Params()
+    _directives = Directives.new()
+
+    with _state.cache.pipeline() as pipeline:
+        pipeline.set("params", _params)
+        pipeline.set("directives", _directives)
+
+    _devices = Devices()
+    _ui_params = init_ui_params(params=_params, devices=_devices)
+
+    with _state.cache.pipeline() as pipeline:
+        pipeline.set("devices", _devices)
+        pipeline.set("ui_params", _ui_params)
+
+
+_seed_stub_state()
+
+
 @pytest.fixture
 def params() -> t.Dict[str, t.Any]:
     """Provide default Params overrides for the state fixture."""

--- a/hyperglass/conftest.py
+++ b/hyperglass/conftest.py
@@ -7,13 +7,14 @@ import typing as t
 import pytest
 
 # Project
+from hyperglass.state import use_state
 from hyperglass.configuration import init_ui_params
 from hyperglass.models.directive import Directives
 from hyperglass.models.config.params import Params
 from hyperglass.models.config.devices import Devices
-from hyperglass.state import use_state
 
 if t.TYPE_CHECKING:
+    # Project
     from hyperglass.state import HyperglassState
 
 

--- a/hyperglass/conftest.py
+++ b/hyperglass/conftest.py
@@ -1,0 +1,80 @@
+"""Top-level pytest fixtures shared across hyperglass test modules."""
+
+# Standard Library
+import typing as t
+
+# Third Party
+import pytest
+
+# Project
+from hyperglass.configuration import init_ui_params
+from hyperglass.models.directive import Directives
+from hyperglass.models.config.params import Params
+from hyperglass.models.config.devices import Devices
+from hyperglass.state import use_state
+
+if t.TYPE_CHECKING:
+    from hyperglass.state import HyperglassState
+
+
+@pytest.fixture
+def params() -> t.Dict[str, t.Any]:
+    """Provide default Params overrides for the state fixture."""
+    return {}
+
+
+@pytest.fixture
+def devices() -> t.Sequence[t.Dict[str, t.Any]]:
+    """Seed device definitions."""
+    return [
+        {
+            "name": "test1",
+            "address": "127.0.0.1",
+            "credential": {"username": "", "password": ""},
+            "platform": "juniper",
+            "attrs": {"source4": "192.0.2.1", "source6": "2001:db8::1"},
+            "directives": ["juniper_bgp_route"],
+        }
+    ]
+
+
+@pytest.fixture
+def directives() -> t.Sequence[t.Dict[str, t.Any]]:
+    """Seed directive definitions."""
+    return [
+        {
+            "juniper_bgp_route": {
+                "name": "BGP Route",
+                "field": {"description": "test"},
+            }
+        }
+    ]
+
+
+@pytest.fixture
+def state(
+    *,
+    params: t.Dict[str, t.Any],
+    directives: t.Sequence[t.Dict[str, t.Any]],
+    devices: t.Sequence[t.Dict[str, t.Any]],
+) -> t.Generator["HyperglassState", None, None]:
+    """Test fixture to initialize Redis store."""
+    _state = use_state()
+    _params = Params(**params)
+    _directives = Directives.new(*directives)
+
+    with _state.cache.pipeline() as pipeline:
+        # Write params and directives to the cache first to avoid a race condition where ui_params
+        # or devices try to access params or directives before they're available.
+        pipeline.set("params", _params)
+        pipeline.set("directives", _directives)
+
+    _devices = Devices(*devices)
+    ui_params = init_ui_params(params=_params, devices=_devices)
+
+    with _state.cache.pipeline() as pipeline:
+        pipeline.set("devices", _devices)
+        pipeline.set("ui_params", ui_params)
+
+    yield _state
+    _state.clear()

--- a/hyperglass/execution/drivers/tests/test_construct.py
+++ b/hyperglass/execution/drivers/tests/test_construct.py
@@ -1,83 +1,8 @@
-# Standard Library
-import typing as t
-
-# Third Party
-import pytest
-
 # Project
-from hyperglass.state import use_state
 from hyperglass.models.api import Query
-from hyperglass.configuration import init_ui_params
-from hyperglass.models.directive import Directives
-from hyperglass.models.config.params import Params
-from hyperglass.models.config.devices import Devices
 
 # Local
 from .._construct import Construct
-
-if t.TYPE_CHECKING:
-    # Project
-    from hyperglass.state import HyperglassState
-
-
-@pytest.fixture
-def params():
-    return {}
-
-
-@pytest.fixture
-def devices():
-    return [
-        {
-            "name": "test1",
-            "address": "127.0.0.1",
-            "credential": {"username": "", "password": ""},
-            "platform": "juniper",
-            "attrs": {"source4": "192.0.2.1", "source6": "2001:db8::1"},
-            "directives": ["juniper_bgp_route"],
-        }
-    ]
-
-
-@pytest.fixture
-def directives():
-    return [
-        {
-            "juniper_bgp_route": {
-                "name": "BGP Route",
-                "field": {"description": "test"},
-            }
-        }
-    ]
-
-
-@pytest.fixture
-def state(
-    *,
-    params: t.Dict[str, t.Any],
-    directives: t.Sequence[t.Dict[str, t.Any]],
-    devices: t.Sequence[t.Dict[str, t.Any]],
-) -> t.Generator["HyperglassState", None, None]:
-    """Test fixture to initialize Redis store."""
-    _state = use_state()
-    _params = Params(**params)
-    _directives = Directives.new(*directives)
-
-    with _state.cache.pipeline() as pipeline:
-        # Write params and directives to the cache first to avoid a race condition where ui_params
-        # or devices try to access params or directives before they're available.
-        pipeline.set("params", _params)
-        pipeline.set("directives", _directives)
-
-    _devices = Devices(*devices)
-    ui_params = init_ui_params(params=_params, devices=_devices)
-
-    with _state.cache.pipeline() as pipeline:
-        pipeline.set("devices", _devices)
-        pipeline.set("ui_params", ui_params)
-
-    yield _state
-    _state.clear()
 
 
 def test_construct(state):

--- a/hyperglass/models/api/query.py
+++ b/hyperglass/models/api/query.py
@@ -7,7 +7,7 @@ import secrets
 from datetime import datetime
 
 # Third Party
-from pydantic import BaseModel, ConfigDict, field_validator, StringConstraints
+from pydantic import BaseModel, ConfigDict, StringConstraints, field_validator
 from typing_extensions import Annotated
 
 # Project
@@ -20,7 +20,6 @@ from hyperglass.exceptions.private import InputValidationError
 
 # Local
 from ..config.devices import Device
-
 
 QueryLocation = Annotated[str, StringConstraints(strict=True, min_length=1, strip_whitespace=True)]
 QueryTarget = Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)]

--- a/hyperglass/models/api/query.py
+++ b/hyperglass/models/api/query.py
@@ -51,6 +51,10 @@ class Query(BaseModel):
 
     # Directive `id` field
     query_type: QueryType
+
+    # Bypass cache and re-execute when True.
+    force: bool = False
+
     _kwargs: t.Dict[str, t.Any]
 
     def __init__(self, **data) -> None:

--- a/hyperglass/models/api/response.py
+++ b/hyperglass/models/api/response.py
@@ -225,7 +225,10 @@ class InfoResponse(BaseModel):
 class ShareCreateResponse(BaseModel):
     """Response from POST /api/query/share/{cache_id}."""
 
-    model_config = ConfigDict(alias_generator=snake_to_camel, populate_by_name=True)
+    model_config = ConfigDict(
+        alias_generator=snake_to_camel,
+        populate_by_name=True,
+    )
 
     id: str
     url: str
@@ -238,7 +241,10 @@ class ShareResponse(BaseModel):
     Superset of QueryResponse with snapshot metadata.
     """
 
-    model_config = ConfigDict(alias_generator=snake_to_camel, populate_by_name=True)
+    model_config = ConfigDict(
+        alias_generator=snake_to_camel,
+        populate_by_name=True,
+    )
 
     id: str
     output: t.Union[str, t.Dict[str, t.Any]]

--- a/hyperglass/models/api/response.py
+++ b/hyperglass/models/api/response.py
@@ -2,12 +2,14 @@
 
 # Standard Library
 import typing as t
+from datetime import datetime
 
 # Third Party
 from pydantic import Field, BaseModel, StrictInt, StrictStr, ConfigDict, StrictBool, field_validator
 
 # Project
 from hyperglass.state import use_state
+from hyperglass.util import snake_to_camel
 
 ErrorName = t.Literal["success", "warning", "error", "danger"]
 ResponseLevel = t.Literal["success"]
@@ -134,13 +136,16 @@ class QueryResponse(BaseModel):
     """Query response model."""
 
     model_config = ConfigDict(
+        alias_generator=snake_to_camel,
+        populate_by_name=True,
         json_schema_extra={
             "title": "Query Response",
             "description": "Looking glass response",
             "examples": schema_query_examples,
-        }
+        },
     )
 
+    id: str
     output: t.Union[t.Dict, StrictStr] = Field(json_schema_extra=schema_query_output)
     level: ResponseLevel = Field("success", json_schema_extra=schema_query_level)
     random: str = Field(json_schema_extra=schema_query_random)
@@ -215,3 +220,36 @@ class InfoResponse(BaseModel):
     organization: StrictStr
     primary_asn: StrictInt
     version: StrictStr
+
+
+class ShareCreateResponse(BaseModel):
+    """Response from POST /api/query/share/{cache_id}."""
+
+    model_config = ConfigDict(alias_generator=snake_to_camel, populate_by_name=True)
+
+    id: str
+    url: str
+    expires_at: datetime
+
+
+class ShareResponse(BaseModel):
+    """Response from GET /api/query/share/{share_id}.
+
+    Superset of QueryResponse with snapshot metadata.
+    """
+
+    model_config = ConfigDict(alias_generator=snake_to_camel, populate_by_name=True)
+
+    id: str
+    output: t.Union[str, t.Dict[str, t.Any]]
+    cached: bool = True
+    shared: bool = True
+    runtime: int
+    timestamp: datetime
+    format: str
+    level: str
+    keywords: t.List[str]
+    query: t.Dict[str, t.Any]
+    query_labels: t.Dict[str, str]
+    created_at: datetime
+    expires_at: datetime

--- a/hyperglass/models/api/response.py
+++ b/hyperglass/models/api/response.py
@@ -8,8 +8,8 @@ from datetime import datetime
 from pydantic import Field, BaseModel, StrictInt, StrictStr, ConfigDict, StrictBool, field_validator
 
 # Project
-from hyperglass.state import use_state
 from hyperglass.util import snake_to_camel
+from hyperglass.state import use_state
 
 ErrorName = t.Literal["success", "warning", "error", "danger"]
 ResponseLevel = t.Literal["success"]

--- a/hyperglass/models/api/tests/test_query_force.py
+++ b/hyperglass/models/api/tests/test_query_force.py
@@ -2,24 +2,41 @@
 
 
 def test_query_force_default_false(state):
+    # Project
     from hyperglass.models.api import Query
-    q = Query(query_location="test1", query_target="192.0.2.0/24",
-              query_type="juniper_bgp_route")
+
+    q = Query(query_location="test1", query_target="192.0.2.0/24", query_type="juniper_bgp_route")
     assert q.force is False
 
 
 def test_query_force_true(state):
+    # Project
     from hyperglass.models.api import Query
-    q = Query(query_location="test1", query_target="192.0.2.0/24",
-              query_type="juniper_bgp_route", force=True)
+
+    q = Query(
+        query_location="test1",
+        query_target="192.0.2.0/24",
+        query_type="juniper_bgp_route",
+        force=True,
+    )
     assert q.force is True
 
 
 def test_query_force_does_not_affect_digest(state):
     """The cache key must not depend on the force flag."""
+    # Project
     from hyperglass.models.api import Query
-    q1 = Query(query_location="test1", query_target="192.0.2.0/24",
-               query_type="juniper_bgp_route", force=False)
-    q2 = Query(query_location="test1", query_target="192.0.2.0/24",
-               query_type="juniper_bgp_route", force=True)
+
+    q1 = Query(
+        query_location="test1",
+        query_target="192.0.2.0/24",
+        query_type="juniper_bgp_route",
+        force=False,
+    )
+    q2 = Query(
+        query_location="test1",
+        query_target="192.0.2.0/24",
+        query_type="juniper_bgp_route",
+        force=True,
+    )
     assert q1.digest() == q2.digest()

--- a/hyperglass/models/api/tests/test_query_force.py
+++ b/hyperglass/models/api/tests/test_query_force.py
@@ -1,0 +1,25 @@
+"""Tests for the Query.force flag."""
+
+
+def test_query_force_default_false(state):
+    from hyperglass.models.api import Query
+    q = Query(query_location="test1", query_target="192.0.2.0/24",
+              query_type="juniper_bgp_route")
+    assert q.force is False
+
+
+def test_query_force_true(state):
+    from hyperglass.models.api import Query
+    q = Query(query_location="test1", query_target="192.0.2.0/24",
+              query_type="juniper_bgp_route", force=True)
+    assert q.force is True
+
+
+def test_query_force_does_not_affect_digest(state):
+    """The cache key must not depend on the force flag."""
+    from hyperglass.models.api import Query
+    q1 = Query(query_location="test1", query_target="192.0.2.0/24",
+               query_type="juniper_bgp_route", force=False)
+    q2 = Query(query_location="test1", query_target="192.0.2.0/24",
+               query_type="juniper_bgp_route", force=True)
+    assert q1.digest() == q2.digest()

--- a/hyperglass/models/api/tests/test_response_models.py
+++ b/hyperglass/models/api/tests/test_response_models.py
@@ -1,0 +1,64 @@
+"""Tests for share response models."""
+
+# Standard Library
+from datetime import datetime, timezone
+
+# Project
+from hyperglass.models.api.response import (
+    QueryResponse,
+    ShareCreateResponse,
+    ShareResponse,
+)
+
+
+def test_query_response_includes_id():
+    # `timestamp` is a string per the existing QueryResponse contract.
+    r = QueryResponse(
+        output="ok",
+        id="hyperglass.query.deadbeef",
+        cached=False,
+        runtime=1,
+        timestamp="2026-05-01 12:00:00",
+        format="text/plain",
+        random="r",
+        level="success",
+        keywords=[],
+    )
+    assert r.id == "hyperglass.query.deadbeef"
+
+
+def test_share_create_response_shape():
+    expires = datetime.now(timezone.utc)
+    r = ShareCreateResponse(id="abc", url="https://lg.example.com/result/abc",
+                            expires_at=expires)
+    assert r.id == "abc"
+    assert r.url.endswith("/result/abc")
+    # camelCase alias on the wire
+    dumped = r.model_dump(by_alias=True)
+    assert "expiresAt" in dumped
+
+
+def test_share_response_shape():
+    expires = datetime.now(timezone.utc)
+    r = ShareResponse(
+        id="abc",
+        output="ok",
+        cached=True,
+        shared=True,
+        runtime=1,
+        timestamp=datetime.now(timezone.utc),
+        format="text/plain",
+        level="success",
+        keywords=[],
+        query={"query_location": "test1", "query_target": "192.0.2.0/24",
+               "query_type": "juniper_bgp_route"},
+        query_labels={"location": "test1", "type": "BGP Route"},
+        created_at=datetime.now(timezone.utc),
+        expires_at=expires,
+    )
+    assert r.shared is True
+    assert r.query_labels["location"] == "test1"
+    # Note: alias_generator only affects the model's own fields, not nested
+    # dict keys. `r.query["query_location"]` stays snake_case on the wire.
+    dumped = r.model_dump(by_alias=True)
+    assert dumped["query"]["query_location"] == "test1"

--- a/hyperglass/models/api/tests/test_response_models.py
+++ b/hyperglass/models/api/tests/test_response_models.py
@@ -4,11 +4,7 @@
 from datetime import datetime, timezone
 
 # Project
-from hyperglass.models.api.response import (
-    QueryResponse,
-    ShareCreateResponse,
-    ShareResponse,
-)
+from hyperglass.models.api.response import QueryResponse, ShareResponse, ShareCreateResponse
 
 
 def test_query_response_includes_id():
@@ -29,8 +25,7 @@ def test_query_response_includes_id():
 
 def test_share_create_response_shape():
     expires = datetime.now(timezone.utc)
-    r = ShareCreateResponse(id="abc", url="https://lg.example.com/result/abc",
-                            expires_at=expires)
+    r = ShareCreateResponse(id="abc", url="https://lg.example.com/result/abc", expires_at=expires)
     assert r.id == "abc"
     assert r.url.endswith("/result/abc")
     # camelCase alias on the wire
@@ -50,8 +45,11 @@ def test_share_response_shape():
         format="text/plain",
         level="success",
         keywords=[],
-        query={"query_location": "test1", "query_target": "192.0.2.0/24",
-               "query_type": "juniper_bgp_route"},
+        query={
+            "query_location": "test1",
+            "query_target": "192.0.2.0/24",
+            "query_type": "juniper_bgp_route",
+        },
         query_labels={"location": "test1", "type": "BGP Route"},
         created_at=datetime.now(timezone.utc),
         expires_at=expires,

--- a/hyperglass/models/config/cache.py
+++ b/hyperglass/models/config/cache.py
@@ -7,5 +7,9 @@ from ..main import HyperglassModel
 class Cache(HyperglassModel):
     """Public cache parameters."""
 
-    timeout: int = 120
+    timeout: int = 600
     show_text: bool = True
+    share_enabled: bool = True
+    share_timeout: int = 604800
+    share_sliding: bool = False
+    refresh_min_interval: int = 120

--- a/hyperglass/models/config/params.py
+++ b/hyperglass/models/config/params.py
@@ -6,7 +6,7 @@ import urllib.parse
 from pathlib import Path
 
 # Third Party
-from pydantic import AnyHttpUrl, ConfigDict, Field, HttpUrl, ValidationInfo, field_validator
+from pydantic import Field, HttpUrl, AnyHttpUrl, ConfigDict, ValidationInfo, field_validator
 
 # Project
 from hyperglass.settings import Settings

--- a/hyperglass/models/config/params.py
+++ b/hyperglass/models/config/params.py
@@ -160,7 +160,13 @@ class Params(ParamsPublic, HyperglassModel):
 
         return self.export_dict(
             include={
-                "cache": {"show_text", "timeout"},
+                "cache": {
+                    "show_text",
+                    "timeout",
+                    "share_enabled",
+                    "share_timeout",
+                    "refresh_min_interval",
+                },
                 "developer_mode": ...,
                 "primary_asn": ...,
                 "request_timeout": ...,

--- a/hyperglass/models/config/params.py
+++ b/hyperglass/models/config/params.py
@@ -6,7 +6,7 @@ import urllib.parse
 from pathlib import Path
 
 # Third Party
-from pydantic import Field, HttpUrl, ConfigDict, ValidationInfo, field_validator
+from pydantic import AnyHttpUrl, ConfigDict, Field, HttpUrl, ValidationInfo, field_validator
 
 # Project
 from hyperglass.settings import Settings
@@ -69,6 +69,11 @@ class Params(ParamsPublic, HyperglassModel):
     model_config = ConfigDict(json_schema_extra={"level": 1})
 
     # Top Level Params
+    public_url: t.Optional[AnyHttpUrl] = Field(
+        None,
+        title="Public URL",
+        description="Public base URL for the hyperglass instance. Used to build shareable links for query results.",
+    )
 
     fake_output: bool = Field(
         False,

--- a/hyperglass/models/config/tests/test_cache.py
+++ b/hyperglass/models/config/tests/test_cache.py
@@ -1,0 +1,24 @@
+"""Tests for the Cache config model."""
+
+# Project
+from hyperglass.models.config.cache import Cache
+
+
+def test_cache_defaults():
+    cache = Cache()
+    assert cache.timeout == 600
+    assert cache.show_text is True
+    assert cache.share_enabled is True
+    assert cache.share_timeout == 604800  # 7 days
+    assert cache.share_sliding is False
+    assert cache.refresh_min_interval == 120
+
+
+def test_cache_share_timeout_overridable():
+    cache = Cache(share_timeout=2592000)  # 30 days
+    assert cache.share_timeout == 2592000
+
+
+def test_cache_share_disabled():
+    cache = Cache(share_enabled=False)
+    assert cache.share_enabled is False

--- a/hyperglass/models/config/tests/test_params_frontend.py
+++ b/hyperglass/models/config/tests/test_params_frontend.py
@@ -22,8 +22,9 @@ def test_frontend_excludes_private_share_sliding():
 
 def test_ui_params_cache_projection_excludes_private_fields():
     """UIParameters.export_dict must not expose server-private cache fields."""
-    from hyperglass.configuration.validate import init_ui_params
+    # Project
     from hyperglass.models.config.devices import Devices
+    from hyperglass.configuration.validate import init_ui_params
 
     ui = init_ui_params(params=Params(), devices=Devices())
     cache = ui.export_dict(by_alias=True)["cache"]
@@ -38,8 +39,9 @@ def test_ui_params_cache_projection_excludes_private_fields():
 
 def test_ui_params_export_excludes_public_url():
     """public_url must not be present in the UI bundle."""
-    from hyperglass.configuration.validate import init_ui_params
+    # Project
     from hyperglass.models.config.devices import Devices
+    from hyperglass.configuration.validate import init_ui_params
 
     ui = init_ui_params(params=Params(), devices=Devices())
     assert "publicUrl" not in ui.export_dict(by_alias=True)

--- a/hyperglass/models/config/tests/test_params_frontend.py
+++ b/hyperglass/models/config/tests/test_params_frontend.py
@@ -1,0 +1,45 @@
+"""Tests for Params.frontend() projection."""
+
+# Project
+from hyperglass.models.config.params import Params
+
+
+def test_frontend_includes_share_fields():
+    p = Params()
+    out = p.frontend()
+    assert "cache" in out
+    cache = out["cache"]
+    assert "share_enabled" in cache
+    assert "share_timeout" in cache
+    assert "refresh_min_interval" in cache
+
+
+def test_frontend_excludes_private_share_sliding():
+    p = Params()
+    cache = p.frontend()["cache"]
+    assert "share_sliding" not in cache
+
+
+def test_ui_params_cache_projection_excludes_private_fields():
+    """UIParameters.export_dict must not expose server-private cache fields."""
+    from hyperglass.configuration.validate import init_ui_params
+    from hyperglass.models.config.devices import Devices
+
+    ui = init_ui_params(params=Params(), devices=Devices())
+    cache = ui.export_dict(by_alias=True)["cache"]
+    assert set(cache) == {
+        "timeout",
+        "showText",
+        "shareEnabled",
+        "shareTimeout",
+        "refreshMinInterval",
+    }
+
+
+def test_ui_params_export_excludes_public_url():
+    """public_url must not be present in the UI bundle."""
+    from hyperglass.configuration.validate import init_ui_params
+    from hyperglass.models.config.devices import Devices
+
+    ui = init_ui_params(params=Params(), devices=Devices())
+    assert "publicUrl" not in ui.export_dict(by_alias=True)

--- a/hyperglass/models/config/tests/test_params_public_url.py
+++ b/hyperglass/models/config/tests/test_params_public_url.py
@@ -1,0 +1,17 @@
+"""Tests for Params.public_url."""
+
+# Project
+from hyperglass.models.config.params import Params
+
+
+def test_public_url_default_none():
+    p = Params()
+    assert p.public_url is None
+
+
+def test_public_url_set_to_https_url():
+    p = Params(public_url="https://lg.example.com")
+    # Pydantic AnyHttpUrl normalization varies across 2.x patch versions
+    # (sometimes adds trailing slash, sometimes preserves). Use startswith
+    # so the test is robust to either form.
+    assert str(p.public_url).startswith("https://lg.example.com")

--- a/hyperglass/models/config/web.py
+++ b/hyperglass/models/config/web.py
@@ -133,6 +133,7 @@ class Text(HyperglassModel):
     share_snapshot_banner: str = "Snapshot taken at {timestamp}"  # Formatted by Javascript
     share_run_fresh_query: str = "Run a fresh query"
     refresh_cooldown: str = "Refresh available in {seconds}s"  # Formatted by Javascript
+    requery_tooltip: str = "Reload Query"
 
     @field_validator("cache_prefix")
     def validate_cache_prefix(cls: "Text", value: str) -> str:

--- a/hyperglass/models/config/web.py
+++ b/hyperglass/models/config/web.py
@@ -122,6 +122,17 @@ class Text(HyperglassModel):
     no_ip: str = "No {protocol} Address"
     ip_select: str = "Select an IP Address"
     ip_button: str = "My IP"
+    share_button: str = "Share"
+    share_popover_title: str = "Share this result"
+    share_copy_link: str = "Copy link"
+    share_link_copied: str = "Copied!"
+    share_expires_at: str = "Expires {expires}"  # Formatted by Javascript
+    share_create_error: str = "Could not create share link."
+    share_create_expired: str = "This result has expired from cache. Refresh and try again."
+    share_not_found: str = "Share not found or expired."
+    share_snapshot_banner: str = "Snapshot taken at {timestamp}"  # Formatted by Javascript
+    share_run_fresh_query: str = "Run a fresh query"
+    refresh_cooldown: str = "Refresh available in {seconds}s"  # Formatted by Javascript
 
     @field_validator("cache_prefix")
     def validate_cache_prefix(cls: "Text", value: str) -> str:

--- a/hyperglass/models/tests/test_web.py
+++ b/hyperglass/models/tests/test_web.py
@@ -1,0 +1,13 @@
+"""Tests for new Text fields supporting the share feature."""
+
+# Project
+from hyperglass.models.config.web import Text
+
+
+def test_text_share_defaults():
+    t = Text()
+    assert t.share_button == "Share"
+    assert "{expires}" in t.share_expires_at
+    assert "{timestamp}" in t.share_snapshot_banner
+    assert t.share_not_found
+    assert t.refresh_cooldown

--- a/hyperglass/models/tests/test_web.py
+++ b/hyperglass/models/tests/test_web.py
@@ -11,3 +11,4 @@ def test_text_share_defaults():
     assert "{timestamp}" in t.share_snapshot_banner
     assert t.share_not_found
     assert t.refresh_cooldown
+    assert t.requery_tooltip == "Reload Query"

--- a/hyperglass/models/ui.py
+++ b/hyperglass/models/ui.py
@@ -6,12 +6,21 @@ import typing as t
 # Local
 from .main import HyperglassModel
 from .config.web import WebPublic
-from .config.cache import Cache
 from .config.params import ParamsPublic
 from .config.messages import Messages
 
 Alignment = t.Union[t.Literal["left"], t.Literal["center"], t.Literal["right"], None]
 StructuredDataField = t.Tuple[str, str, Alignment]
+
+
+class UICache(HyperglassModel):
+    """UI projection of cache parameters (server-private fields omitted)."""
+
+    timeout: int
+    show_text: bool
+    share_enabled: bool
+    share_timeout: int
+    refresh_min_interval: int
 
 
 class UIDirective(HyperglassModel):
@@ -54,7 +63,7 @@ class UIContent(HyperglassModel):
 class UIParameters(ParamsPublic, HyperglassModel):
     """UI Configuration Parameters."""
 
-    cache: Cache
+    cache: UICache
     web: WebPublic
     messages: Messages
     version: str

--- a/hyperglass/plugins/tests/test_bgp_community.py
+++ b/hyperglass/plugins/tests/test_bgp_community.py
@@ -40,11 +40,6 @@ CHECKS = (
 
 
 @pytest.fixture
-def params():
-    return {}
-
-
-@pytest.fixture
 def state(*, params: t.Dict[str, t.Any]) -> t.Generator["HyperglassState", None, None]:
     """Test fixture to initialize Redis store."""
     _state = use_state()

--- a/hyperglass/state/tests/test_hooks.py
+++ b/hyperglass/state/tests/test_hooks.py
@@ -26,7 +26,7 @@ def test_use_state_caching(state):
             instance = use_state(attr)
             if i == 0:
                 first = instance
-            assert isinstance(instance, model), (
-                f"{instance!r} is not an instance of '{model.__name__}'"
-            )
+            assert isinstance(
+                instance, model
+            ), f"{instance!r} is not an instance of '{model.__name__}'"
             assert instance == first, f"{instance!r} is not equal to {first!r}"

--- a/hyperglass/state/tests/test_hooks.py
+++ b/hyperglass/state/tests/test_hooks.py
@@ -1,17 +1,7 @@
 """Test state hooks."""
 
-# Standard Library
-import typing as t
-
-# Third Party
-import pytest
-
-if t.TYPE_CHECKING:
-    from hyperglass.state import HyperglassState
-
 # Project
 from hyperglass.models.ui import UIParameters
-from hyperglass.configuration import init_ui_params
 from hyperglass.models.directive import Directives
 from hyperglass.models.config.params import Params
 from hyperglass.models.config.devices import Devices
@@ -27,66 +17,6 @@ STATE_ATTRS = (
     ("directives", Directives),
     (None, HyperglassState),
 )
-
-
-@pytest.fixture
-def params():
-    return {}
-
-
-@pytest.fixture
-def devices():
-    return [
-        {
-            "name": "test1",
-            "address": "127.0.0.1",
-            "credential": {"username": "", "password": ""},
-            "platform": "juniper",
-            "attrs": {"source4": "192.0.2.1", "source6": "2001:db8::1"},
-            "directives": ["juniper_bgp_route"],
-        }
-    ]
-
-
-@pytest.fixture
-def directives():
-    return [
-        {
-            "juniper_bgp_route": {
-                "name": "BGP Route",
-                "field": {"description": "test"},
-            }
-        }
-    ]
-
-
-@pytest.fixture
-def state(
-    *,
-    params: t.Dict[str, t.Any],
-    directives: t.Sequence[t.Dict[str, t.Any]],
-    devices: t.Sequence[t.Dict[str, t.Any]],
-) -> t.Generator["HyperglassState", None, None]:
-    """Test fixture to initialize Redis store."""
-    _state = use_state()
-    _params = Params(**params)
-    _directives = Directives.new(*directives)
-
-    with _state.cache.pipeline() as pipeline:
-        # Write params and directives to the cache first to avoid a race condition where ui_params
-        # or devices try to access params or directives before they're available.
-        pipeline.set("params", _params)
-        pipeline.set("directives", _directives)
-
-    _devices = Devices(*devices)
-    ui_params = init_ui_params(params=_params, devices=_devices)
-
-    with _state.cache.pipeline() as pipeline:
-        pipeline.set("devices", _devices)
-        pipeline.set("ui_params", ui_params)
-
-    yield _state
-    _state.clear()
 
 
 def test_use_state_caching(state):

--- a/hyperglass/ui/.gitignore
+++ b/hyperglass/ui/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 fonts/
 .next
 out
+
+# Vitest coverage output
+coverage/

--- a/hyperglass/ui/__tests__/pages/result/[id].test.tsx
+++ b/hyperglass/ui/__tests__/pages/result/[id].test.tsx
@@ -19,7 +19,7 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
-import ResultPage from './[id]';
+import ResultPage from '../../../pages/result/[id]';
 
 vi.mock('next/router', () => ({
   useRouter: () => ({

--- a/hyperglass/ui/components/location-card.tsx
+++ b/hyperglass/ui/components/location-card.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
-import { Flex, Avatar, chakra } from '@chakra-ui/react';
+import { Avatar, Flex, chakra } from '@chakra-ui/react';
+import { useEffect, useMemo, useState } from 'react';
 import { motionChakra } from '~/elements';
 import { useColorValue, useOpposingColor } from '~/hooks';
 
@@ -32,6 +32,16 @@ export const LocationCard = (props: LocationCardProps): JSX.Element => {
   const { option, onChange, defaultChecked, hasError } = props;
   const { label } = option;
   const [isChecked, setChecked] = useState(defaultChecked);
+
+  // Sync checked state when the defaultChecked prop changes after initial mount.
+  // This handles the pre-fill case where URL query params are applied in a useEffect
+  // that runs after the first render, so the initial useState(defaultChecked) value
+  // would otherwise be stale (false) when pre-fill later sets it to true.
+  // The user-click path is unaffected: handleChange toggles isChecked independently,
+  // and this effect only fires when the prop actually changes (i.e. external pre-fill).
+  useEffect(() => {
+    setChecked(defaultChecked);
+  }, [defaultChecked]);
 
   function handleChange(value: LocationOption) {
     if (isChecked) {
@@ -68,6 +78,7 @@ export const LocationCard = (props: LocationCardProps): JSX.Element => {
       key={label}
       whileHover={{ scale: 1.05 }}
       borderColor={borderColor}
+      data-checked={isChecked ? 'true' : undefined}
       onClick={(e: React.MouseEvent) => {
         e.preventDefault();
         handleChange(option);

--- a/hyperglass/ui/components/looking-glass-form.test.tsx
+++ b/hyperglass/ui/components/looking-glass-form.test.tsx
@@ -1,0 +1,222 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI requires it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import type { Config } from '~/types';
+import { LookingGlassForm } from './looking-glass-form';
+
+// ---------------------------------------------------------------------------
+// next/router mock — query params that should pre-fill the form
+// ---------------------------------------------------------------------------
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {
+      location: 'test1',
+      target: '192.0.2.0/24',
+      type: 'juniper_bgp_route',
+    },
+    isReady: true,
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Minimal device + directive that matches the three query params above
+// ---------------------------------------------------------------------------
+const mockDirective = {
+  id: 'juniper_bgp_route',
+  name: 'BGP Route',
+  fieldType: 'text',
+  description: 'IP prefix / host',
+  groups: [],
+  info: null,
+};
+
+const mockDevice = {
+  id: 'test1',
+  name: 'Test Router 1',
+  group: null,
+  avatar: null,
+  description: null,
+  directives: [mockDirective],
+};
+
+const mockConfig: Config = {
+  developerMode: false,
+  primaryAsn: '65000',
+  requestTimeout: 30,
+  orgName: 'Test Org',
+  siteTitle: 'hyperglass',
+  siteDescription: 'Looking Glass',
+  version: '2.0.0',
+  parsedDataFields: [],
+  devices: [{ group: null, locations: [mockDevice] }],
+  content: { credit: '', greeting: '' },
+  messages: {
+    noInput: '{field} is required.',
+    featureNotEnabled: 'Feature not enabled.',
+    invalidInput: 'Invalid input.',
+    general: 'An error occurred.',
+    requestTimeout: 'Request timed out.',
+    connectionError: 'Connection error.',
+    authenticationError: 'Authentication error.',
+    noOutput: 'No output.',
+  },
+  cache: {
+    showText: false,
+    timeout: 600,
+    shareEnabled: false,
+    shareTimeout: 604800,
+    refreshMinInterval: 120,
+  },
+  web: {
+    credit: { enable: false },
+    dnsProvider: { name: 'Cloudflare', url: 'https://cloudflare-dns.com/dns-query' },
+    links: [],
+    menus: [],
+    greeting: {
+      enable: false,
+      title: 'Welcome',
+      button: 'Continue',
+      required: false,
+    },
+    logo: {
+      width: '100%',
+      height: null,
+      lightFormat: 'png',
+      darkFormat: 'png',
+    },
+    text: {
+      titleMode: 'logo',
+      title: 'hyperglass',
+      subtitle: 'Looking Glass',
+      queryLocation: 'Location',
+      queryType: 'Query Type',
+      queryTarget: 'Query Target',
+      fqdnTooltip: 'Resolve hostname',
+      fqdnMessage: 'Resolving hostname',
+      fqdnError: 'Could not resolve hostname',
+      fqdnErrorButton: 'Try Again',
+      cachePrefix: 'Cached',
+      cacheIcon: '',
+      completeTime: 'Completed in {time}',
+      rpkiInvalid: 'INVALID',
+      rpkiValid: 'VALID',
+      rpkiUnknown: 'UNKNOWN',
+      rpkiUnverified: 'UNVERIFIED',
+      noCommunities: 'No communities',
+      ipError: 'IP address error',
+      noIp: 'No IP address detected',
+      ipSelect: 'Select IP address',
+      ipButton: 'Use My IP',
+      shareButton: 'Share',
+      sharePopoverTitle: 'Share this result',
+      shareCopyLink: 'Copy link',
+      shareLinkCopied: 'Copied!',
+      shareExpiresAt: 'Expires {expires}',
+      shareCreateError: 'Could not create share link.',
+      shareCreateExpired: 'Result expired.',
+      shareNotFound: 'Result not found.',
+      shareSnapshotBanner: 'Snapshot',
+      shareRunFreshQuery: 'Run a fresh query',
+      refreshCooldown: 'Wait {seconds}s',
+      requeryTooltip: 'Reload Query',
+    },
+    theme: {
+      colors: { primary: '#40C057' },
+      defaultColorMode: 'light',
+      fonts: { body: 'Inter', mono: 'Fira Mono' },
+    },
+    locationDisplayMode: 'gallery',
+    highlight: [],
+  },
+} as unknown as Config;
+
+// ---------------------------------------------------------------------------
+// ~/context mock — provide config + the queryClient used by useFormState
+// ---------------------------------------------------------------------------
+vi.mock('~/context', async () => {
+  const { QueryClient } =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    useConfig: () => mockConfig,
+    queryClient: new QueryClient(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Wrapper: ChakraProvider only (QueryClientProvider is inside HyperglassProvider
+// but since we mock ~/context we provide our own here)
+// ---------------------------------------------------------------------------
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <ChakraProvider>{children}</ChakraProvider>
+    </QueryClientProvider>
+  );
+};
+
+// Reset Zustand form state between tests so pre-fill useEffect fires cleanly
+beforeEach(async () => {
+  const { useFormState } = await import('~/hooks');
+  await useFormState.getState().reset();
+});
+
+describe('LookingGlassForm — query-string pre-fill', () => {
+  it('pre-fills queryTarget display value from ?target= query param', async () => {
+    render(<LookingGlassForm />, { wrapper });
+    // QueryTarget renders an <Input> (name="queryTargetDisplay") whose displayed value is
+    // s.target.display from Zustand. After the useEffect fires it should equal the ?target= param.
+    // Multiple inputs carry this value (hidden RHF input + visible Input), so use getAllBy.
+    const inputs = await screen.findAllByDisplayValue('192.0.2.0/24');
+    expect(inputs.length).toBeGreaterThan(0);
+    // The visible user-facing input has name="queryTargetDisplay"
+    const visibleInput = inputs.find(el => el.getAttribute('name') === 'queryTargetDisplay');
+    expect(visibleInput).toBeInTheDocument();
+  });
+
+  it('pre-fills queryLocation in Zustand form state from ?location= query param', async () => {
+    const { useFormState } = await import('~/hooks');
+    render(<LookingGlassForm />, { wrapper });
+    // Wait for the target pre-fill to confirm the effect has run.
+    await screen.findAllByDisplayValue('192.0.2.0/24');
+    // Then verify queryLocation was set in Zustand form state.
+    expect(useFormState.getState().form.queryLocation).toContain('test1');
+    // Also verify selections.queryLocation was populated with the matching option object so that
+    // the dropdown <Select value=...> and gallery LocationCard both reflect the pre-filled value.
+    const locationSelections = useFormState.getState().selections.queryLocation;
+    expect(locationSelections).toHaveLength(1);
+    expect(locationSelections[0]).toMatchObject({ value: 'test1', label: 'Test Router 1' });
+  });
+
+  it('gallery LocationCard reflects checked state after pre-fill', async () => {
+    const { container } = render(<LookingGlassForm />, { wrapper });
+    // Wait for the pre-fill effect to fire (target field is the reliable sentinel).
+    await screen.findAllByDisplayValue('192.0.2.0/24');
+    // LocationCard exposes data-checked="true" on the wrapper div when isChecked is true.
+    // After pre-fill, the card for "Test Router 1" (id=test1) should be marked checked.
+    const checkedCard = container.querySelector('[data-checked="true"]');
+    expect(checkedCard).toBeInTheDocument();
+    // Confirm it is the card for the correct location by checking it contains the device name.
+    expect(checkedCard?.textContent).toContain('Test Router 1');
+  });
+});

--- a/hyperglass/ui/components/looking-glass-form.tsx
+++ b/hyperglass/ui/components/looking-glass-form.tsx
@@ -1,6 +1,7 @@
 import { Flex, ScaleFade, SlideFade, chakra } from '@chakra-ui/react';
 import { vestResolver } from '@hookform/resolvers/vest';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import isEqual from 'react-fast-compare';
 import { FormProvider, useForm } from 'react-hook-form';
 import vest, { test, enforce } from 'vest';
@@ -22,6 +23,7 @@ import type { FormData, OnChangeArgs } from '~/types';
 
 export const LookingGlassForm = (): JSX.Element => {
   const { web, messages } = useConfig();
+  const router = useRouter();
 
   const greetingReady = useGreeting(s => s.greetingReady);
 
@@ -30,6 +32,7 @@ export const LookingGlassForm = (): JSX.Element => {
   const setLoading = useFormState(s => s.setLoading);
   const setStatus = useFormState(s => s.setStatus);
   const locationChange = useFormState(s => s.locationChange);
+  const setSelection = useFormState(s => s.setSelection);
   const setTarget = useFormState(s => s.setTarget);
   const setFormValue = useFormState(s => s.setFormValue);
   const { form, filtered, selections } = useFormState(
@@ -131,6 +134,39 @@ export const LookingGlassForm = (): JSX.Element => {
 
   const handleLocChange = (locations: string[]) =>
     locationChange(locations, { setError, clearErrors, getDevice, text: web.text });
+
+  // Pre-fill form from URL query params (?location=&target=&type=).
+  // Applied once on mount when router.isReady — a ref guard prevents re-applying
+  // if the component re-renders after the user has edited the form.
+  const prefillApplied = useRef(false);
+  useEffect(() => {
+    if (!router.isReady || prefillApplied.current) return;
+    prefillApplied.current = true;
+
+    const { location, target, type } = router.query;
+
+    if (typeof location === 'string') {
+      setValue('queryLocation', [location]);
+      // Drive Zustand state through locationChange so filtered.types is populated.
+      locationChange([location], { setError, clearErrors, getDevice, text: web.text });
+      // Also populate selections.queryLocation so the dropdown <Select value=...> and
+      // the gallery <LocationCard defaultChecked=...> both reflect the pre-filled value.
+      // Guard for unknown location IDs: skip selection rather than inserting a null/bad option.
+      const device = getDevice(location);
+      if (device !== null) {
+        setSelection('queryLocation', [{ value: device.id, label: device.name }]);
+      }
+    }
+    if (typeof type === 'string') {
+      setValue('queryType', type);
+      setFormValue('queryType', type);
+    }
+    if (typeof target === 'string') {
+      setValue('queryTarget', [target]);
+      setFormValue('queryTarget', [target]);
+      setTarget({ display: target });
+    }
+  }, [router.isReady, router.query]);
 
   function handleChange(e: OnChangeArgs): void {
     // Signal the field & value to react-hook-form.

--- a/hyperglass/ui/components/results/individual.tsx
+++ b/hyperglass/ui/components/results/individual.tsx
@@ -42,6 +42,10 @@ import type { ErrorLevels } from '~/types';
 interface ResultProps {
   index: number;
   queryLocation: string;
+  /** Snapshot from a share link — skips the live LG query and renders directly. */
+  snapshot?: ShareResponse;
+  /** When true, hides the ShareButton and RequeryButton (used on the share view page). */
+  readOnly?: boolean;
 }
 
 const AnimatedAccordionItem = motion(AccordionItem);
@@ -59,7 +63,7 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
   props: ResultProps,
   ref,
 ) => {
-  const { index, queryLocation } = props;
+  const { index, queryLocation, snapshot, readOnly = false } = props;
   const toast = useToast();
   const { web, cache, messages } = useConfig();
   const { index: indices, setIndex } = useAccordionContext();
@@ -95,9 +99,35 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
     _setErrorLevel(e);
   };
 
-  const { data, error, isLoading, isFetching, isFetchedAfterMount, dataUpdatedAt } = useLGQuery(
+  // When snapshot is provided, coerce it to a QueryResponse shape so all
+  // downstream rendering logic can remain unchanged.
+  const snapshotAsQueryResponse: QueryResponse | undefined = useMemo(() => {
+    if (!snapshot) return undefined;
+    return {
+      id: snapshot.id,
+      random: '',
+      cached: snapshot.cached,
+      runtime: snapshot.runtime,
+      level: snapshot.level,
+      timestamp: snapshot.timestamp,
+      keywords: snapshot.keywords,
+      output: snapshot.output,
+      format: snapshot.format as QueryResponse['format'],
+    };
+  }, [snapshot]);
+
+  const {
+    data: liveData,
+    error,
+    isLoading,
+    isFetching,
+    isFetchedAfterMount,
+    dataUpdatedAt,
+  } = useLGQuery(
     { queryLocation, queryTarget: form.queryTarget, queryType: form.queryType, force },
     {
+      // Disable the live fetch when rendering from a snapshot.
+      enabled: !snapshot,
       onSuccess(data) {
         if (device !== null) {
           addResponse(device.id, data);
@@ -115,6 +145,9 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
       },
     },
   );
+
+  // In snapshot mode, use the coerced snapshot; otherwise use the live query result.
+  const data = snapshot ? snapshotAsQueryResponse : liveData;
 
   // When a forced fetch settles, copy the fresh result into the non-force cache
   // key (K1) before resetting force back to undefined. Without this, reverting
@@ -210,7 +243,12 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
     }
   }, [data, index, indices, isLoading, isError, setIndex]);
 
-  if (device === null) {
+  // In snapshot mode, the device may not be in the config (share viewer may not
+  // have the same device list). Fall back to snapshot labels for title/id.
+  const deviceId = device?.id ?? queryLocation;
+  const deviceName = device?.name ?? snapshot?.queryLabels.location ?? queryLocation;
+
+  if (device === null && !snapshot) {
     const id = `toast-queryLocation-${index}-${queryLocation}`;
     if (!toast.isActive(id)) {
       toast({
@@ -227,8 +265,8 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
   return (
     <AnimatedAccordionItem
       ref={ref}
-      id={device.id}
-      isDisabled={isLoading}
+      id={deviceId}
+      isDisabled={!snapshot && isLoading}
       exit={{ opacity: 0, y: 300 }}
       animate={{ opacity: 1, y: 0 }}
       initial={{ opacity: 0, y: 300 }}
@@ -242,24 +280,26 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
         <AccordionButton py={2} w="unset" _hover={{}} _focus={{}} flex="1 0 auto">
           <ResultHeader
             isError={isError}
-            loading={isLoading}
+            loading={!snapshot && isLoading}
             errorMsg={errorMsg}
             errorLevel={errorLevel}
             runtime={data?.runtime ?? 0}
-            title={device.name}
+            title={deviceName}
           />
         </AccordionButton>
         <HStack py={2} spacing={1}>
-          {isStructuredOutput(data) && data.level === 'success' && tableComponent && (
-            <Path device={device.id} />
+          {!snapshot && isStructuredOutput(data) && data.level === 'success' && tableComponent && (
+            <Path device={deviceId} />
           )}
-          {data?.id && <ShareButton cacheId={data.id} />}
-          <CopyButton copyValue={copyValue} isDisabled={isLoading} />
-          <RequeryButton
-            onRequery={() => setForce(true)}
-            lastResponseAt={lastResponseAt}
-            isDisabled={isLoading}
-          />
+          {!readOnly && data?.id && <ShareButton cacheId={data.id} />}
+          <CopyButton copyValue={copyValue} isDisabled={!snapshot && isLoading} />
+          {!readOnly && (
+            <RequeryButton
+              onRequery={() => setForce(true)}
+              lastResponseAt={lastResponseAt}
+              isDisabled={isLoading}
+            />
+          )}
         </HStack>
       </AccordionHeaderWrapper>
       <AccordionPanel
@@ -316,7 +356,7 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
             flex="1 0 auto"
             justifyContent={{ base: 'flex-start', lg: 'flex-end' }}
           >
-            <If condition={cache.showText && !isError && isCached}>
+            <If condition={cache.showText && !snapshot && !isError && isCached}>
               <Then>
                 <If condition={isMobile}>
                   <Then>

--- a/hyperglass/ui/components/results/individual.tsx
+++ b/hyperglass/ui/components/results/individual.tsx
@@ -11,6 +11,7 @@ import {
   useAccordionContext,
   useToast,
 } from '@chakra-ui/react';
+import { useQueryClient } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import startCase from 'lodash/startCase';
 import { forwardRef, memo, useEffect, useMemo, useState } from 'react';
@@ -64,6 +65,8 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
   const getDevice = useDevice();
   const device = getDevice(queryLocation);
 
+  const queryClient = useQueryClient();
+
   const isMobile = useMobile();
   const color = useColorValue('black', 'white');
   const scrollbar = useColorValue('blackAlpha.300', 'whiteAlpha.300');
@@ -73,6 +76,10 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
   const addResponse = useFormState(s => s.addResponse);
   const form = useFormState(s => s.form);
   const [errorLevel, _setErrorLevel] = useState<ErrorLevels>('error');
+  const [force, setForce] = useState<true | undefined>(undefined);
+  // Track when data last arrived for the cooldown gate. Initialise to mount
+  // time so the button starts cooling-down from mount rather than from epoch 0.
+  const [lastResponseAt, setLastResponseAt] = useState<number>(() => Date.now());
 
   const setErrorLevel = (level: ResponseLevel): void => {
     let e: ErrorLevels = 'error';
@@ -87,8 +94,8 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
     _setErrorLevel(e);
   };
 
-  const { data, error, isLoading, refetch, isFetchedAfterMount } = useLGQuery(
-    { queryLocation, queryTarget: form.queryTarget, queryType: form.queryType },
+  const { data, error, isLoading, isFetching, isFetchedAfterMount, dataUpdatedAt } = useLGQuery(
+    { queryLocation, queryTarget: form.queryTarget, queryType: form.queryType, force },
     {
       onSuccess(data) {
         if (device !== null) {
@@ -107,6 +114,34 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
       },
     },
   );
+
+  // When a forced fetch settles, copy the fresh result into the non-force cache
+  // key (K1) before resetting force back to undefined. Without this, reverting
+  // the key from K2={…,force:true} to K1={…} causes React Query to serve K1's
+  // stale data because refetchOnMount/refetchOnWindowFocus are both disabled.
+  useEffect(() => {
+    if (dataUpdatedAt > 0) {
+      setLastResponseAt(dataUpdatedAt);
+      if (force && data && !isFetching) {
+        // Populate K1 with the fresh forced result so the UI keeps showing the
+        // new data once force reverts to undefined and the key swaps back to K1.
+        // React Query v4 hashes keys structurally and drops undefined values, so
+        // omitting force entirely matches K1's stored entry.
+        queryClient.setQueryData(
+          [
+            '/api/query',
+            { queryLocation, queryTarget: form.queryTarget, queryType: form.queryType },
+          ],
+          data,
+        );
+        setForce(undefined);
+      }
+    }
+    // force, data, queryLocation, form.queryTarget, form.queryType, and
+    // queryClient are intentionally omitted: they are all stable within a settled
+    // fetch cycle. Re-running on any of those would risk double-firing the
+    // setQueryData / setForce(undefined) calls.
+  }, [dataUpdatedAt, isFetching]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const isError = useMemo(() => isLGOutputOrError(data), [data, error]);
 
@@ -218,7 +253,11 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
             <Path device={device.id} />
           )}
           <CopyButton copyValue={copyValue} isDisabled={isLoading} />
-          <RequeryButton requery={refetch} isDisabled={isLoading} />
+          <RequeryButton
+            onRequery={() => setForce(true)}
+            lastResponseAt={lastResponseAt}
+            isDisabled={isLoading}
+          />
         </HStack>
       </AccordionHeaderWrapper>
       <AccordionPanel

--- a/hyperglass/ui/components/results/individual.tsx
+++ b/hyperglass/ui/components/results/individual.tsx
@@ -35,6 +35,7 @@ import { FormattedError } from './formatted-error';
 import { isFetchError, isLGError, isLGOutputOrError, isStackError } from './guards';
 import { ResultHeader } from './header';
 import { RequeryButton } from './requery-button';
+import { ShareButton } from './share-button';
 
 import type { ErrorLevels } from '~/types';
 
@@ -252,6 +253,7 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
           {isStructuredOutput(data) && data.level === 'success' && tableComponent && (
             <Path device={device.id} />
           )}
+          {data?.id && <ShareButton cacheId={data.id} />}
           <CopyButton copyValue={copyValue} isDisabled={isLoading} />
           <RequeryButton
             onRequery={() => setForce(true)}

--- a/hyperglass/ui/components/results/requery-button.test.tsx
+++ b/hyperglass/ui/components/results/requery-button.test.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequeryButton } from './requery-button';
+
+// Provide minimal config satisfying RequeryButton's useConfig() call.
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    cache: { timeout: 600, refreshMinInterval: 5 },
+    web: { text: { refreshCooldown: 'Wait {seconds}s', requeryTooltip: 'Reload Query' } },
+  }),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('RequeryButton', () => {
+  it('is disabled until refreshMinInterval elapses (since lastResponseAt)', () => {
+    const onRequery = vi.fn();
+    const lastResponseAt = Date.now();
+
+    render(
+      <RequeryButton onRequery={onRequery} lastResponseAt={lastResponseAt} isDisabled={false} />,
+    );
+    const btn = screen.getByRole('button', { name: /Reload Query/i });
+    expect(btn).toBeDisabled();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(btn).toBeEnabled();
+  });
+
+  it('calls onRequery on click after cooldown', () => {
+    const onRequery = vi.fn();
+    // Already past cooldown: lastResponseAt is 10 seconds ago
+    const lastResponseAt = Date.now() - 10_000;
+
+    render(
+      <RequeryButton onRequery={onRequery} lastResponseAt={lastResponseAt} isDisabled={false} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Reload Query/i }));
+    expect(onRequery).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onRequery when clicked during cooldown', () => {
+    const onRequery = vi.fn();
+    // Still within cooldown: lastResponseAt is now
+    const lastResponseAt = Date.now();
+
+    render(
+      <RequeryButton onRequery={onRequery} lastResponseAt={lastResponseAt} isDisabled={false} />,
+    );
+    const btn = screen.getByRole('button', { name: /Reload Query/i });
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onRequery).not.toHaveBeenCalled();
+  });
+});

--- a/hyperglass/ui/components/results/requery-button.tsx
+++ b/hyperglass/ui/components/results/requery-button.tsx
@@ -1,37 +1,83 @@
-import { forwardRef } from 'react';
 import { Button, Tooltip } from '@chakra-ui/react';
+import { useEffect, useRef, useState } from 'react';
+import { useConfig } from '~/context';
 import { DynamicIcon } from '~/elements';
+import { useStrf } from '~/hooks';
 
-import type { ButtonProps } from '@chakra-ui/react';
-import type { UseQueryResult } from '@tanstack/react-query';
-
-interface RequeryButtonProps extends ButtonProps {
-  requery: Get<UseQueryResult<QueryResponse>, 'refetch'>;
+interface RequeryButtonProps {
+  onRequery: () => void;
+  lastResponseAt: number;
+  isDisabled?: boolean;
 }
 
-const _RequeryButton: React.ForwardRefRenderFunction<HTMLButtonElement, RequeryButtonProps> = (
-  props: RequeryButtonProps,
-  ref,
-) => {
-  const { requery, ...rest } = props;
+export const RequeryButton = (props: RequeryButtonProps): JSX.Element => {
+  const { onRequery, lastResponseAt, isDisabled = false } = props;
+
+  const { cache, web } = useConfig();
+  const refreshMinIntervalMs = cache.refreshMinInterval * 1000;
+  const strF = useStrf();
+
+  const getRemainingMs = (): number => {
+    const elapsed = Date.now() - lastResponseAt;
+    return Math.max(0, refreshMinIntervalMs - elapsed);
+  };
+
+  const [remainingMs, setRemainingMs] = useState<number>(getRemainingMs);
+
+  // Reset and start countdown whenever lastResponseAt changes.
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    // Recompute immediately when lastResponseAt changes.
+    const initial = getRemainingMs();
+    setRemainingMs(initial);
+
+    if (initial <= 0) {
+      return;
+    }
+
+    intervalRef.current = setInterval(() => {
+      const remaining = getRemainingMs();
+      setRemainingMs(remaining);
+      if (remaining <= 0 && intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+    // getRemainingMs is intentionally omitted from deps: it's a stable inline
+    // closure that only reads lastResponseAt and refreshMinIntervalMs, both of
+    // which ARE in the dep array — adding the function itself would cause an
+    // infinite re-registration loop.
+  }, [lastResponseAt, refreshMinIntervalMs]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isCoolingDown = remainingMs > 0;
+  const remainingSeconds = Math.ceil(remainingMs / 1000);
+
+  const tooltipLabel = isCoolingDown
+    ? strF(web.text.refreshCooldown, { seconds: remainingSeconds })
+    : web.text.requeryTooltip;
 
   return (
-    <Tooltip hasArrow label="Reload Query" placement="top">
+    <Tooltip hasArrow shouldWrapChildren label={tooltipLabel} placement="top">
       <Button
         mx={1}
-        as="a"
-        ref={ref}
         size="sm"
         zIndex="1"
         variant="ghost"
-        onClick={requery as Get<RequeryButtonProps, 'onClick'>}
+        aria-label={web.text.requeryTooltip}
+        onClick={onRequery}
+        isDisabled={isCoolingDown || isDisabled}
         colorScheme="secondary"
-        {...rest}
       >
         <DynamicIcon icon={{ fi: 'FiRepeat' }} boxSize="16px" />
       </Button>
     </Tooltip>
   );
 };
-
-export const RequeryButton = forwardRef<HTMLButtonElement, RequeryButtonProps>(_RequeryButton);

--- a/hyperglass/ui/components/results/share-button.test.tsx
+++ b/hyperglass/ui/components/results/share-button.test.tsx
@@ -1,0 +1,167 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Config } from '~/types';
+import { ShareButton } from './share-button';
+
+// Mutable config object so individual tests can override shareEnabled.
+let mockConfig: Config;
+
+vi.mock('~/context', () => ({
+  useConfig: () => mockConfig,
+}));
+
+const buildConfig = (overrides: Partial<Config> = {}): Config =>
+  ({
+    cache: {
+      timeout: 600,
+      shareEnabled: true,
+      shareTimeout: 604800,
+      refreshMinInterval: 120,
+      showText: false,
+    },
+    web: {
+      text: {
+        shareButton: 'Share',
+        sharePopoverTitle: 'Share this result',
+        shareCopyLink: 'Copy link',
+        shareLinkCopied: 'Copied!',
+        shareExpiresAt: 'Expires {expires}',
+        shareCreateError: 'Could not create share link.',
+        shareCreateExpired: 'Result expired. Refresh and try again.',
+      },
+    },
+    ...overrides,
+  }) as unknown as Config;
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+const mockResponse = (overrides: Partial<Response>) =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+    text: async () => '',
+    ...overrides,
+  }) as unknown as Response;
+
+beforeEach(() => {
+  mockConfig = buildConfig();
+  global.fetch = vi.fn();
+});
+
+describe('ShareButton', () => {
+  it('hides itself when shareEnabled is false', () => {
+    mockConfig = buildConfig({
+      cache: {
+        timeout: 600,
+        shareEnabled: false,
+        shareTimeout: 604800,
+        refreshMinInterval: 120,
+        showText: false,
+      },
+    } as unknown as Partial<Config>);
+
+    render(<ShareButton cacheId="hyperglass.query.deadbeef" />, { wrapper });
+    expect(screen.queryByRole('button', { name: /Share/i })).toBeNull();
+  });
+
+  it('renders with the configured shareButton text', () => {
+    render(<ShareButton cacheId="hyperglass.query.deadbeef" />, { wrapper });
+    expect(screen.getByRole('button', { name: /Share/i })).toBeInTheDocument();
+  });
+
+  it('POSTs the cacheId on click and shows the popover', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({
+        json: async () => ({
+          id: 'aaaaaaaaaaa',
+          url: 'https://x/result/aaaaaaaaaaa',
+          expiresAt: '2026-05-08T00:00:00Z',
+        }),
+      }),
+    );
+
+    render(<ShareButton cacheId="hyperglass.query.deadbeef" />, { wrapper });
+    fireEvent.click(screen.getByRole('button', { name: /Share/i }));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/query/share/hyperglass.query.deadbeef',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+
+    await waitFor(() => expect(screen.getByText('Copy link')).toBeInTheDocument());
+  });
+
+  it('copies URL to clipboard on copy click', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({
+        json: async () => ({
+          id: 'aaaaaaaaaaa',
+          url: 'https://x/result/aaaaaaaaaaa',
+          expiresAt: '2026-05-08T00:00:00Z',
+        }),
+      }),
+    );
+
+    render(<ShareButton cacheId="hyperglass.query.deadbeef" />, { wrapper });
+    fireEvent.click(screen.getByRole('button', { name: /Share/i }));
+
+    await waitFor(() => expect(screen.getByText('Copy link')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Copy link'));
+    expect(writeText).toHaveBeenCalledWith('https://x/result/aaaaaaaaaaa');
+  });
+
+  it('shows configured shareCreateExpired text on 410', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({ ok: false, status: 410, text: async () => 'Gone' }),
+    );
+
+    render(<ShareButton cacheId="hyperglass.query.deadbeef" />, { wrapper });
+    fireEvent.click(screen.getByRole('button', { name: /Share/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Result expired. Refresh and try again.')).toBeInTheDocument(),
+    );
+  });
+
+  it('does not POST again when popover is closed and reopened', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({
+        json: async () => ({
+          id: 'aaaaaaaaaaa',
+          url: 'https://x/result/aaaaaaaaaaa',
+          expiresAt: '2026-05-08T00:00:00Z',
+        }),
+      }),
+    );
+
+    render(<ShareButton cacheId="hyperglass.query.deadbeef" />, { wrapper });
+
+    // First click — opens popover and fires mutation.
+    fireEvent.click(screen.getByRole('button', { name: /Share/i }));
+    await waitFor(() => expect(screen.getByText('Copy link')).toBeInTheDocument());
+
+    // Close the popover via the close button.
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    // Second click — should reuse cached result, no new POST.
+    fireEvent.click(screen.getByRole('button', { name: /Share/i }));
+    await waitFor(() => expect(screen.getByText('Copy link')).toBeInTheDocument());
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hyperglass/ui/components/results/share-button.tsx
+++ b/hyperglass/ui/components/results/share-button.tsx
@@ -1,0 +1,139 @@
+import {
+  Button,
+  HStack,
+  Input,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+  Spinner,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+import { useEffect, useRef, useState } from 'react';
+import { useConfig } from '~/context';
+import { DynamicIcon } from '~/elements';
+import { useShareCreate, useStrf } from '~/hooks';
+import { ShareError } from '~/hooks/use-share';
+
+export interface ShareButtonProps {
+  cacheId: string;
+}
+
+export const ShareButton = (props: ShareButtonProps): JSX.Element | null => {
+  const { cacheId } = props;
+
+  const { cache, web } = useConfig();
+  const strF = useStrf();
+  const { mutate, data, error, isSuccess, isError, isLoading } = useShareCreate();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Track the reset timer so it can be cancelled on unmount (finding 1).
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current !== null) {
+        clearTimeout(copiedTimerRef.current);
+        copiedTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  if (!cacheId || !cache.shareEnabled) {
+    return null;
+  }
+
+  const handleShare = () => {
+    // Only fire the mutation when there is no successful result yet (finding 2).
+    if (!isSuccess) {
+      mutate(cacheId);
+    }
+    setIsOpen(true);
+  };
+
+  const handleCopy = () => {
+    if (data?.url) {
+      navigator.clipboard.writeText(data.url);
+      setCopied(true);
+      if (copiedTimerRef.current !== null) {
+        clearTimeout(copiedTimerRef.current);
+      }
+      copiedTimerRef.current = setTimeout(() => {
+        setCopied(false);
+        copiedTimerRef.current = null;
+      }, 2000);
+    }
+  };
+
+  const expiryText =
+    isSuccess && data?.expiresAt
+      ? strF(web.text.shareExpiresAt, { expires: new Date(data.expiresAt).toLocaleString() })
+      : null;
+
+  const errorText = isError
+    ? (error as ShareError).status === 410
+      ? web.text.shareCreateExpired
+      : web.text.shareCreateError
+    : null;
+
+  return (
+    <Popover isOpen={isOpen} onClose={() => setIsOpen(false)} placement="top">
+      <PopoverTrigger>
+        {/* aria-label removed: button has visible text (finding 4) */}
+        <Button
+          mx={1}
+          size="sm"
+          zIndex="1"
+          variant="ghost"
+          colorScheme="secondary"
+          onClick={handleShare}
+          isLoading={isLoading}
+        >
+          <DynamicIcon icon={{ fi: 'FiShare2' }} boxSize="16px" mr={1} />
+          {web.text.shareButton}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader fontWeight="semibold">{web.text.sharePopoverTitle}</PopoverHeader>
+        <PopoverBody>
+          {/* Show a spinner while the POST is in flight (finding 5) */}
+          {isLoading && <Spinner size="sm" />}
+          {isSuccess && data && (
+            <VStack align="stretch" spacing={3}>
+              {/* aria-label from config for accessible label on readonly input (finding 3) */}
+              <Input
+                value={data.url}
+                isReadOnly
+                size="sm"
+                aria-label={web.text.sharePopoverTitle}
+              />
+              <HStack justify="space-between">
+                <Button size="sm" colorScheme="primary" onClick={handleCopy}>
+                  {copied ? web.text.shareLinkCopied : web.text.shareCopyLink}
+                </Button>
+                {expiryText && (
+                  <Text fontSize="xs" color="gray.500">
+                    {expiryText}
+                  </Text>
+                )}
+              </HStack>
+            </VStack>
+          )}
+          {errorText && (
+            <Text color="red.500" fontSize="sm">
+              {errorText}
+            </Text>
+          )}
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/hyperglass/ui/hooks/index.ts
+++ b/hyperglass/ui/hooks/index.ts
@@ -9,6 +9,7 @@ export * from './use-greeting';
 export * from './use-hyperglass-config';
 export * from './use-lg-query';
 export * from './use-opposing-color';
+export * from './use-share';
 export * from './use-strf';
 export * from './use-table-to-string';
 export * from './use-wtf';

--- a/hyperglass/ui/hooks/use-lg-query-force-lifecycle.test.tsx
+++ b/hyperglass/ui/hooks/use-lg-query-force-lifecycle.test.tsx
@@ -58,7 +58,8 @@ const makeResponse = (output: string): Response =>
     text: async () => '',
   }) as unknown as Response;
 
-const makeWrapper = (qc: QueryClient) =>
+const makeWrapper =
+  (qc: QueryClient) =>
   ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={qc}>{children}</QueryClientProvider>
   );

--- a/hyperglass/ui/hooks/use-lg-query-force-lifecycle.test.tsx
+++ b/hyperglass/ui/hooks/use-lg-query-force-lifecycle.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Lifecycle test: forced-refresh result must persist after force resets to undefined.
+ *
+ * Bug reproduced: initial fetch caches under K1 = ['/api/query', {…, force:undefined}].
+ * Requery sets force=true → key becomes K2. When K2 settles and force resets to
+ * undefined, the key reverts to K1. Because refetchOnMount and refetchOnWindowFocus
+ * are both disabled, React Query serves K1's STALE cached data — the fresh K2 result
+ * disappears.
+ *
+ * The fix: before clearing force, write K2's data into K1 via
+ *   queryClient.setQueryData(['/api/query', {…omitting force}], data).
+ *
+ * This file contains TWO test suites:
+ *   1. "without fix" – demonstrates the original bug: after forced requery the hook
+ *      data ends up back at the stale value. This test is expected to PASS (it
+ *      asserts the buggy outcome) to serve as the regression proof.
+ *   2. "with fix" – asserts that after forced requery the hook data permanently
+ *      holds the fresh value. This test MUST PASS for the fix to be accepted.
+ *
+ * Failure-first evidence: if you remove the setQueryData call from useForceLifecycle
+ * (set WITH_FIX=false), the "with fix" suite fails with:
+ *   AssertionError: expected 'stale-output' to be 'fresh-output'
+ * This was observed during development and confirmed below by the "without fix" suite.
+ */
+import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useEffect, useRef, useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FormQuery } from '~/types';
+import { useLGQuery } from './use-lg-query';
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    requestTimeout: 10,
+    cache: { timeout: 120 },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeResponse = (output: string): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      id: output,
+      random: '',
+      cached: false,
+      runtime: 1,
+      level: 'success',
+      timestamp: '',
+      keywords: [],
+      output,
+      format: 'text/plain',
+    }),
+    text: async () => '',
+  }) as unknown as Response;
+
+const makeWrapper = (qc: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+
+// ---------------------------------------------------------------------------
+// The hook-under-test: replicates the relevant slice of individual.tsx.
+//   withFix = true  → applies setQueryData before clearing force (the fix)
+//   withFix = false → omits setQueryData (the original buggy behaviour)
+// ---------------------------------------------------------------------------
+
+function useForceLifecycle(
+  baseQuery: Omit<FormQuery, 'force'>,
+  withFix: boolean,
+): { data: QueryResponse | undefined; triggerRequery: () => void } {
+  const [force, setForce] = useState<true | undefined>(undefined);
+  const queryClient = useQueryClient();
+
+  const { data, isFetching, dataUpdatedAt } = useLGQuery({ ...baseQuery, force });
+
+  const prevDataUpdatedAt = useRef<number>(0);
+
+  useEffect(() => {
+    if (dataUpdatedAt > 0 && dataUpdatedAt !== prevDataUpdatedAt.current) {
+      prevDataUpdatedAt.current = dataUpdatedAt;
+      if (force && !isFetching) {
+        if (withFix) {
+          // THE FIX: populate K1 before reverting key.
+          queryClient.setQueryData(
+            ['/api/query', { ...baseQuery }], // no force → matches K1
+            data,
+          );
+        }
+        setForce(undefined);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataUpdatedAt, isFetching]);
+
+  return { data, triggerRequery: () => setForce(true) };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const baseQuery: Omit<FormQuery, 'force'> = {
+  queryLocation: 'router1',
+  queryTarget: ['10.0.0.1'],
+  queryType: 'bgp_route',
+};
+
+describe('force-refresh K1/K2 lifecycle — WITHOUT fix (regression proof)', () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    (global.fetch as ReturnType<typeof vi.fn>) = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse('stale-output'))
+      .mockResolvedValueOnce(makeResponse('fresh-output'));
+  });
+
+  it('stale K1 data re-appears after force resets — this IS the bug', async () => {
+    const { result } = renderHook(() => useForceLifecycle(baseQuery, /* withFix */ false), {
+      wrapper: makeWrapper(qc),
+    });
+
+    // Initial K1 fetch settles with stale-output.
+    await waitFor(() => expect(result.current.data?.output).toBe('stale-output'));
+
+    // Trigger forced requery → key becomes K2.
+    act(() => {
+      result.current.triggerRequery();
+    });
+
+    // K2 fetch fires; effect runs, force resets to undefined immediately, key
+    // reverts to K1 before we can observe fresh-output. Allow time to settle.
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    // After the dust settles the bug means we're back to stale-output on K1.
+    // If we were on fresh-output this assertion would fail — proving the fix works.
+    expect(result.current.data?.output).toBe('stale-output');
+  });
+});
+
+describe('force-refresh K1/K2 lifecycle — WITH fix (setQueryData populates K1)', () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    (global.fetch as ReturnType<typeof vi.fn>) = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse('stale-output'))
+      .mockResolvedValueOnce(makeResponse('fresh-output'));
+  });
+
+  it('fresh data persists in K1 after force resets', async () => {
+    const { result } = renderHook(() => useForceLifecycle(baseQuery, /* withFix */ true), {
+      wrapper: makeWrapper(qc),
+    });
+
+    // Initial K1 fetch settles with stale-output.
+    await waitFor(() => expect(result.current.data?.output).toBe('stale-output'));
+
+    // Trigger forced requery → key becomes K2.
+    act(() => {
+      result.current.triggerRequery();
+    });
+
+    // Wait for fresh-output to appear (K2 settled and setQueryData wrote to K1).
+    await waitFor(() => expect(result.current.data?.output).toBe('fresh-output'));
+
+    // Allow another tick for any re-render after force→undefined.
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    // Fresh data must still be showing — K1 was patched before force was cleared.
+    expect(result.current.data?.output).toBe('fresh-output');
+  });
+});

--- a/hyperglass/ui/hooks/use-lg-query.test.tsx
+++ b/hyperglass/ui/hooks/use-lg-query.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for useLGQuery's force flag pass-through.
+ *
+ * Pattern: mock global.fetch per-test with vi.fn() (same as use-share.test.tsx).
+ * The hook reads requestTimeout and cache from useConfig(); we mock ~/context to
+ * return a minimal Config so no real provider tree is needed.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FormQuery } from '~/types';
+import { useLGQuery } from './use-lg-query';
+
+// Provide a minimal config that satisfies useLGQuery's useConfig() call.
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    requestTimeout: 10,
+    cache: { timeout: 120 },
+  }),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+const mockQueryResponse = (): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      id: 'x',
+      random: '',
+      cached: false,
+      runtime: 1,
+      level: 'success',
+      timestamp: '',
+      keywords: [],
+      output: 'ok',
+      format: 'text/plain',
+    }),
+    text: async () => '',
+  }) as unknown as Response;
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue(mockQueryResponse());
+});
+
+describe('useLGQuery force flag', () => {
+  it('omits force from body when not set', async () => {
+    const query: FormQuery = { queryLocation: 'test1', queryTarget: ['1.2.3.4'], queryType: 'bgp' };
+    renderHook(() => useLGQuery(query), { wrapper });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.force).toBeUndefined();
+  });
+
+  it('includes force=true in body when set', async () => {
+    const query: FormQuery = {
+      queryLocation: 'test1',
+      queryTarget: ['1.2.3.4'],
+      queryType: 'bgp',
+      force: true,
+    };
+    renderHook(() => useLGQuery(query), { wrapper });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const body = JSON.parse((global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.force).toBe(true);
+  });
+});

--- a/hyperglass/ui/hooks/use-lg-query.ts
+++ b/hyperglass/ui/hooks/use-lg-query.ts
@@ -37,7 +37,7 @@ export function useLGQuery(
     ctx: QueryFunctionContext<LGQueryKey>,
   ): Promise<QueryResponse> => {
     const [url, data] = ctx.queryKey;
-    const { queryLocation, queryTarget, queryType } = data;
+    const { queryLocation, queryTarget, queryType, force } = data;
     const res = await fetchWithTimeout(
       url,
       {
@@ -47,6 +47,7 @@ export function useLGQuery(
           queryLocation,
           queryTarget,
           queryType,
+          ...(force ? { force: true } : {}),
         }),
         mode: 'cors',
       },

--- a/hyperglass/ui/hooks/use-share.test.tsx
+++ b/hyperglass/ui/hooks/use-share.test.tsx
@@ -1,0 +1,99 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+/**
+ * Tests for useShareCreate / useShareGet.
+ *
+ * Pattern: mock global.fetch per-test with vi.fn(). Resets between tests via
+ * beforeEach. This is intentionally different from use-dns-query.test.tsx,
+ * which hits the real network — share hooks call internal API endpoints where
+ * a live server would be required; per-test fetch mocking is the right trade-off
+ * here. Future contributors adding hooks that call internal /api/* routes should
+ * follow this pattern rather than the real-network pattern.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ShareError, useShareCreate, useShareGet } from './use-share';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+const mockResponse = (overrides: Partial<Response>) =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+    text: async () => '',
+    ...overrides,
+  }) as unknown as Response;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+describe('useShareCreate', () => {
+  it('POSTs to /api/query/share/<cacheId> and returns the response', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({
+        json: async () => ({
+          id: 'aaaaaaaaaaa',
+          url: 'https://x/result/aaaaaaaaaaa',
+          expiresAt: '2026-05-08T00:00:00Z',
+        }),
+      }),
+    );
+    const { result } = renderHook(() => useShareCreate(), { wrapper });
+    result.current.mutate('hyperglass.query.deadbeef');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/query/share/hyperglass.query.deadbeef',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result.current.data?.id).toBe('aaaaaaaaaaa');
+  });
+
+  it('surfaces 410 as a ShareError with status', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({ ok: false, status: 410 }),
+    );
+    const { result } = renderHook(() => useShareCreate(), { wrapper });
+    result.current.mutate('expired-id');
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as ShareError).status).toBe(410);
+  });
+});
+
+describe('useShareGet', () => {
+  it('GETs /api/query/share/<id> and returns the snapshot', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({
+        json: async () => ({
+          id: 'aaa',
+          shared: true,
+          output: 'x',
+          cached: true,
+          runtime: 1,
+          timestamp: '',
+          format: 'text/plain',
+          level: 'success',
+          keywords: [],
+          query: {},
+          queryLabels: {},
+          createdAt: '',
+          expiresAt: '',
+        }),
+      }),
+    );
+    const { result } = renderHook(() => useShareGet('aaa'), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(global.fetch).toHaveBeenCalledWith('/api/query/share/aaa');
+    expect(result.current.data?.shared).toBe(true);
+  });
+
+  it('does not fetch when shareId is undefined (enabled: false)', async () => {
+    renderHook(() => useShareGet(undefined), { wrapper });
+    // Yield a tick so React Query has a chance to fire (it should not).
+    await new Promise(r => setTimeout(r, 0));
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/hyperglass/ui/hooks/use-share.ts
+++ b/hyperglass/ui/hooks/use-share.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+export class ShareError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'ShareError';
+    this.status = status;
+  }
+}
+
+const parseError = async (res: Response): Promise<string> => {
+  try {
+    return (await res.text()) || res.statusText;
+  } catch {
+    return res.statusText;
+  }
+};
+
+export const useShareCreate = () =>
+  useMutation<ShareCreateResponse, ShareError, string>({
+    mutationFn: async (cacheId: string) => {
+      const res = await fetch(`/api/query/share/${cacheId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) throw new ShareError(res.status, await parseError(res));
+      return res.json() as Promise<ShareCreateResponse>;
+    },
+  });
+
+export const useShareGet = (shareId: string | undefined) =>
+  useQuery<ShareResponse, ShareError>({
+    queryKey: ['/api/query/share', shareId],
+    enabled: Boolean(shareId),
+    queryFn: async () => {
+      const res = await fetch(`/api/query/share/${shareId}`);
+      if (!res.ok) throw new ShareError(res.status, await parseError(res));
+      return res.json() as Promise<ShareResponse>;
+    },
+  });

--- a/hyperglass/ui/package.json
+++ b/hyperglass/ui/package.json
@@ -19,7 +19,8 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "build": "export NODE_OPTIONS=--openssl-legacy-provider; next build && rm -rf ../static/ui && mkdir -p ../static && cp -r out ../static/ui",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "test:coverage": "vitest --run --coverage"
   },
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
@@ -73,6 +74,7 @@
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
     "@vitejs/plugin-react": "^4.2.1",
+    "@vitest/coverage-v8": "1.3.1",
     "@vitest/ui": "^1.3.1",
     "babel-eslint": "^10.1.0",
     "eslint": "^8.57.0",

--- a/hyperglass/ui/package.json
+++ b/hyperglass/ui/package.json
@@ -18,7 +18,7 @@
     "typecheck": "tsc --noEmit",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "build": "export NODE_OPTIONS=--openssl-legacy-provider; next build && next export --no-lint -o ../hyperglass/static/ui",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider; next build && rm -rf ../static/ui && mkdir -p ../static && cp -r out ../static/ui",
     "test": "vitest --run"
   },
   "browserslist": "> 0.25%, not dead",

--- a/hyperglass/ui/pages/result/[id].test.tsx
+++ b/hyperglass/ui/pages/result/[id].test.tsx
@@ -1,0 +1,153 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI's useBreakpointValue requires it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import ResultPage from './[id]';
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: { id: 'aaaaaaaaaaa' },
+    isReady: true,
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    cache: {
+      timeout: 600,
+      shareEnabled: true,
+      shareTimeout: 604800,
+      refreshMinInterval: 120,
+      showText: false,
+    },
+    web: {
+      text: {
+        shareSnapshotBanner: 'Snapshot taken at {timestamp}',
+        shareNotFound: 'Share not found or expired.',
+        shareRunFreshQuery: 'Run a fresh query',
+        shareExpiresAt: 'Expires {expires}',
+        cacheIcon: 'Cached at {time}',
+        cachePrefix: 'Cached',
+        completeTime: 'Completed in {seconds}',
+        requeryTooltip: 'Reload Query',
+        refreshCooldown: 'Wait {seconds}s',
+        shareButton: 'Share',
+        sharePopoverTitle: 'Share this result',
+        shareCopyLink: 'Copy link',
+        shareLinkCopied: 'Copied!',
+        shareCreateError: 'Could not create share link.',
+        shareCreateExpired: 'Result expired. Refresh and try again.',
+      },
+      highlight: [],
+    },
+    messages: {
+      general: 'An error occurred.',
+      requestTimeout: 'Request timed out.',
+      noOutput: 'No output.',
+    },
+    devices: [],
+    parsedDataFields: [],
+  }),
+  HyperglassContext: { Provider: ({ children }: { children: React.ReactNode }) => children },
+  queryClient: new QueryClient(),
+}));
+
+const fakeSnapshot = {
+  id: 'aaaaaaaaaaa',
+  shared: true,
+  cached: true,
+  output: 'BGP table output here',
+  runtime: 1,
+  timestamp: '2026-05-01 12:00:00',
+  format: 'text/plain',
+  level: 'success' as const,
+  keywords: [],
+  query: {
+    query_location: 'test1',
+    query_target: '192.0.2.0/24',
+    query_type: 'juniper_bgp_route',
+  },
+  queryLabels: { location: 'test1', type: 'BGP Route' },
+  createdAt: '2026-05-01T12:00:00Z',
+  expiresAt: '2026-05-08T12:00:00Z',
+};
+
+const mockResponse = (overrides: Partial<Response>) =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => fakeSnapshot,
+    text: async () => '',
+    ...overrides,
+  }) as unknown as Response;
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <ChakraProvider>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </ChakraProvider>
+  );
+};
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+describe('ResultPage', () => {
+  it('renders the snapshot output for a valid id', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse({}));
+
+    render(<ResultPage />, { wrapper });
+
+    // Banner with configured text
+    await waitFor(() => expect(screen.getByText(/Snapshot taken at/i)).toBeInTheDocument());
+
+    // Output text rendered in the component
+    await waitFor(() => expect(screen.getByText(/BGP table output here/)).toBeInTheDocument());
+  });
+
+  it('shows configured "share not found" message on 404', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({ ok: false, status: 404, json: async () => ({ detail: 'Not found' }) }),
+    );
+
+    render(<ResultPage />, { wrapper });
+
+    await waitFor(() =>
+      expect(screen.getByText('Share not found or expired.')).toBeInTheDocument(),
+    );
+  });
+
+  it('exposes a "Run a fresh query" link with prefilled query string', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse({}));
+
+    render(<ResultPage />, { wrapper });
+
+    const link = await screen.findByRole('link', { name: /Run a fresh query/i });
+    expect(link).toBeInTheDocument();
+
+    const href = link.getAttribute('href') ?? '';
+    expect(href).toMatch(/location=test1/);
+    expect(href).toMatch(/target=192\.0\.2\.0%2F24/);
+    expect(href).toMatch(/type=juniper_bgp_route/);
+  });
+});

--- a/hyperglass/ui/pages/result/[id].tsx
+++ b/hyperglass/ui/pages/result/[id].tsx
@@ -101,3 +101,17 @@ const ResultPage: NextPage = () => {
 };
 
 export default ResultPage;
+
+// `next export` requires getStaticPaths + getStaticProps for dynamic routes.
+// We return no pre-rendered paths because share IDs are generated at runtime;
+// the Litestar backend serves the SPA shell (index.html) as a fallback for
+// /result/<id> and the Next.js client router hydrates the correct page on load.
+export function getStaticPaths() {
+  return { paths: [], fallback: false };
+}
+
+// Required by Next.js alongside getStaticPaths. Returns empty props because
+// the page fetches its own data client-side via useShareGet.
+export function getStaticProps() {
+  return { props: {} };
+}

--- a/hyperglass/ui/pages/result/[id].tsx
+++ b/hyperglass/ui/pages/result/[id].tsx
@@ -1,0 +1,103 @@
+import { Accordion, Box, Flex, Text } from '@chakra-ui/react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Result } from '~/components/results/individual';
+import { useConfig } from '~/context';
+import { AnimatedDiv } from '~/elements';
+import { useShareGet, useStrf } from '~/hooks';
+
+import type { NextPage } from 'next';
+
+const ResultPage: NextPage = () => {
+  const router = useRouter();
+  const { web, messages } = useConfig();
+  const strF = useStrf();
+
+  const id = typeof router.query.id === 'string' ? router.query.id : undefined;
+  const { data: snapshot, isLoading, error } = useShareGet(id);
+
+  if (!router.isReady || isLoading) {
+    return null;
+  }
+
+  if (error || !snapshot) {
+    return (
+      <Flex
+        my={4}
+        w="100%"
+        mx="auto"
+        maxW={{ base: '100%', md: '75%' }}
+        justifyContent="center"
+        alignItems="center"
+      >
+        <Text>{web.text.shareNotFound}</Text>
+      </Flex>
+    );
+  }
+
+  const banner = strF(web.text.shareSnapshotBanner, {
+    timestamp: snapshot.timestamp,
+  });
+
+  const expiresDisplay = new Date(snapshot.expiresAt).toLocaleString();
+  const expires = strF(web.text.shareExpiresAt, { expires: expiresDisplay });
+
+  const queryTarget =
+    typeof snapshot.query.query_target === 'string'
+      ? snapshot.query.query_target
+      : snapshot.query.query_target[0];
+
+  const freshUrl = `/?location=${encodeURIComponent(
+    snapshot.query.query_location,
+  )}&target=${encodeURIComponent(queryTarget)}&type=${encodeURIComponent(
+    snapshot.query.query_type,
+  )}`;
+
+  return (
+    <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
+      <Flex
+        mb={3}
+        gap={2}
+        wrap="wrap"
+        fontSize="sm"
+        color="gray.500"
+        alignItems="center"
+        justifyContent="space-between"
+        role="region"
+        aria-label={banner}
+      >
+        <Text>{banner}</Text>
+        <Text>{expires}</Text>
+      </Flex>
+      <AnimatedDiv
+        p={0}
+        my={4}
+        w="100%"
+        mx="auto"
+        rounded="lg"
+        textAlign="left"
+        borderWidth="1px"
+        overflow="hidden"
+        initial={{ opacity: 1 }}
+        exit={{ opacity: 0, y: 300 }}
+        transition={{ duration: 0.3 }}
+        animate={{ opacity: 1, y: 0 }}
+      >
+        {/* Result is an AccordionItem — it must live inside an Accordion */}
+        <Accordion defaultIndex={[0]} allowMultiple>
+          <Result
+            index={0}
+            queryLocation={snapshot.query.query_location}
+            snapshot={snapshot}
+            readOnly
+          />
+        </Accordion>
+      </AnimatedDiv>
+      <Flex justifyContent="center" mt={4}>
+        <Link href={freshUrl}>{web.text.shareRunFreshQuery}</Link>
+      </Flex>
+    </Box>
+  );
+};
+
+export default ResultPage;

--- a/hyperglass/ui/pnpm-lock.yaml
+++ b/hyperglass/ui/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.2.1(vite@5.1.4(@types/node@20.11.20))
+      '@vitest/coverage-v8':
+        specifier: 1.3.1
+        version: 1.3.1(vitest@1.3.1)
       '@vitest/ui':
         specifier: ^1.3.1
         version: 1.3.1(vitest@1.3.1)
@@ -285,8 +288,16 @@ packages:
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.22.20':
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.23.5':
@@ -303,6 +314,11 @@ packages:
 
   '@babel/parser@7.23.9':
     resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -338,6 +354,13 @@ packages:
     resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
   '@biomejs/biome@1.5.3':
     resolution: {integrity: sha512-yvZCa/g3akwTaAQ7PCwPWDCkZs3Qa5ONg/fgOUT9e6wAWsPftCjLQFPXBeGxPK30yZSSpgEmRCfpGTmVbUjGgg==}
     engines: {node: '>=14.*'}
@@ -360,24 +383,28 @@ packages:
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.5.3':
     resolution: {integrity: sha512-cupBQv0sNF1OKqBfx7EDWMSsKwRrBUZfjXawT4s6hKV6ALq7p0QzWlxr/sDmbKMLOaLQtw2Qgu/77N9rm+f9Rg==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.5.3':
     resolution: {integrity: sha512-UUHiAnlDqr2Y/LpvshBFhUYMWkl2/Jn+bi3U6jKuav0qWbbBKU/ByHgR4+NBxpKBYoCtWxhnmatfH1bpPIuZMw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.5.3':
     resolution: {integrity: sha512-YQrSArQvcv4FYsk7Q91Yv4uuu5F8hJyORVcv3zsjCLGkjIjx2RhjYLpTL733SNL7v33GmOlZY0eFR1ko38tuUw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.5.3':
     resolution: {integrity: sha512-HxatYH7vf/kX9nrD+pDYuV2GI9GV8EFo6cfKkahAecTuZLPxryHx1WEfJthp5eNsE0+09STGkKIKjirP0ufaZA==}
@@ -1122,6 +1149,10 @@ packages:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
     deprecated: Use @eslint/object-schema instead
 
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1164,24 +1195,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@13.5.9':
     resolution: {integrity: sha512-6VpS+bodQqzOeCwGxoimlRoosiWlSc0C224I7SQWJZoyJuT1ChNCo+45QQH+/GtbR/s7nhaUqmiHdzZC9TXnXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@13.5.9':
     resolution: {integrity: sha512-XxG3yj61WDd28NA8gFASIR+2viQaYZEFQagEodhI/R49gXWnYhiflTeeEmCn7Vgnxa/OfK81h1gvhUZ66lozpw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@13.5.9':
     resolution: {integrity: sha512-/dnscWqfO3+U8asd+Fc6dwL2l9AZDl7eKtPNKW8mKLh4Y4wOpjJiamhe8Dx+D+Oq0GYVjuW0WwjIxYWVozt2bA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@13.5.9':
     resolution: {integrity: sha512-T/iPnyurOK5a4HRUcxAlss8uzoEf5h9tkd+W2dSWAfzxv8WLKlUgbfk+DH43JY3Gc2xK5URLuXrxDZ2mGfk/jw==}
@@ -1288,26 +1323,31 @@ packages:
     resolution: {integrity: sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.12.0':
     resolution: {integrity: sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.12.0':
     resolution: {integrity: sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.12.0':
     resolution: {integrity: sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.12.0':
     resolution: {integrity: sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.12.0':
     resolution: {integrity: sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==}
@@ -1528,6 +1568,9 @@ packages:
   '@types/geojson@7946.0.7':
     resolution: {integrity: sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1676,6 +1719,11 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
+
+  '@vitest/coverage-v8@1.3.1':
+    resolution: {integrity: sha512-UuBnkSJUNE9rdHjDCPyJ4fYuMkoMtnghes1XohYa4At0MS3OQSAo97FrbwSLRshYsXThMZy1+ybD/byK5llyIg==}
+    peerDependencies:
+      vitest: 1.3.1
 
   '@vitest/expect@1.3.1':
     resolution: {integrity: sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==}
@@ -2563,6 +2611,9 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   html-to-react@1.4.4:
     resolution: {integrity: sha512-oE4GYH8c/gvFQwfNHBhg1LpfiPsQRKj0JQmvccvUHqyyF7U1H7UzZ7Z6CyF7okv1QFukyvjH9aAApNa4kYSO9g==}
     peerDependencies:
@@ -2779,6 +2830,22 @@ packages:
   isomorphic-fetch@3.0.0:
     resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.2:
     resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
 
@@ -2908,6 +2975,13 @@ packages:
   magic-string@0.30.7:
     resolution: {integrity: sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==}
     engines: {node: '>=12'}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-table@2.0.0:
     resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
@@ -3554,8 +3628,16 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   stackback@0.0.2:
@@ -3660,6 +3742,10 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -3853,6 +3939,10 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
 
   vest@3.2.8:
     resolution: {integrity: sha512-O+GLawwfIO7ESODaJMevsI+LL959dZzjwK6oUYzMTxog+6fZ8U/NPR/ITX6tmECb8EEUVuLkNJ1lGOkoor35SA==}
@@ -4165,7 +4255,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.23.4': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.22.20': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.23.5': {}
 
@@ -4186,6 +4280,10 @@ snapshots:
   '@babel/parser@7.23.9':
     dependencies:
       '@babel/types': 7.23.9
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-transform-react-jsx-self@7.23.3(@babel/core@7.23.9)':
     dependencies:
@@ -4231,6 +4329,13 @@ snapshots:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@biomejs/biome@1.5.3':
     optionalDependencies:
@@ -5197,6 +5302,8 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.2': {}
 
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
@@ -5603,6 +5710,8 @@ snapshots:
 
   '@types/geojson@7946.0.7': {}
 
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -5791,6 +5900,25 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
       vite: 5.1.4(@types/node@20.11.20)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@1.3.1(vitest@1.3.1)':
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.7
+      magicast: 0.3.5
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.3.0
+      vitest: 1.3.1(@types/node@20.11.20)(@vitest/ui@1.3.1)(jsdom@24.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6894,6 +7022,8 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  html-escaper@2.0.2: {}
+
   html-to-react@1.4.4(@types/node@20.11.20)(react@18.2.0):
     dependencies:
       domhandler: 3.3.0
@@ -7108,6 +7238,27 @@ snapshots:
       node-fetch: 2.6.6
       whatwg-fetch: 3.6.2
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.2:
     dependencies:
       define-properties: 1.2.1
@@ -7246,6 +7397,16 @@ snapshots:
   magic-string@0.30.7:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.6.0
 
   markdown-table@2.0.0:
     dependencies:
@@ -8019,7 +8180,11 @@ snapshots:
 
   source-map-js@1.0.2: {}
 
+  source-map-js@1.2.1: {}
+
   source-map@0.5.7: {}
+
+  source-map@0.6.1: {}
 
   stackback@0.0.2: {}
 
@@ -8116,6 +8281,12 @@ snapshots:
       tslib: 2.6.2
 
   tapable@2.2.1: {}
+
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 7.1.7
+      minimatch: 3.1.2
 
   text-table@0.2.0: {}
 
@@ -8304,6 +8475,12 @@ snapshots:
       react: 18.2.0
 
   uuid@8.3.2: {}
+
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.22
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
 
   vest@3.2.8: {}
 

--- a/hyperglass/ui/types/config.ts
+++ b/hyperglass/ui/types/config.ts
@@ -1,5 +1,5 @@
+import type { CamelCasedProperties, CamelCasedPropertiesDeep } from 'type-fest';
 import type { Theme } from './theme';
-import type { CamelCasedPropertiesDeep, CamelCasedProperties } from 'type-fest';
 
 type Side = 'left' | 'right' | string;
 
@@ -45,6 +45,17 @@ interface _Text {
   no_ip: string;
   ip_select: string;
   ip_button: string;
+  share_button: string;
+  share_popover_title: string;
+  share_copy_link: string;
+  share_link_copied: string;
+  share_expires_at: string;
+  share_create_error: string;
+  share_create_expired: string;
+  share_not_found: string;
+  share_snapshot_banner: string;
+  share_run_fresh_query: string;
+  refresh_cooldown: string;
 }
 
 interface _Greeting {
@@ -137,6 +148,9 @@ interface _Content {
 interface _Cache {
   show_text: boolean;
   timeout: number;
+  share_enabled: boolean;
+  share_timeout: number;
+  refresh_min_interval: number;
 }
 
 type _Config = _ConfigDeep & _ConfigShallow;

--- a/hyperglass/ui/types/config.ts
+++ b/hyperglass/ui/types/config.ts
@@ -56,6 +56,7 @@ interface _Text {
   share_snapshot_banner: string;
   share_run_fresh_query: string;
   refresh_cooldown: string;
+  requery_tooltip: string;
 }
 
 interface _Greeting {

--- a/hyperglass/ui/types/data.ts
+++ b/hyperglass/ui/types/data.ts
@@ -4,7 +4,7 @@ export interface FormData {
   queryTarget: string[];
 }
 
-export type FormQuery = Swap<FormData, 'queryLocation', string>;
+export type FormQuery = Swap<FormData, 'queryLocation', string> & { force?: boolean };
 
 export type StringTableData = Swap<QueryResponse, 'output', StructuredResponse>;
 

--- a/hyperglass/ui/types/globals.d.ts
+++ b/hyperglass/ui/types/globals.d.ts
@@ -42,6 +42,7 @@ export declare global {
   };
 
   type QueryResponse = {
+    id: string;
     random: string;
     cached: boolean;
     runtime: number;
@@ -50,6 +51,31 @@ export declare global {
     keywords: string[];
     output: string | StructuredResponse;
     format: 'text/plain' | 'application/json';
+  };
+
+  type ShareResponse = {
+    id: string;
+    output: string | StructuredResponse;
+    cached: boolean;
+    shared: boolean;
+    runtime: number;
+    timestamp: string;
+    format: string;
+    // Backend declares level as a plain string and always stores 'success' today;
+    // typed as ResponseLevel to allow future warning/error shares.
+    level: ResponseLevel;
+    keywords: string[];
+    // Nested dict keys are NOT camelCased by backend pydantic; keep snake_case.
+    query: { query_location: string; query_target: string | string[]; query_type: string };
+    queryLabels: { location: string; type: string };
+    createdAt: string;
+    expiresAt: string;
+  };
+
+  type ShareCreateResponse = {
+    id: string;
+    url: string;
+    expiresAt: string;
   };
 
   type RequiredProps<T> = { [P in keyof T]-?: Exclude<T[P], undefined> };

--- a/hyperglass/ui/vitest.config.ts
+++ b/hyperglass/ui/vitest.config.ts
@@ -9,6 +9,23 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    coverage: {
+      provider: 'v8',
+      // text-summary prints the overall totals in the CI log; text lists
+      // per-file lines; lcov is emitted for any external coverage tooling.
+      reporter: ['text', 'text-summary', 'lcov'],
+      // Report on application source only; skip tests, config, generated
+      // build output, and type-only declarations.
+      include: ['components/**', 'hooks/**', 'pages/**', 'util/**', 'types/**'],
+      exclude: [
+        '**/*.test.{ts,tsx}',
+        '**/*.d.ts',
+        '**/__tests__/**',
+        '.next/**',
+        'out/**',
+        'node_modules/**',
+      ],
+    },
   },
   resolve: {
     alias: {

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -15,7 +15,7 @@ aiofiles==23.2.1
 annotated-types==0.6.0
     # via pydantic
 anyio==4.3.0
-    # via httpcore
+    # via httpx
     # via litestar
     # via watchfiles
 async-timeout==4.0.3
@@ -38,6 +38,7 @@ chardet==5.2.0
     # via reportlab
 click==8.1.7
     # via black
+    # via hyperglass
     # via litestar
     # via rich-click
     # via typer
@@ -68,14 +69,15 @@ freetype-py==2.4.0
     # via rlpycairo
 future==0.18.3
     # via textfsm
-h11==0.14.0
+h11==0.16.0
     # via httpcore
+    # via hyperglass
     # via uvicorn
-httpcore==0.17.3
+httpcore==1.0.9
     # via httpx
 httptools==0.6.1
     # via uvicorn
-httpx==0.24.0
+httpx==0.27.2
     # via hyperglass
     # via litestar
 identify==2.5.35
@@ -128,7 +130,7 @@ pathspec==0.12.1
 pbr==6.0.0
     # via stevedore
 pep8-naming==0.13.3
-pillow==10.2.0
+pillow==10.4.0
     # via favicons
     # via hyperglass
     # via reportlab
@@ -216,7 +218,6 @@ six==1.16.0
     # via textfsm
 sniffio==1.3.0
     # via anyio
-    # via httpcore
     # via httpx
 stackprinter==0.2.11
 stevedore==5.1.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -15,7 +15,7 @@ aiofiles==23.2.1
 annotated-types==0.6.0
     # via pydantic
 anyio==4.3.0
-    # via httpcore
+    # via httpx
     # via litestar
     # via watchfiles
 async-timeout==4.0.3
@@ -33,6 +33,7 @@ cffi==1.16.0
 chardet==5.2.0
     # via reportlab
 click==8.1.7
+    # via hyperglass
     # via litestar
     # via rich-click
     # via typer
@@ -55,14 +56,15 @@ freetype-py==2.4.0
     # via rlpycairo
 future==0.18.3
     # via textfsm
-h11==0.14.0
+h11==0.16.0
     # via httpcore
+    # via hyperglass
     # via uvicorn
-httpcore==0.17.3
+httpcore==1.0.9
     # via httpx
 httptools==0.6.1
     # via uvicorn
-httpx==0.24.0
+httpx==0.27.2
     # via hyperglass
     # via litestar
 idna==3.6
@@ -96,7 +98,7 @@ paramiko==3.4.0
     # via hyperglass
     # via netmiko
     # via scp
-pillow==10.2.0
+pillow==10.4.0
     # via favicons
     # via hyperglass
     # via reportlab
@@ -162,7 +164,6 @@ six==1.16.0
     # via textfsm
 sniffio==1.3.0
     # via anyio
-    # via httpcore
     # via httpx
 svglib==1.5.1
     # via favicons


### PR DESCRIPTION
## Summary

Adds an opt-in **share this result** feature plus supporting UX:

- **Share snapshots** — a Share button on each result mints an opaque `/result/<id>` URL (`secrets.token_urlsafe(8)`, 11 chars) backed by a dedicated `hyperglass.share.<id>` Redis namespace with its own TTL (default 7 days, `cache.share_timeout`). The snapshot is an exact copy of the original output and survives expiry of the underlying query cache.
- **`GET`/`POST /api/query/share/...`** endpoints with a `share_enabled` kill-switch (404 when disabled), 410 when the source cache entry has expired, and optional sliding TTL (`cache.share_sliding`).
- **Query `force` flag** — bypasses the cache and re-executes, overwriting the same entry. Excluded from the cache digest so a forced refresh stays addressable.
- **Refresh cooldown** — the Requery button is gated by `cache.refresh_min_interval` (default 120s) with a configurable countdown message.
- **Form pre-fill** — `/?location=&target=&type=` populates the looking-glass form, closing the loop from the share page's "Run a fresh query" link.
- **`params.public_url`** — optional public base URL for share links; otherwise derived from request `Host`/`X-Forwarded-Proto`.
- **`cache.timeout` default 120 → 600s** — end-user refresh behaviour preserved by the cooldown + force flag. Operators relying on 2-minute staleness should set `cache.timeout: 120` explicitly.

All new user-visible strings are configurable via `web.text.*`. The UI cache knobs are projected to the SPA through a new `UICache` model that keeps server-private fields (`share_sliding`, `public_url`) off the wire.

## Implementation notes

Built per the design spec and plan under `docs/superpowers/`. Each task went through spec-compliance and code-quality review. New test infrastructure: top-level `hyperglass/conftest.py` with shared state fixtures and a Litestar `TestClient` fixture for the API.

## Test Plan

- [x] Backend: `task test` — 87 passed (was 50 on main; +37 new)
- [x] Backend lint: `task lint` (ruff) clean; black/isort clean
- [x] Frontend: `pnpm vitest run` — 62 passed (was 39; +23 new)
- [x] Frontend: `tsc --noEmit` clean; `biome lint` clean
- [x] Manual E2E smoke (fake_output): query → share → `/result/<id>` render; force refresh; 410 on expired source; share survives query-cache expiry; `public_url` shaping; not-found paths