### PR TITLE
fix: hermetic external tests + _safe_format crash on brace-laden error bodies

### DIFF
--- a/hyperglass/exceptions/_common.py
+++ b/hyperglass/exceptions/_common.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 
 # Project
 from hyperglass.log import log
-from hyperglass.util import get_fmt_keys, repr_from_attrs
+from hyperglass.util import repr_from_attrs
 from hyperglass.constants import STATUS_CODE_MAP
 
 ErrorLevel = Literal["danger", "warning"]
@@ -56,16 +56,20 @@ class HyperglassError(Exception):
         return _json.dumps(self.__dict__())
 
     @staticmethod
-    def _safe_format(template: str, **kwargs: Dict[str, str]) -> str:
-        """Safely format a string template from keyword arguments."""
+    def _safe_format(template: str, **kwargs: Any) -> str:
+        """Substitute known ``{placeholders}`` in a template from kwargs.
 
-        keys = get_fmt_keys(template)
-        for key in keys:
-            if key not in kwargs:
-                kwargs.pop(key)
-            else:
-                kwargs[key] = str(kwargs[key])
-        return template.format(**kwargs)
+        Only ``{key}`` tokens whose key is present in ``kwargs`` are
+        replaced. Any other braces — unmatched placeholders, or literal
+        brace characters embedded in an upstream error body such as a dict
+        or JSON repr — are left untouched. This avoids feeding arbitrary
+        text to ``str.format`` (which would raise ``KeyError``/``ValueError``
+        on stray ``{...}`` tokens) so message formatting never crashes.
+        """
+        result = str(template)
+        for key, value in kwargs.items():
+            result = result.replace("{" + str(key) + "}", str(value))
+        return result
 
     def _parse_pydantic_errors(*errors: Dict[str, Any]) -> str:
         errs = ("\n",)

--- a/hyperglass/exceptions/tests/test_common.py
+++ b/hyperglass/exceptions/tests/test_common.py
@@ -1,0 +1,40 @@
+"""Tests for the HyperglassError message-formatting helper."""
+
+# Project
+from hyperglass.exceptions._common import HyperglassError
+
+
+def test_safe_format_substitutes_known_keys():
+    result = HyperglassError._safe_format("{device} is not allowed", device="rtr1")
+    assert result == "rtr1 is not allowed"
+
+
+def test_safe_format_casts_non_string_values():
+    result = HyperglassError._safe_format("count is {n}", n=5)
+    assert result == "count is 5"
+
+
+def test_safe_format_leaves_unknown_placeholders_intact():
+    # A placeholder with no matching kwarg must not raise; it is left verbatim.
+    result = HyperglassError._safe_format("{device} at {site}", device="rtr1")
+    assert result == "rtr1 at {site}"
+
+
+def test_safe_format_does_not_crash_on_brace_laden_message():
+    # Upstream error bodies often embed dict/JSON reprs whose braces look like
+    # format fields but are not. Formatting must pass them through unchanged
+    # rather than raising KeyError (regression: GitHub issue #7).
+    message = "SERVICE UNAVAILABLE: {'data': '<html>503</html>'}"
+    result = HyperglassError._safe_format(message)
+    assert result == message
+
+
+def test_safe_format_replaces_repeated_placeholder():
+    result = HyperglassError._safe_format("{device} talks to {device}", device="rtr1")
+    assert result == "rtr1 talks to rtr1"
+
+
+def test_safe_format_substitutes_around_literal_braces():
+    message = "{name} returned {'error': 'boom'}"
+    result = HyperglassError._safe_format(message, name="provider")
+    assert result == "provider returned {'error': 'boom'}"

--- a/hyperglass/external/tests/test_base.py
+++ b/hyperglass/external/tests/test_base.py
@@ -1,9 +1,16 @@
-"""Test external http client."""
+"""Test external http client.
+
+These tests are hermetic: the low-level reachability probe and the httpx
+request layer are stubbed so the suite never touches the network. A small
+fake reproduces the subset of httpbin.org echo behaviour the client relies on
+(`/get`, `/post`, and a `/delay/*` endpoint that simulates a timeout).
+"""
 
 # Standard Library
 import asyncio
 
 # Third Party
+import httpx
 import pytest
 
 # Project
@@ -15,9 +22,51 @@ from .._base import BaseExternal
 
 config = Http(provider="generic", host="https://httpbin.org")
 
+BASE_URL = "https://httpbin.org"
+
+
+def _fake_response(**request: object) -> httpx.Response:
+    """Mimic httpbin's echo endpoints from the kwargs BaseExternal sends.
+
+    `BaseExternal._build_request` passes `method`, `url` (the endpoint path),
+    and optionally `params`/`json`/`timeout` to `httpx.Client.request`.
+    """
+    # `_build_request` strips the leading slash; httpx rejoins against base_url.
+    path = str(request["url"]).lstrip("/")
+    full_url = f"{BASE_URL}/{path}"
+    params = request.get("params") or {}
+    json_body = request.get("json") or {}
+
+    if path.startswith("delay/"):
+        # Simulate the timeout httpbin would produce for a slow endpoint.
+        raise httpx.ConnectTimeout(
+            "simulated timeout", request=httpx.Request(request["method"], full_url)
+        )
+    if path == "get":
+        return httpx.Response(200, json={"url": full_url, "args": dict(params)})
+    if path == "post":
+        return httpx.Response(200, json={"json": json_body})
+    return httpx.Response(404, json={"error": f"no fake for {path}"})
+
+
+@pytest.fixture(autouse=True)
+def _stub_network(monkeypatch):
+    """Stub the socket reachability probe and the httpx request layer."""
+    # `_test`/`_atest` open a raw socket to host:443 — skip it.
+    monkeypatch.setattr(BaseExternal, "_test", lambda self: True)
+
+    def _sync_request(self, **kwargs):
+        return _fake_response(**kwargs)
+
+    async def _async_request(self, **kwargs):
+        return _fake_response(**kwargs)
+
+    monkeypatch.setattr(httpx.Client, "request", _sync_request)
+    monkeypatch.setattr(httpx.AsyncClient, "request", _async_request)
+
 
 def test_base_external_sync():
-    with BaseExternal(base_url="https://httpbin.org", config=config) as client:
+    with BaseExternal(base_url=BASE_URL, config=config) as client:
         res1 = client._get("/get")
         res2 = client._get("/get", params={"key": "value"})
         res3 = client._post("/post", data={"strkey": "value", "intkey": 1})
@@ -27,12 +76,12 @@ def test_base_external_sync():
     assert res3["json"].get("intkey") == 1
 
     with pytest.raises(ExternalError):
-        with BaseExternal(base_url="https://httpbin.org", config=config, timeout=2) as client:
+        with BaseExternal(base_url=BASE_URL, config=config, timeout=2) as client:
             client._get("/delay/4")
 
 
 async def _run_test_base_external_async():
-    async with BaseExternal(base_url="https://httpbin.org", config=config) as client:
+    async with BaseExternal(base_url=BASE_URL, config=config) as client:
         res1 = await client._aget("/get")
         res2 = await client._aget("/get", params={"key": "value"})
         res3 = await client._apost("/post", data={"strkey": "value", "intkey": 1})
@@ -42,8 +91,8 @@ async def _run_test_base_external_async():
     assert res3["json"].get("intkey") == 1
 
     with pytest.raises(ExternalError):
-        async with BaseExternal(base_url="https://httpbin.org", config=config, timeout=2) as client:
-            await client._get("/delay/4")
+        async with BaseExternal(base_url=BASE_URL, config=config, timeout=2) as client:
+            await client._aget("/delay/4")
 
 
 def test_base_external_async():


### PR DESCRIPTION
Closes #7.

## Problem

Two related, pre-existing issues (independent of the share-results PR #6) make the **Backend Tests** CI job flaky/red:

1. **`_safe_format` crashes on upstream error bodies.** `hyperglass/exceptions/_common.py::_safe_format` fed arbitrary text to `str.format`. An external HTTP error body containing brace tokens that aren't real format fields — e.g. a dict/JSON repr like `{'data': '<html>503</html>'}` — is parsed as a format field. The `if key not in kwargs: kwargs.pop(key)` branch then pops a key that was never present, raising `KeyError`; even past that, `str.format` would fail on the stray tokens. So the *error formatter itself* crashes while reporting an upstream error (Slack/Teams webhooks, HTTP-driver devices).

2. **`test_base.py` is network-coupled.** It exercised the live public `httpbin.org`, which rate-limits CI runner IPs (429/503). When that happens the non-2xx body trips bug #1, failing `test_base_external_sync`/`async` on every cell.

## Fix

- **`_safe_format`** now substitutes only the `{key}` tokens whose key is present in `kwargs` and leaves all other braces untouched — never running stray text through `str.format`. No hyperglass message template uses format specs/conversions (`{x:spec}`/`{x!r}`), so behaviour for real templates is preserved (verified by grep). Also corrects the long-wrong `**kwargs` value annotation.
- **`test_base.py`** is now hermetic: an autouse fixture stubs the raw-socket reachability probe and the httpx request layer with a small fake mimicking httpbin's `/get`, `/post`, and `/delay` (timeout) behaviour. The tests still exercise the real `BaseExternal` request plumbing (URL building, param/JSON handling, response parsing, `httpx.HTTPError` → `ExternalError` mapping) — just without the network.

## Test Plan

- [x] New `hyperglass/exceptions/tests/test_common.py` — 6 tests incl. the brace-laden-message regression
- [x] `test_base.py` rewritten hermetic — 2 tests, ~0.6s, zero network
- [x] `task test` (ignoring the external plugin dir): **56 passed**
- [x] `task lint` (ruff) clean; black/isort clean
- [x] Verified the fix reproduces the original `KeyError` before the change and passes after

Once merged, PR #6 (share-results) rebases onto this and its Backend Tests job goes green.