### PR TITLE
chore: rename to hyperglass-ng, version 2.1.0.dev0, Keep a Changelog 1.1.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Publish under the fork's own image name, independent of the GitHub repo
+  # name, so the maintained line is `ghcr.io/<owner>/hyperglass-ng`.
+  IMAGE_NAME: ${{ github.repository_owner }}/hyperglass-ng
 
 jobs:
   build-and-push-image:
@@ -29,14 +31,14 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # Mark every build as :latest (including pre-release semver
-          # tags like 2.0.4-jsenecal.1, which the default "latest=auto"
+          # tags like 2.1.0-rc.1, which the default "latest=auto"
           # would otherwise skip).
           flavor: |
             latest=true
           tags: |
             # Branch pushes -> :main (or whatever branch pushed)
             type=ref,event=branch
-            # Tag pushes -> :2.0.4-jsenecal.1 (strips leading "v")
+            # Tag pushes -> :2.1.0 (strips leading "v")
             type=semver,pattern={{version}}
             # Every build -> :sha-abc1234 (immutable, pin-friendly)
             type=sha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- [#304](https://github.com/thatmattlove/hyperglass/pull/304): Add FRR structured output for BGP Routes - @chriswiggins
+- Sharable result snapshots: clicking the new Share button on a result mints a `/result/<id>` URL (default 7-day TTL, operator-tunable via `cache.share_timeout`).
+- `params.public_url` (optional): when set, share URLs use this base; otherwise derived from request headers.
+
+### Changed
+
+- [#245](https://github.com/thatmattlove/hyperglass/issues/245): v2.0.0 Vyos version platforms - Moved to latest LTS command set. - @ServerForge
+- [#292](https://github.com/thatmattlove/hyperglass/pull/292): Updates Mikrotik BGP route command so supernets are selected as well as exact matches. - @GrandArcher
+- `cache.timeout` default raised from 120s → 600s. End-user refresh behavior is preserved by `cache.refresh_min_interval` (UI cooldown, default 120s) and the new query `force` flag. Operators relying on 2-minute cache staleness should set `cache.timeout: 120` explicitly.
 
 ### Fixed
 - [#280](https://github.com/thatmattlove/hyperglass/issues/280): Fix: `condition: None` caused error in directive @Jimmy01240397
@@ -21,18 +33,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Security
 - [#334](https://github.com/thatmattlove/hyperglass/issues/334): Address runtime-relevant CVEs surfaced by container scanners — bump Next.js to `13.5.11` (covers CVE-2025-29927 middleware bypass, CVE-2024-34351 SSRF, CVE-2024-46982 cache poisoning, CVE-2024-51479 auth bypass), bump Pillow to `>=10.4.0` (CVE-2024-28219), pin `h11>=0.16.0` (CVE-2025-43859 request smuggling), use the rolling `python:3.12-alpine` base with `apk upgrade` (CVE-2024-6119 / CVE-2024-12797 OpenSSL, CVE-2025-31115 xz), and bump `setuptools>=78.1.1` (CVE-2025-47273) inside the image.
-
-### Updated
-
-- [#245](https://github.com/thatmattlove/hyperglass/issues/245): v2.0.0 Vyos version platforms - Moved to latest LTS command set. - @ServerForge
-- [#292](https://github.com/thatmattlove/hyperglass/pull/292): Updates Mikrotik BGP route command so supernets are selected as well as exact matches. - @GrandArcher
-- `cache.timeout` default raised from 120s → 600s. End-user refresh behavior is preserved by `cache.refresh_min_interval` (UI cooldown, default 120s) and the new query `force` flag. Operators relying on 2-minute cache staleness should set `cache.timeout: 120` explicitly.
-
-### Added
-
-- [#304](https://github.com/thatmattlove/hyperglass/pull/304): Add FRR structured output for BGP Routes - @chriswiggins
-- Sharable result snapshots: clicking the new Share button on a result mints a `/result/<id>` URL (default 7-day TTL, operator-tunable via `cache.share_timeout`).
-- `params.public_url` (optional): when set, share URLs use this base; otherwise derived from request headers.
 
 ## 2.0.4 - 2024-06-30
 
@@ -611,3 +611,10 @@ $ hyperglass-agent send-certificate
 ### Changed
 
 - **BREAKING CHANGE**: The `logo` section now requires the full path for logo files. See [the docs](https://hyperglass.dev/docs/ui/logo) for details.
+
+<!--
+Version comparison links. Only the fork-era tags exist in this repository
+(v2.0.4-jsenecal.*); historical upstream versions below were never tagged
+here, so they are intentionally left unlinked.
+-->
+[Unreleased]: https://github.com/jsenecal/hyperglass/compare/v2.0.4-jsenecal.2...HEAD

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN npm install -g pnpm
 RUN pnpm install -P
 
 FROM ui as hyperglass
+LABEL org.opencontainers.image.title="hyperglass-ng" \
+      org.opencontainers.image.description="hyperglass-ng — maintained fork of the hyperglass network looking glass" \
+      org.opencontainers.image.source="https://github.com/jsenecal/hyperglass" \
+      org.opencontainers.image.licenses="BSD-3-Clause-Clear"
 WORKDIR /opt/hyperglass
 RUN pip3 install -e .
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,7 @@ services:
     redis:
         image: "redis:alpine"
     hyperglass:
+        image: "ghcr.io/jsenecal/hyperglass-ng:latest"
         depends_on:
             - redis
         environment:

--- a/hyperglass/constants.py
+++ b/hyperglass/constants.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 
 __name__ = "hyperglass"
-__version__ = "2.0.4+jsenecal.2"
+__version__ = "2.1.0.dev0"
 __author__ = "Matt Love"
 __copyright__ = f"Copyright {datetime.now().year} Matthew Love"
 __license__ = "BSD 3-Clause Clear License"

--- a/hyperglass/ui/package.json
+++ b/hyperglass/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.4-jsenecal.2",
+  "version": "2.1.0-dev.0",
   "name": "ui",
   "description": "UI for hyperglass, the modern network looking glass",
   "author": "Matt Love",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "hyperglass"
-version = "2.0.4+jsenecal.2"
+name = "hyperglass-ng"
+version = "2.1.0.dev0"
 description = "hyperglass is the modern network looking glass that tries to make the internet better."
 authors = [
     { name = "thatmattlove", email = "matt@hyperglass.dev" },
@@ -35,6 +35,11 @@ dependencies = [
 ]
 readme = "README.md"
 requires-python = ">= 3.11"
+
+[project.urls]
+Homepage = "https://github.com/jsenecal/hyperglass"
+Repository = "https://github.com/jsenecal/hyperglass"
+"Upstream (unmaintained)" = "https://github.com/thatmattlove/hyperglass"
 
 [project.scripts]
 hyperglass = "hyperglass.console:run"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -11,7 +11,7 @@
 
 -e file:.
 aiofiles==23.2.1
-    # via hyperglass
+    # via hyperglass-ng
 annotated-types==0.6.0
     # via pydantic
 anyio==4.3.0
@@ -38,7 +38,7 @@ chardet==5.2.0
     # via reportlab
 click==8.1.7
     # via black
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
     # via rich-click
     # via typer
@@ -52,7 +52,7 @@ cssselect2==0.7.0
 distlib==0.3.8
     # via virtualenv
 distro==1.8.0
-    # via hyperglass
+    # via hyperglass-ng
 editorconfig==0.12.4
     # via jsbeautifier
 faker==24.4.0
@@ -60,7 +60,7 @@ faker==24.4.0
 fast-query-parsers==1.0.3
     # via litestar
 favicons==0.2.2
-    # via hyperglass
+    # via hyperglass-ng
 filelock==3.13.1
     # via virtualenv
 flake8==7.0.0
@@ -71,14 +71,14 @@ future==0.18.3
     # via textfsm
 h11==0.16.0
     # via httpcore
-    # via hyperglass
+    # via hyperglass-ng
     # via uvicorn
 httpcore==1.0.9
     # via httpx
 httptools==0.6.1
     # via uvicorn
 httpx==0.27.2
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
 identify==2.5.35
     # via pre-commit
@@ -93,9 +93,9 @@ jinja2==3.1.3
 jsbeautifier==1.15.1
     # via litestar
 litestar==2.7.1
-    # via hyperglass
+    # via hyperglass-ng
 loguru==0.7.2
-    # via hyperglass
+    # via hyperglass-ng
 lxml==5.1.0
     # via svglib
 markdown-it-py==3.0.0
@@ -113,7 +113,7 @@ multidict==6.0.5
 mypy-extensions==1.0.0
     # via black
 netmiko==4.1.2
-    # via hyperglass
+    # via hyperglass-ng
 nodeenv==1.8.0
     # via pre-commit
 ntc-templates==4.3.0
@@ -122,7 +122,7 @@ packaging==23.2
     # via black
     # via pytest
 paramiko==3.4.0
-    # via hyperglass
+    # via hyperglass-ng
     # via netmiko
     # via scp
 pathspec==0.12.1
@@ -132,7 +132,7 @@ pbr==6.0.0
 pep8-naming==0.13.3
 pillow==10.4.0
     # via favicons
-    # via hyperglass
+    # via hyperglass-ng
     # via reportlab
 platformdirs==4.2.0
     # via black
@@ -143,10 +143,10 @@ polyfactory==2.15.0
     # via litestar
 pre-commit==3.6.2
 psutil==5.9.4
-    # via hyperglass
+    # via hyperglass-ng
     # via taskipy
 py-cpuinfo==9.0.0
-    # via hyperglass
+    # via hyperglass-ng
 pycairo==1.26.0
     # via rlpycairo
 pycodestyle==2.11.1
@@ -154,21 +154,21 @@ pycodestyle==2.11.1
 pycparser==2.21
     # via cffi
 pydantic==2.6.3
-    # via hyperglass
+    # via hyperglass-ng
     # via pydantic-extra-types
     # via pydantic-settings
 pydantic-core==2.16.3
     # via pydantic
 pydantic-extra-types==2.6.0
-    # via hyperglass
+    # via hyperglass-ng
 pydantic-settings==2.2.1
-    # via hyperglass
+    # via hyperglass-ng
 pyflakes==3.2.0
     # via flake8
 pygments==2.17.2
     # via rich
 pyjwt==2.6.0
-    # via hyperglass
+    # via hyperglass-ng
 pynacl==1.5.0
     # via paramiko
 pyserial==3.5
@@ -185,20 +185,20 @@ python-dotenv==1.0.1
     # via uvicorn
 pyyaml==6.0.1
     # via bandit
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
     # via netmiko
     # via pre-commit
     # via uvicorn
 redis==4.5.4
-    # via hyperglass
+    # via hyperglass-ng
 reportlab==4.1.0
     # via favicons
     # via svglib
 rich==13.7.0
     # via bandit
     # via favicons
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
     # via rich-click
 rich-click==1.7.4
@@ -234,12 +234,12 @@ tinycss2==1.2.1
     # via cssselect2
     # via svglib
 toml==0.10.2
-    # via hyperglass
+    # via hyperglass-ng
 tomli==2.0.1
     # via taskipy
 typer==0.9.0
     # via favicons
-    # via hyperglass
+    # via hyperglass-ng
 typing-extensions==4.9.0
     # via litestar
     # via polyfactory
@@ -248,10 +248,10 @@ typing-extensions==4.9.0
     # via rich-click
     # via typer
 uvicorn==0.21.1
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
 uvloop==0.18.0
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
     # via uvicorn
 virtualenv==20.25.0
@@ -264,4 +264,4 @@ webencodings==0.5.1
 websockets==12.0
     # via uvicorn
 xmltodict==0.13.0
-    # via hyperglass
+    # via hyperglass-ng

--- a/requirements.lock
+++ b/requirements.lock
@@ -11,7 +11,7 @@
 
 -e file:.
 aiofiles==23.2.1
-    # via hyperglass
+    # via hyperglass-ng
 annotated-types==0.6.0
     # via pydantic
 anyio==4.3.0
@@ -33,7 +33,7 @@ cffi==1.16.0
 chardet==5.2.0
     # via reportlab
 click==8.1.7
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
     # via rich-click
     # via typer
@@ -43,7 +43,7 @@ cryptography==42.0.3
 cssselect2==0.7.0
     # via svglib
 distro==1.8.0
-    # via hyperglass
+    # via hyperglass-ng
 editorconfig==0.12.4
     # via jsbeautifier
 faker==24.4.0
@@ -51,21 +51,21 @@ faker==24.4.0
 fast-query-parsers==1.0.3
     # via litestar
 favicons==0.2.2
-    # via hyperglass
+    # via hyperglass-ng
 freetype-py==2.4.0
     # via rlpycairo
 future==0.18.3
     # via textfsm
 h11==0.16.0
     # via httpcore
-    # via hyperglass
+    # via hyperglass-ng
     # via uvicorn
 httpcore==1.0.9
     # via httpx
 httptools==0.6.1
     # via uvicorn
 httpx==0.27.2
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
 idna==3.6
     # via anyio
@@ -75,9 +75,9 @@ jinja2==3.1.3
 jsbeautifier==1.15.1
     # via litestar
 litestar==2.7.1
-    # via hyperglass
+    # via hyperglass-ng
 loguru==0.7.2
-    # via hyperglass
+    # via hyperglass-ng
 lxml==5.1.0
     # via svglib
 markdown-it-py==3.0.0
@@ -91,41 +91,41 @@ msgspec==0.18.6
 multidict==6.0.5
     # via litestar
 netmiko==4.1.2
-    # via hyperglass
+    # via hyperglass-ng
 ntc-templates==4.3.0
     # via netmiko
 paramiko==3.4.0
-    # via hyperglass
+    # via hyperglass-ng
     # via netmiko
     # via scp
 pillow==10.4.0
     # via favicons
-    # via hyperglass
+    # via hyperglass-ng
     # via reportlab
 polyfactory==2.15.0
     # via litestar
 psutil==5.9.4
-    # via hyperglass
+    # via hyperglass-ng
 py-cpuinfo==9.0.0
-    # via hyperglass
+    # via hyperglass-ng
 pycairo==1.26.0
     # via rlpycairo
 pycparser==2.21
     # via cffi
 pydantic==2.6.3
-    # via hyperglass
+    # via hyperglass-ng
     # via pydantic-extra-types
     # via pydantic-settings
 pydantic-core==2.16.3
     # via pydantic
 pydantic-extra-types==2.6.0
-    # via hyperglass
+    # via hyperglass-ng
 pydantic-settings==2.2.1
-    # via hyperglass
+    # via hyperglass-ng
 pygments==2.17.2
     # via rich
 pyjwt==2.6.0
-    # via hyperglass
+    # via hyperglass-ng
 pynacl==1.5.0
     # via paramiko
 pyserial==3.5
@@ -136,18 +136,18 @@ python-dotenv==1.0.1
     # via pydantic-settings
     # via uvicorn
 pyyaml==6.0.1
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
     # via netmiko
     # via uvicorn
 redis==4.5.4
-    # via hyperglass
+    # via hyperglass-ng
 reportlab==4.1.0
     # via favicons
     # via svglib
 rich==13.7.0
     # via favicons
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
     # via rich-click
 rich-click==1.7.4
@@ -176,10 +176,10 @@ tinycss2==1.2.1
     # via cssselect2
     # via svglib
 toml==0.10.2
-    # via hyperglass
+    # via hyperglass-ng
 typer==0.9.0
     # via favicons
-    # via hyperglass
+    # via hyperglass-ng
 typing-extensions==4.9.0
     # via litestar
     # via polyfactory
@@ -188,10 +188,10 @@ typing-extensions==4.9.0
     # via rich-click
     # via typer
 uvicorn==0.21.1
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
 uvloop==0.18.0
-    # via hyperglass
+    # via hyperglass-ng
     # via litestar
     # via uvicorn
 watchfiles==0.21.0
@@ -202,4 +202,4 @@ webencodings==0.5.1
 websockets==12.0
     # via uvicorn
 xmltodict==0.13.0
-    # via hyperglass
+    # via hyperglass-ng


### PR DESCRIPTION
Establishes the fork's own versioning and identity now that it has diverged from the unmaintained upstream and is adding features.

## Why

The package was at `2.0.4+jsenecal.2` — upstream's `2.0.4` with SemVer **build metadata** appended. Per SemVer, everything after `+` is ignored for precedence: `2.0.4`, `2.0.4+jsenecal.2`, and plain `2.0.4` all sort **equal**, so the scheme can't express new functionality or be pinned/upgraded by any resolver. Fine for "a couple of patches on 2.0.4"; broken once we ship features.

## Changes

**Version → `2.1.0.dev0`** (PEP 440 dev marker; UI uses `2.1.0-dev.0` npm-side). Dropped `+jsenecal.N`. The dev marker keeps everything accumulating under `## [Unreleased]`; it flips to `2.1.0` when a release is cut. Applied across `pyproject.toml`, `hyperglass/constants.py`, `hyperglass/ui/package.json`.

**Distribution renamed `hyperglass` → `hyperglass-ng`.** PyPI's `hyperglass` is held by upstream (stuck at 1.0.4), so the fork can't publish under it. The **import package, module, `hyperglass` CLI command, and `HYPERGLASS_` env prefix all stay `hyperglass`** — this is distribution metadata only, zero runtime/config impact. `project.urls` now point at the fork. (Note: the app isn't really pip-installable anyway — the UI is built from Node at startup — so this is mostly about a clean, collision-free identity for Docker/metadata.)

**Docker identity → `ghcr.io/<owner>/hyperglass-ng`.** `docker.yml` `IMAGE_NAME` overridden so it's independent of the GitHub repo name; added OCI labels to the final image stage and an explicit `image:` in `compose.yaml`.

**Lockfiles:** only the `# via hyperglass` → `# via hyperglass-ng` provenance comments changed (no dependency drift) — a direct consequence of the rename.

**CHANGELOG → Keep a Changelog 1.1.0:** bumped the format link, reordered the Unreleased subsections to canonical order (Added, Changed, Deprecated, Removed, Fixed, Security), renamed the non-standard `Updated` group to `Changed`, and added an `[Unreleased]` comparison link anchored on the last real tag (`v2.0.4-jsenecal.2`). Historical upstream versions are **intentionally left unlinked** — they were never tagged in this fork, so bracketed links would be dead.

## Test Plan

- [x] `pyproject.toml` / `package.json` / `constants.py` parse; versions valid PEP 440 / npm semver
- [x] `rye sync` → installs as `hyperglass-ng` 2.1.0.dev0; `import hyperglass` OK; `__version__ == "2.1.0.dev0"`
- [x] `task test` (ignoring external plugin dir): **93 passed, 1 skipped**
- [x] `task lint` (ruff) clean
- [x] Changelog Unreleased order verified canonical

Docker publish workflow only runs on tag pushes, so it isn't exercised by this PR's checks; the image-name change takes effect on the next tagged release.