### PR TITLE
ci(renovate): automerge patch & minor updates on green CI

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge patch and minor updates once CI passes. Majors are not matched here, so they still open PRs for manual review.",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Reconfigures Renovate so patch and minor dependency updates **automerge once CI passes**, instead of every update waiting on a manual merge.

## Why

The bare `config:recommended` gates everything behind a human merge. The Dependency Dashboard currently has **~95 updates queued** (throttled by the default 2/hour, 10-concurrent limits). Hand-merging that volume isn't sustainable; automerging the low-risk tiers drains it automatically while keeping a human in the loop for the risky ones.

## Change

```json
"packageRules": [
  { "matchUpdateTypes": ["minor", "patch"], "automerge": true }
]
```

- **patch + minor → automerge** after Renovate confirms the branch's status checks are green (it doesn't merge on red CI).
- **major → unchanged** — not matched by the rule, so majors keep opening PRs for review (which is exactly where they belong).

## Notes / follow-ups

- For the smoothest behavior, enable **Settings → "Allow auto-merge"** on the repo so Renovate uses GitHub-native auto-merge; without it Renovate falls back to merging via API once checks pass (still works).
- Optional hardening I can add if you want: `minimumReleaseAge: "3 days"` (avoid auto-merging a release that later gets yanked), and/or `matchCurrentVersion: "!/^0/"` to exclude `0.x` packages from minor automerge (0.x minors can be breaking per SemVer). Left out for now to match the literal ask.