### PR TITLE
ci(renovate): 3-day minimum release age + exclude 0.x minors from automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "description": "Automerge patch and minor updates once CI passes. Majors are not matched here, so they still open PRs for manual review.",
@@ -11,6 +12,14 @@
         "patch"
       ],
       "automerge": true
+    },
+    {
+      "description": "0.x minor bumps can be breaking under SemVer, so require manual review instead of automerging them. 0.x patch updates still automerge.",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "matchCurrentVersion": "/^0\\./",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Safety hardening on top of the patch/minor automerge enabled in #16.

## Changes

- **`minimumReleaseAge: "3 days"`** — Renovate holds any update until the release is at least 3 days old, so a freshly published version that gets yanked or has an immediate regression doesn't auto-merge before the ecosystem notices.
- **Exclude `0.x` minors from automerge** — a second, more-specific `packageRule` sets `automerge: false` for `minor` updates whose current version matches `/^0\./`. Under SemVer, 0.x minor bumps may be breaking, so these now open PRs for manual review. **0.x patch updates still automerge**, and `>=1.0` minor/patch automerge as before.

Rule precedence: Renovate applies `packageRules` in order, last match wins — so the 0.x rule overrides the broad minor/patch automerge only for 0.x minors.

This repo has several 0.x deps (httpx, uvloop, typer, favicons, loguru, jsdom, …), so the exclusion is meaningful here.