### PR TITLE
feat: per-browser query history on the landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ hyperglass/hyperglass/static
 TODO*
 .env
 .worktrees/
+.superpowers/
 
 test.py
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - [#304](https://github.com/thatmattlove/hyperglass/pull/304): Add FRR structured output for BGP Routes - @chriswiggins
 - Sharable result snapshots: clicking the new Share button on a result mints a `/result/<id>` URL (default 7-day TTL, operator-tunable via `cache.share_timeout`).
 - `params.public_url` (optional): when set, share URLs use this base; otherwise derived from request headers.
+- Per-browser query history on the landing page (Open / Share / Re-run / Re-run with new target / Delete), with an operator kill-switch (`cache.history_enabled`), retention limit (`cache.history_limit`), and per-directive opt-out (`directives.<id>.history`).
 
 ### Changed
 

--- a/docs/pages/configuration/config/caching.mdx
+++ b/docs/pages/configuration/config/caching.mdx
@@ -12,9 +12,15 @@ hyperglass automatically caches responses to reduce the number of times devices 
 | `cache.share_timeout`        | Number  | 604800        | Seconds to retain a shared snapshot (default 7 days).                                               |
 | `cache.share_sliding`        | Boolean | False         | If true, viewing a share extends its TTL by another `share_timeout`.                                |
 | `cache.refresh_min_interval` | Number  | 120           | Minimum seconds between manual refreshes from the UI.                                               |
+| `cache.history_enabled`      | Boolean | True          | Enable the per-browser query history panel on the landing page. Disabling requires a UI rebuild.    |
+| `cache.history_limit`        | Number  | 10            | Maximum number of recent queries retained per browser. Disabling requires a UI rebuild.             |
 
 <Callout type="warning">
     Disabling `share_enabled` (or changing any cache UI knob) requires a UI rebuild — the values are baked into the static `hyperglass.json` at build time.
+</Callout>
+
+<Callout type="warning" title="Privacy">
+    Query history stores query targets (e.g. IP addresses, BGP communities) in the **user's browser localStorage** — it is never sent to the server and is not shared across devices or browsers. On shared, public, or kiosk terminals, consider setting `history_enabled: false` or lowering `history_limit` to minimise exposure of previous users' queries. Only successful query results are recorded.
 </Callout>
 
 ### Example with Defaults
@@ -27,4 +33,6 @@ cache:
     share_timeout: 604800
     share_sliding: false
     refresh_min_interval: 120
+    history_enabled: true
+    history_limit: 10
 ```

--- a/docs/pages/configuration/directives.mdx
+++ b/docs/pages/configuration/directives.mdx
@@ -26,6 +26,7 @@ Each directive has the following options:
 | `groups`             | List of Strings |               | List of names by which directives are grouped in the UI.                                                                                                                   |
 | `multiple`           | Boolean         | `false`       | Command supports receiving multiple values. For example, Cisco IOS's `show ip bgp community` accepts multiple communities as arguments.                                    |
 | `multiple_separator` | String          | `" "`         | String by which multiple values are separated. For example, a list of values `[65001, 65002, 65003]` would be rendered as `65001 65002 65003` for when the command is run. |
+| `history`            | Boolean         | `true`        | Whether queries of this directive type are saved to the browser's query history. Set to `false` to keep sensitive query types (e.g. internal diagnostic commands) out of history. When `cache.history_enabled` is `true` and this field is `false`, the UI shows a "not saved to history" hint. |
 
 ## Rules
 

--- a/docs/superpowers/plans/2026-06-04-query-history.md
+++ b/docs/superpowers/plans/2026-06-04-query-history.md
@@ -11,14 +11,12 @@
 **Reference spec:** `docs/superpowers/specs/2026-06-03-query-history-design.md`
 
 **Key environment facts:**
-- Zustand is **v3** (`^3.7.2`). The `persist` middleware uses `getStorage: () => StateStorage` (NOT v4's `createJSONStorage`). Mirror the existing store in `hyperglass/ui/hooks/use-greeting.ts`.
-
-> ⚠️ **Version assumption — READ FIRST.** This plan was authored against **zustand v3**. A separate PR/session may upgrade zustand to **v4/v5 first** (decided 2026-06-04). **Before implementing, check `hyperglass/ui/package.json`.** If zustand is now v4+, apply these deltas to the affected tasks:
-> - **Imports (Tasks 9):** `import create from 'zustand'` → `import { create } from 'zustand'`. (Match whatever style the upgraded `use-greeting.ts` / `use-form-state.ts` now use.)
-> - **Persist storage (Task 9):** replace `getStorage: () => historyStorage` with `storage: createJSONStorage(() => historyStorage)` — but note v4's `createJSONStorage` expects a `StateStorage` returning **strings**, which `historyStorage` already does; confirm the wrapper still receives the serialized blob so `shrinkSerialized` (Task 8) keeps working unchanged.
-> - **Hydration (Task 19):** the mounted-flag guard still works and remains the recommended approach; optionally simplify using v4's `useQueryHistory.persist.hasHydrated()` if the upgraded codebase adopts that pattern elsewhere.
-> - **`withDev` (Task 9 dependency):** if the upgrade rewrote `util/state.ts` for v4 middleware typing, ensure `withDev<QueryHistoryState>(...)` still composes inside `persist(...)`; mirror the post-upgrade `use-greeting.ts` composition order exactly.
-> Everything else in this plan (backend config, components, recording, prefillForm, SnapshotResults) is version-independent.
+- Zustand is **v5** (`^5.0.8`, migrated in PR #116; this branch is rebased on top of it). The established patterns on main:
+  - `import { create } from 'zustand'` and the **curried** call `create<T>()(...)` (note the extra `()`).
+  - `withDev` (`util/state.ts`) is typed `StateCreator<T, [], []>`; usage `withDev<T>(creator, 'name')` is unchanged.
+  - Custom persist storage: `storage: createJSONStorage(() => historyStorage)` (import `createJSONStorage` from `zustand/middleware`).
+  - **Object-returning selectors must be wrapped in `useShallow`** from `zustand/react/shallow` (the v3 `(selector, isEqual)` second-arg form is gone). The new code in this plan uses only single-value selectors, so `useShallow` is not required — but if you combine fields into one selector, wrap it. See `hooks/use-form-state.ts` / `components/looking-glass-form.tsx` for the in-repo pattern.
+  - Mirror the existing v5 store in `hyperglass/ui/hooks/use-greeting.ts`; the persist-rehydrate test pattern is in `hooks/use-greeting-rehydrate.test.tsx`.
 - `Directive.frontend()` (`hyperglass/models/directive.py:334`) **whitelists** UI-visible fields — a new directive field must be added there explicitly.
 - `Params.frontend()` (`hyperglass/models/config/params.py:158`) includes `web` and `messages` wholesale (`"web": ...`, `"messages": ...`), so new `Text`/`Messages` fields reach the UI automatically; only the `cache` include set must be edited.
 - Backend attrs are snake_case; `HyperglassModel` camelCases JSON keys. UI config types are written snake_case and run through `CamelCasedProperties`.
@@ -796,8 +794,8 @@ Expected: FAIL — cannot find module.
 Create `hyperglass/ui/hooks/use-query-history.ts`:
 
 ```ts
-import create from 'zustand';
-import { persist } from 'zustand/middleware';
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import { historyStorage } from '~/util/history-storage';
 import { withDev } from '~/util';
 
@@ -843,7 +841,7 @@ interface QueryHistoryState {
 
 const uniq = (values: string[]): string[] => Array.from(new Set(values));
 
-export const useQueryHistory = create<QueryHistoryState>(
+export const useQueryHistory = create<QueryHistoryState>()(
   persist(
     withDev<QueryHistoryState>(
       (set, get) => ({
@@ -904,8 +902,8 @@ export const useQueryHistory = create<QueryHistoryState>(
     {
       name: 'hyperglass.queryHistory',
       version: 1,
-      getStorage: () => historyStorage,
-      partialize: (state: QueryHistoryState) => ({ entries: state.entries }) as QueryHistoryState,
+      storage: createJSONStorage(() => historyStorage),
+      partialize: state => ({ entries: state.entries }),
     },
   ),
 );

--- a/docs/superpowers/plans/2026-06-04-query-history.md
+++ b/docs/superpowers/plans/2026-06-04-query-history.md
@@ -1,0 +1,2375 @@
+# Query History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-browser query history to the hyperglass landing page — a list of recent successful queries the user can Open (locally-cached output), Share (single-device), Re-run, Re-run with a new target, or Delete.
+
+**Architecture:** History is a frontend feature persisted in `localStorage` via a Zustand `persist` store. Recording happens per-device inside the existing `Result` component (effect keyed on `dataUpdatedAt`). Opening an entry reuses the share-results read-only `Result` snapshot rendering through a newly-extracted `SnapshotResults` component. The only backend changes are config fields: two on `Cache`, one on `Directive`, and new UI strings on `Text`/`Messages`, all projected to the build-time `hyperglass.json`.
+
+**Tech Stack:** Python 3.11 + Pydantic (backend config models); Next.js 13 / React / Chakra UI / Zustand **v3** / React Query v4 / dayjs (frontend); pytest (backend tests); Vitest + jsdom (frontend tests).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-03-query-history-design.md`
+
+**Key environment facts:**
+- Zustand is **v3** (`^3.7.2`). The `persist` middleware uses `getStorage: () => StateStorage` (NOT v4's `createJSONStorage`). Mirror the existing store in `hyperglass/ui/hooks/use-greeting.ts`.
+- `Directive.frontend()` (`hyperglass/models/directive.py:334`) **whitelists** UI-visible fields — a new directive field must be added there explicitly.
+- `Params.frontend()` (`hyperglass/models/config/params.py:158`) includes `web` and `messages` wholesale (`"web": ...`, `"messages": ...`), so new `Text`/`Messages` fields reach the UI automatically; only the `cache` include set must be edited.
+- Backend attrs are snake_case; `HyperglassModel` camelCases JSON keys. UI config types are written snake_case and run through `CamelCasedProperties`.
+- Run a single backend test: `pytest hyperglass/path/test_x.py::test_name -v`
+- Run a single UI test: `pnpm --dir ./hyperglass/ui test path/to/file.test.tsx`
+- `task lint` (Ruff) and `task ui-lint` (Biome) must be clean; `task ui-typecheck` (tsc) must pass.
+
+---
+
+## File Structure
+
+**Backend (modify):**
+- `hyperglass/models/config/cache.py` — add `history_enabled`, `history_limit`.
+- `hyperglass/models/config/params.py` — add both to the `frontend()` cache include set.
+- `hyperglass/models/directive.py` — add `history: bool = True`; project it in `frontend()`.
+- `hyperglass/models/config/web.py` — add history `Text` strings.
+- `hyperglass/models/config/messages.py` — add `history_device_unavailable`.
+
+**Backend (tests):**
+- `hyperglass/models/config/tests/test_cache.py` (extend)
+- `hyperglass/models/config/tests/test_params_frontend.py` (extend)
+- `hyperglass/models/tests/test_web.py` (extend)
+- `hyperglass/models/tests/test_directive_history.py` (create)
+
+**Frontend (create):**
+- `hyperglass/ui/util/history-id.ts` — `makeSubmissionId()`.
+- `hyperglass/ui/util/history-storage.ts` — quota-aware `StateStorage`.
+- `hyperglass/ui/hooks/use-query-history.ts` — the persist store.
+- `hyperglass/ui/hooks/use-record-history.ts` — config-gated recording wrapper.
+- `hyperglass/ui/components/results/snapshot-results.tsx` — shared snapshot accordion.
+- `hyperglass/ui/components/history/recent-queries.tsx`
+- `hyperglass/ui/components/history/history-entry-row.tsx`
+- `hyperglass/ui/components/history/history-disabled-hint.tsx`
+- `hyperglass/ui/components/history/index.ts`
+
+**Frontend (modify):**
+- `hyperglass/ui/types/config.ts` — `_Cache`, `_DirectiveBase`, `_Text`, `_Messages`.
+- `hyperglass/ui/types/globals.d.ts` — `ResultSnapshot`, `ShareResponse extends ResultSnapshot`, `force?` already present.
+- `hyperglass/ui/hooks/use-form-state.ts` — add `submissionId`, `prefillForm`, extend `reset`.
+- `hyperglass/ui/components/results/individual.tsx` — `showShare` prop, snapshot type, recording effect, header hint.
+- `hyperglass/ui/pages/result/[id].tsx` — use `SnapshotResults`.
+- `hyperglass/ui/pages/index.tsx` — history-open view branch.
+- `hyperglass/ui/components/looking-glass-form.tsx` — set `submissionId` on submit; render hint.
+- `hyperglass/ui/hooks/index.ts`, `hyperglass/ui/components/index.ts`, `hyperglass/ui/util/index.ts` — re-exports.
+
+**Docs:**
+- `docs/...` operator docs + CHANGELOG (Task 24).
+
+---
+
+## Phase 1 — Backend config
+
+### Task 1: Add `history_enabled` / `history_limit` to the Cache model
+
+**Files:**
+- Modify: `hyperglass/models/config/cache.py`
+- Test: `hyperglass/models/config/tests/test_cache.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `hyperglass/models/config/tests/test_cache.py`:
+
+```python
+def test_cache_history_defaults():
+    from hyperglass.models.config.cache import Cache
+
+    cache = Cache()
+    assert cache.history_enabled is True
+    assert cache.history_limit == 10
+
+
+def test_cache_history_overrides():
+    from hyperglass.models.config.cache import Cache
+
+    cache = Cache(history_enabled=False, history_limit=25)
+    assert cache.history_enabled is False
+    assert cache.history_limit == 25
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest hyperglass/models/config/tests/test_cache.py::test_cache_history_defaults -v`
+Expected: FAIL — `Cache` has no attribute `history_enabled`.
+
+- [ ] **Step 3: Add the fields**
+
+In `hyperglass/models/config/cache.py`, append to the `Cache` class body (after `refresh_min_interval`):
+
+```python
+    history_enabled: bool = True
+    history_limit: int = 10
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest hyperglass/models/config/tests/test_cache.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/models/config/cache.py hyperglass/models/config/tests/test_cache.py
+git commit -m "feat(config): add cache.history_enabled and history_limit"
+```
+
+---
+
+### Task 2: Project the cache history fields to the frontend
+
+**Files:**
+- Modify: `hyperglass/models/config/params.py:163-169` (the `cache` include set in `frontend()`)
+- Test: `hyperglass/models/config/tests/test_params_frontend.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `hyperglass/models/config/tests/test_params_frontend.py`:
+
+```python
+def test_frontend_includes_cache_history_fields():
+    from hyperglass.models.config.params import Params
+
+    fe = Params().frontend()
+    assert fe["cache"]["history_enabled"] is True
+    assert fe["cache"]["history_limit"] == 10
+```
+
+(If the existing tests in this file construct `Params` differently — e.g. with required fixtures — mirror that construction.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest hyperglass/models/config/tests/test_params_frontend.py::test_frontend_includes_cache_history_fields -v`
+Expected: FAIL — `KeyError: 'history_enabled'`.
+
+- [ ] **Step 3: Extend the include set**
+
+In `hyperglass/models/config/params.py`, change the `cache` include set inside `frontend()` to:
+
+```python
+                "cache": {
+                    "show_text",
+                    "timeout",
+                    "share_enabled",
+                    "share_timeout",
+                    "refresh_min_interval",
+                    "history_enabled",
+                    "history_limit",
+                },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest hyperglass/models/config/tests/test_params_frontend.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/models/config/params.py hyperglass/models/config/tests/test_params_frontend.py
+git commit -m "feat(config): project cache history fields to hyperglass.json"
+```
+
+---
+
+### Task 3: Add `history` to the Directive model and project it
+
+**Files:**
+- Modify: `hyperglass/models/directive.py` (class body near line 272; `frontend()` near line 337)
+- Test: `hyperglass/models/tests/test_directive_history.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/models/tests/test_directive_history.py`:
+
+```python
+"""Tests for the per-directive history opt-out field."""
+
+from hyperglass.models.directive import Directive
+
+
+def _directive(**kwargs):
+    base = {"id": "test", "name": "Test", "rules": [], "field": None}
+    base.update(kwargs)
+    return Directive(**base)
+
+
+def test_directive_history_defaults_true():
+    assert _directive().history is True
+
+
+def test_directive_history_can_be_disabled():
+    assert _directive(history=False).history is False
+
+
+def test_directive_frontend_includes_history():
+    fe = _directive(history=False).frontend()
+    assert fe["history"] is False
+
+    fe_default = _directive().frontend()
+    assert fe_default["history"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest hyperglass/models/tests/test_directive_history.py -v`
+Expected: FAIL — `Directive` has no attribute `history`.
+
+- [ ] **Step 3: Add the field and project it**
+
+In `hyperglass/models/directive.py`, add to the `Directive` class body (alongside `multiple`, near line 272):
+
+```python
+    history: bool = True
+```
+
+Then in `Directive.frontend()`, add `"history"` to the returned `value` dict:
+
+```python
+        value = {
+            "id": self.id,
+            "name": self.name,
+            "field_type": self.field_type,
+            "groups": self.groups,
+            "description": self.field.description if self.field is not None else '',
+            "info": None,
+            "history": self.history,
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest hyperglass/models/tests/test_directive_history.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/models/directive.py hyperglass/models/tests/test_directive_history.py
+git commit -m "feat(config): add per-directive history opt-out"
+```
+
+---
+
+### Task 4: Add history UI strings to Text and Messages
+
+**Files:**
+- Modify: `hyperglass/models/config/web.py` (the `Text` class, after `requery_tooltip` ~line 136)
+- Modify: `hyperglass/models/config/messages.py` (the `Messages` class)
+- Test: `hyperglass/models/tests/test_web.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `hyperglass/models/tests/test_web.py`:
+
+```python
+def test_text_history_string_defaults():
+    from hyperglass.models.config.web import Text
+
+    text = Text()
+    assert text.history_title == "Recent queries"
+    assert text.history_clear_all == "Clear all"
+    assert text.history_disabled_hint == "Results for this query type are not saved to history."
+    assert text.history_open == "Open"
+    assert text.history_delete == "Delete"
+```
+
+And add to `hyperglass/models/tests/test_web.py` (or wherever `Messages` is tested; create a small test if none exists):
+
+```python
+def test_messages_history_device_unavailable_default():
+    from hyperglass.models.config.messages import Messages
+
+    msgs = Messages()
+    assert msgs.history_device_unavailable == "The device for this saved query is no longer available."
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest hyperglass/models/tests/test_web.py -v`
+Expected: FAIL — `Text` has no attribute `history_title`.
+
+- [ ] **Step 3: Add the Text fields**
+
+In `hyperglass/models/config/web.py`, add to the `Text` class (after `requery_tooltip`):
+
+```python
+    history_title: str = "Recent queries"
+    history_clear_all: str = "Clear all"
+    history_clear_confirm: str = "Clear all saved queries?"
+    history_back: str = "Back"
+    history_open: str = "Open"
+    history_share: str = "Share"
+    history_rerun: str = "Run again"
+    history_new_target: str = "Run with a new target"
+    history_delete: str = "Delete"
+    history_disabled_hint: str = "Results for this query type are not saved to history."
+```
+
+- [ ] **Step 4: Add the Messages field**
+
+In `hyperglass/models/config/messages.py`, add to the `Messages` class (mirror the existing `Field(...)` style):
+
+```python
+    history_device_unavailable: str = Field(
+        "The device for this saved query is no longer available.",
+        title="History Device Unavailable",
+        description="Displayed when re-running a saved query whose device no longer exists.",
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest hyperglass/models/tests/test_web.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hyperglass/models/config/web.py hyperglass/models/config/messages.py hyperglass/models/tests/test_web.py
+git commit -m "feat(config): add query-history UI strings"
+```
+
+---
+
+## Phase 2 — UI types
+
+### Task 5: Extend UI config types
+
+**Files:**
+- Modify: `hyperglass/ui/types/config.ts` (`_Cache` ~149, `_DirectiveBase` ~114, `_Text` ~25, `_Messages` ~8)
+
+No unit test — validated by `task ui-typecheck` after consumers exist. This task is a prerequisite; typecheck is exercised in later tasks.
+
+- [ ] **Step 1: Add the fields**
+
+`_Cache` (after `refresh_min_interval`):
+
+```ts
+  history_enabled: boolean;
+  history_limit: number;
+```
+
+`_DirectiveBase` (after `info`):
+
+```ts
+  history: boolean;
+```
+
+`_Text` (after `requery_tooltip`):
+
+```ts
+  history_title: string;
+  history_clear_all: string;
+  history_clear_confirm: string;
+  history_back: string;
+  history_open: string;
+  history_share: string;
+  history_rerun: string;
+  history_new_target: string;
+  history_delete: string;
+  history_disabled_hint: string;
+```
+
+`_Messages` (after `no_output`):
+
+```ts
+  history_device_unavailable: string;
+```
+
+- [ ] **Step 2: Verify typecheck still passes**
+
+Run: `pnpm --dir ./hyperglass/ui typecheck` (or `task ui-typecheck`)
+Expected: PASS (no consumers yet, so no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hyperglass/ui/types/config.ts
+git commit -m "feat(ui): add query-history fields to config types"
+```
+
+---
+
+### Task 6: Add the `ResultSnapshot` type and base `ShareResponse` on it
+
+**Files:**
+- Modify: `hyperglass/ui/types/globals.d.ts`
+
+- [ ] **Step 1: Inspect the current `ShareResponse`**
+
+Run: `grep -n "ShareResponse\|QueryResponse\|ResponseLevel" hyperglass/ui/types/globals.d.ts`
+Note the exact current shape of `ShareResponse` and `QueryResponse` so the new interface matches their field types.
+
+- [ ] **Step 2: Add `ResultSnapshot` and re-base `ShareResponse`**
+
+In `hyperglass/ui/types/globals.d.ts`, add:
+
+```ts
+interface ResultSnapshot {
+  id: string;
+  output: QueryResponse['output'];
+  format: QueryResponse['format'];
+  level: ResponseLevel;
+  timestamp: string;
+  runtime: number;
+  cached: boolean;
+  keywords: string[];
+  queryLabels: { location: string };
+}
+```
+
+Then change the existing `ShareResponse` declaration so it extends `ResultSnapshot`, keeping its share-only fields (`shared`, `query`, `createdAt`, `expiresAt`, and any others currently present). If `ShareResponse` currently re-declares fields now in `ResultSnapshot`, remove those duplicates and rely on the `extends`. Example shape (adapt to the real one found in Step 1):
+
+```ts
+interface ShareResponse extends ResultSnapshot {
+  shared: boolean;
+  query: SimpleQuery;          // keep the existing query type name
+  createdAt: string;
+  expiresAt: string;
+}
+```
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `pnpm --dir ./hyperglass/ui typecheck`
+Expected: PASS. If `ShareResponse` consumers break, it means a field type drifted — align `ResultSnapshot` to the real `QueryResponse`/`ShareResponse` types.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hyperglass/ui/types/globals.d.ts
+git commit -m "feat(ui): add ResultSnapshot type, re-base ShareResponse"
+```
+
+---
+
+## Phase 3 — History store
+
+### Task 7: Submission-id utility
+
+**Files:**
+- Create: `hyperglass/ui/util/history-id.ts`
+- Modify: `hyperglass/ui/util/index.ts` (re-export)
+- Test: `hyperglass/ui/util/history-id.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/util/history-id.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { makeSubmissionId } from './history-id';
+
+describe('makeSubmissionId', () => {
+  it('returns a non-empty string', () => {
+    expect(typeof makeSubmissionId()).toBe('string');
+    expect(makeSubmissionId().length).toBeGreaterThan(0);
+  });
+
+  it('returns unique values across calls', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => makeSubmissionId()));
+    expect(ids.size).toBe(100);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test util/history-id.test.ts`
+Expected: FAIL — cannot find module `./history-id`.
+
+- [ ] **Step 3: Implement**
+
+Create `hyperglass/ui/util/history-id.ts`:
+
+```ts
+/**
+ * Generate a unique submission id. Prefers crypto.randomUUID, with a fallback
+ * for environments that lack it.
+ */
+export function makeSubmissionId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+```
+
+Add to `hyperglass/ui/util/index.ts`:
+
+```ts
+export * from './history-id';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test util/history-id.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/ui/util/history-id.ts hyperglass/ui/util/index.ts hyperglass/ui/util/history-id.test.ts
+git commit -m "feat(ui): add makeSubmissionId util"
+```
+
+---
+
+### Task 8: Quota-aware storage adapter
+
+**Files:**
+- Create: `hyperglass/ui/util/history-storage.ts`
+- Test: `hyperglass/ui/util/history-storage.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/util/history-storage.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { shrinkSerialized } from './history-storage';
+
+const make = (entries: unknown[]) =>
+  JSON.stringify({ state: { entries }, version: 1 });
+
+describe('shrinkSerialized', () => {
+  it('strips output from the oldest entry that still has one', () => {
+    const serialized = make([
+      { id: 'new', results: { d1: { output: 'A' } } },
+      { id: 'old', results: { d1: { output: 'B' } } },
+    ]);
+    const out = JSON.parse(shrinkSerialized(serialized) as string);
+    // oldest (last) entry stripped first
+    expect('output' in out.state.entries[1].results.d1).toBe(false);
+    expect(out.state.entries[0].results.d1.output).toBe('A');
+  });
+
+  it('drops the oldest entry once no outputs remain to strip', () => {
+    const serialized = make([
+      { id: 'new', results: { d1: {} } },
+      { id: 'old', results: { d1: {} } },
+    ]);
+    const out = JSON.parse(shrinkSerialized(serialized) as string);
+    expect(out.state.entries).toHaveLength(1);
+    expect(out.state.entries[0].id).toBe('new');
+  });
+
+  it('returns null when nothing remains', () => {
+    expect(shrinkSerialized(make([]))).toBeNull();
+    expect(shrinkSerialized('not json')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test util/history-storage.test.ts`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement**
+
+Create `hyperglass/ui/util/history-storage.ts`:
+
+```ts
+import type { StateStorage } from 'zustand/middleware';
+
+/**
+ * Incrementally shrink a serialized persisted-history blob to fit under the
+ * localStorage quota: first strip `output` from the oldest entry that still has
+ * one, then (when no outputs remain) drop the oldest entry. Returns the new
+ * serialized string, or null when nothing remains / input is unparseable.
+ */
+export function shrinkSerialized(serialized: string): string | null {
+  let parsed: { state?: { entries?: unknown[] } };
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    return null;
+  }
+  const entries = parsed?.state?.entries;
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return null;
+  }
+  // Entries are stored newest-first, so the oldest is at the end.
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i] as { results?: Record<string, { output?: unknown }> };
+    const results = entry.results ?? {};
+    for (const key of Object.keys(results)) {
+      if (results[key] && 'output' in results[key]) {
+        delete results[key].output;
+        return JSON.stringify(parsed);
+      }
+    }
+  }
+  entries.pop();
+  return JSON.stringify(parsed);
+}
+
+/**
+ * A zustand v3 StateStorage backed by localStorage that never throws: reads and
+ * writes are guarded, and a QuotaExceededError on write triggers incremental
+ * shrink-and-retry via shrinkSerialized.
+ */
+export const historyStorage: StateStorage = {
+  getItem(name: string): string | null {
+    try {
+      return typeof window === 'undefined' ? null : window.localStorage.getItem(name);
+    } catch {
+      return null;
+    }
+  },
+  setItem(name: string, value: string): void {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(name, value);
+      return;
+    } catch {
+      let current: string | null = value;
+      // Shrink until it fits or there is nothing left to store.
+      while (current !== null) {
+        current = shrinkSerialized(current);
+        if (current === null) {
+          try {
+            window.localStorage.removeItem(name);
+          } catch {
+            /* ignore */
+          }
+          return;
+        }
+        try {
+          window.localStorage.setItem(name, current);
+          return;
+        } catch {
+          /* keep shrinking */
+        }
+      }
+    }
+  },
+  removeItem(name: string): void {
+    try {
+      if (typeof window !== 'undefined') window.localStorage.removeItem(name);
+    } catch {
+      /* ignore */
+    }
+  },
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test util/history-storage.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/ui/util/history-storage.ts hyperglass/ui/util/history-storage.test.ts
+git commit -m "feat(ui): add quota-aware history storage adapter"
+```
+
+---
+
+### Task 9: The query-history store
+
+**Files:**
+- Create: `hyperglass/ui/hooks/use-query-history.ts`
+- Modify: `hyperglass/ui/hooks/index.ts` (re-export)
+- Test: `hyperglass/ui/hooks/use-query-history.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/hooks/use-query-history.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useQueryHistory } from './use-query-history';
+import type { RecordInput } from './use-query-history';
+
+const snapshot = (output: string) => ({
+  id: 'cache-1',
+  output,
+  format: 'text/plain',
+  level: 'success',
+  timestamp: 'now',
+  runtime: 1,
+  cached: false,
+  keywords: [],
+  queryLabels: { location: 'Core 1' },
+});
+
+const input = (over: Partial<RecordInput> = {}): RecordInput => ({
+  submissionId: 's1',
+  deviceId: 'core1',
+  deviceLabel: 'Core 1',
+  query: { queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
+  labels: { type: 'BGP Route', target: '8.8.8.0/24' },
+  snapshot: snapshot('A'),
+  limit: 10,
+  ...over,
+});
+
+beforeEach(() => {
+  useQueryHistory.setState({ entries: [], openId: null });
+  window.localStorage.clear();
+});
+
+describe('useQueryHistory.record', () => {
+  it('creates an entry keyed by submissionId', () => {
+    useQueryHistory.getState().record(input());
+    const { entries } = useQueryHistory.getState();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('s1');
+    expect(entries[0].results.core1.output).toBe('A');
+    expect(entries[0].query.queryLocation).toEqual(['core1']);
+  });
+
+  it('groups multiple devices of the same submission into one entry', () => {
+    useQueryHistory.getState().record(input());
+    useQueryHistory.getState().record(
+      input({ deviceId: 'edge2', deviceLabel: 'Edge 2', snapshot: snapshot('B') }),
+    );
+    const { entries } = useQueryHistory.getState();
+    expect(entries).toHaveLength(1);
+    expect(Object.keys(entries[0].results).sort()).toEqual(['core1', 'edge2']);
+    expect(entries[0].query.queryLocation.sort()).toEqual(['core1', 'edge2']);
+  });
+
+  it('keeps distinct submissions as separate entries, newest first', () => {
+    useQueryHistory.getState().record(input({ submissionId: 's1' }));
+    useQueryHistory.getState().record(input({ submissionId: 's2' }));
+    const { entries } = useQueryHistory.getState();
+    expect(entries.map(e => e.id)).toEqual(['s2', 's1']);
+  });
+
+  it('enforces the limit, evicting oldest', () => {
+    for (let i = 0; i < 12; i++) {
+      useQueryHistory.getState().record(input({ submissionId: `s${i}`, limit: 10 }));
+    }
+    const { entries } = useQueryHistory.getState();
+    expect(entries).toHaveLength(10);
+    expect(entries[0].id).toBe('s11');
+    expect(entries.find(e => e.id === 's0')).toBeUndefined();
+  });
+});
+
+describe('useQueryHistory remove/clear/open/close', () => {
+  it('remove deletes by id', () => {
+    useQueryHistory.getState().record(input({ submissionId: 's1' }));
+    useQueryHistory.getState().record(input({ submissionId: 's2' }));
+    useQueryHistory.getState().remove('s1');
+    expect(useQueryHistory.getState().entries.map(e => e.id)).toEqual(['s2']);
+  });
+
+  it('clear empties entries', () => {
+    useQueryHistory.getState().record(input());
+    useQueryHistory.getState().clear();
+    expect(useQueryHistory.getState().entries).toHaveLength(0);
+  });
+
+  it('open/close set and reset openId', () => {
+    useQueryHistory.getState().open('s1');
+    expect(useQueryHistory.getState().openId).toBe('s1');
+    useQueryHistory.getState().close();
+    expect(useQueryHistory.getState().openId).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test hooks/use-query-history.test.ts`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement the store**
+
+Create `hyperglass/ui/hooks/use-query-history.ts`:
+
+```ts
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+import { historyStorage } from '~/util/history-storage';
+import { withDev } from '~/util';
+
+export interface ResultSnapshotData {
+  id: string;
+  output: QueryResponse['output'];
+  format: QueryResponse['format'];
+  level: ResponseLevel;
+  timestamp: string;
+  runtime: number;
+  cached: boolean;
+  keywords: string[];
+  queryLabels: { location: string };
+}
+
+export interface HistoryEntry {
+  id: string;
+  savedAt: number;
+  query: { queryLocation: string[]; queryType: string; queryTarget: string[] };
+  labels: { locations: string[]; type: string; target: string };
+  results: Record<string, ResultSnapshotData>;
+}
+
+export interface RecordInput {
+  submissionId: string;
+  deviceId: string;
+  deviceLabel: string;
+  query: { queryType: string; queryTarget: string[] };
+  labels: { type: string; target: string };
+  snapshot: ResultSnapshotData;
+  limit: number;
+}
+
+interface QueryHistoryState {
+  entries: HistoryEntry[];
+  openId: string | null;
+  record(input: RecordInput): void;
+  remove(id: string): void;
+  clear(): void;
+  open(id: string): void;
+  close(): void;
+}
+
+const uniq = (values: string[]): string[] => Array.from(new Set(values));
+
+export const useQueryHistory = create<QueryHistoryState>(
+  persist(
+    withDev<QueryHistoryState>(
+      (set, get) => ({
+        entries: [],
+        openId: null,
+
+        record(input: RecordInput): void {
+          const { submissionId, deviceId, deviceLabel, query, labels, snapshot, limit } = input;
+          const existing = get().entries.find(e => e.id === submissionId);
+
+          const entry: HistoryEntry = existing
+            ? {
+                ...existing,
+                results: { ...existing.results, [deviceId]: snapshot },
+                query: {
+                  ...existing.query,
+                  queryLocation: uniq([...existing.query.queryLocation, deviceId]),
+                },
+                labels: {
+                  ...existing.labels,
+                  locations: uniq([...existing.labels.locations, deviceLabel]),
+                },
+              }
+            : {
+                id: submissionId,
+                savedAt: Date.now(),
+                query: {
+                  queryLocation: [deviceId],
+                  queryType: query.queryType,
+                  queryTarget: query.queryTarget,
+                },
+                labels: { locations: [deviceLabel], type: labels.type, target: labels.target },
+                results: { [deviceId]: snapshot },
+              };
+
+          const others = get().entries.filter(e => e.id !== submissionId);
+          set({ entries: [entry, ...others].slice(0, Math.max(0, limit)) });
+        },
+
+        remove(id: string): void {
+          set(state => ({ entries: state.entries.filter(e => e.id !== id) }));
+        },
+
+        clear(): void {
+          set({ entries: [] });
+        },
+
+        open(id: string): void {
+          set({ openId: id });
+        },
+
+        close(): void {
+          set({ openId: null });
+        },
+      }),
+      'useQueryHistory',
+    ),
+    {
+      name: 'hyperglass.queryHistory',
+      version: 1,
+      getStorage: () => historyStorage,
+      partialize: (state: QueryHistoryState) => ({ entries: state.entries }) as QueryHistoryState,
+    },
+  ),
+);
+```
+
+Add to `hyperglass/ui/hooks/index.ts`:
+
+```ts
+export * from './use-query-history';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --dir ./hyperglass/ui test hooks/use-query-history.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm --dir ./hyperglass/ui typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hyperglass/ui/hooks/use-query-history.ts hyperglass/ui/hooks/index.ts hyperglass/ui/hooks/use-query-history.test.ts
+git commit -m "feat(ui): add useQueryHistory persist store"
+```
+
+---
+
+### Task 10: Config-gated recording wrapper hook
+
+**Files:**
+- Create: `hyperglass/ui/hooks/use-record-history.ts`
+- Modify: `hyperglass/ui/hooks/index.ts`
+- Test: `hyperglass/ui/hooks/use-record-history.test.tsx` (create)
+
+The hook returns a stable callback that records only when the global switch and the directive flag both allow it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/hooks/use-record-history.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRecordHistory } from './use-record-history';
+import { useQueryHistory } from './use-query-history';
+
+const recordSpy = vi.fn();
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({ cache: { historyEnabled: true, historyLimit: 10 } }),
+}));
+
+beforeEach(() => {
+  recordSpy.mockClear();
+  useQueryHistory.setState({
+    entries: [],
+    openId: null,
+    record: recordSpy,
+  } as never);
+});
+
+const payload = {
+  submissionId: 's1',
+  deviceId: 'core1',
+  deviceLabel: 'Core 1',
+  directiveHistory: true,
+  query: { queryType: 'bgp_route', queryTarget: ['x'] },
+  labels: { type: 'BGP Route', target: 'x' },
+  snapshot: {} as never,
+};
+
+describe('useRecordHistory', () => {
+  it('records when global + directive both allow it', () => {
+    const { result } = renderHook(() => useRecordHistory());
+    result.current(payload);
+    expect(recordSpy).toHaveBeenCalledOnce();
+    expect(recordSpy.mock.calls[0][0].limit).toBe(10);
+  });
+
+  it('no-ops when the directive opts out', () => {
+    const { result } = renderHook(() => useRecordHistory());
+    result.current({ ...payload, directiveHistory: false });
+    expect(recordSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+(If `cache` is consumed as `cache.historyEnabled`/`cache.historyLimit` via `useConfig()`, the mock above reflects the camelCased runtime shape.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test hooks/use-record-history.test.tsx`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement**
+
+Create `hyperglass/ui/hooks/use-record-history.ts`:
+
+```ts
+import { useCallback } from 'react';
+import { useConfig } from '~/context';
+import { useQueryHistory } from './use-query-history';
+import type { ResultSnapshotData } from './use-query-history';
+
+interface RecordHistoryArgs {
+  submissionId: string;
+  deviceId: string;
+  deviceLabel: string;
+  directiveHistory: boolean;
+  query: { queryType: string; queryTarget: string[] };
+  labels: { type: string; target: string };
+  snapshot: ResultSnapshotData;
+}
+
+/**
+ * Returns a callback that records a successful result into query history,
+ * unless history is disabled globally or for the directive.
+ */
+export function useRecordHistory(): (args: RecordHistoryArgs) => void {
+  const { cache } = useConfig();
+  const record = useQueryHistory(s => s.record);
+
+  return useCallback(
+    (args: RecordHistoryArgs): void => {
+      if (!cache.historyEnabled || !args.directiveHistory) return;
+      const { directiveHistory, ...rest } = args;
+      record({ ...rest, limit: cache.historyLimit });
+    },
+    [cache.historyEnabled, cache.historyLimit, record],
+  );
+}
+```
+
+Add to `hyperglass/ui/hooks/index.ts`:
+
+```ts
+export * from './use-record-history';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test hooks/use-record-history.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/ui/hooks/use-record-history.ts hyperglass/ui/hooks/index.ts hyperglass/ui/hooks/use-record-history.test.tsx
+git commit -m "feat(ui): add config-gated useRecordHistory hook"
+```
+
+---
+
+## Phase 4 — Result / SnapshotResults refactor
+
+### Task 11: Decouple `readOnly`, add `showShare`, retype `snapshot`
+
+**Files:**
+- Modify: `hyperglass/ui/components/results/individual.tsx` (props ~42-49; share render line 294; snapshot type)
+- Test: `hyperglass/ui/components/results/individual.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/components/results/individual.test.tsx`. (Mirror the rendering/provider setup used in `hyperglass/ui/components/looking-glass-form.test.tsx` for `useConfig`/Chakra; reuse its test harness/wrapper.)
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Accordion } from '@chakra-ui/react';
+// import the shared test wrapper used elsewhere (provides Chakra + config context)
+import { TestWrapper } from '~/test/wrapper'; // adjust to the actual shared helper
+import { Result } from './individual';
+
+const snapshot = {
+  id: 'cache-1',
+  output: 'hello',
+  format: 'text/plain',
+  level: 'success',
+  timestamp: 'now',
+  runtime: 1,
+  cached: true,
+  keywords: [],
+  queryLabels: { location: 'Core 1' },
+} as never;
+
+const renderResult = (props: Record<string, unknown>) =>
+  render(
+    <TestWrapper>
+      <Accordion>
+        <Result index={0} queryLocation="core1" snapshot={snapshot} {...props} />
+      </Accordion>
+    </TestWrapper>,
+  );
+
+describe('Result share visibility', () => {
+  it('hides Share when readOnly and showShare not set', () => {
+    renderResult({ readOnly: true });
+    expect(screen.queryByText('Share')).not.toBeInTheDocument();
+  });
+
+  it('shows Share in history mode (readOnly + showShare)', () => {
+    renderResult({ readOnly: true, showShare: true });
+    expect(screen.getByText('Share')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test components/results/individual.test.tsx`
+Expected: FAIL — `showShare` does nothing yet (the second assertion fails).
+
+- [ ] **Step 3: Implement**
+
+In `hyperglass/ui/components/results/individual.tsx`:
+
+Change the props interface:
+
+```ts
+interface ResultProps {
+  index: number;
+  queryLocation: string;
+  /** Snapshot (share link or local history) — skips the live LG query and renders directly. */
+  snapshot?: ResultSnapshot;
+  /** When true, hides the RequeryButton (read-only views). */
+  readOnly?: boolean;
+  /** Controls ShareButton visibility; defaults to !readOnly. */
+  showShare?: boolean;
+}
+```
+
+Destructure with a default:
+
+```ts
+  const { index, queryLocation, snapshot, readOnly = false, showShare = !readOnly } = props;
+```
+
+Change the share-button render (currently `{!readOnly && data?.id && <ShareButton cacheId={data.id} />}`) to:
+
+```tsx
+          {showShare && data?.id && <ShareButton cacheId={data.id} />}
+```
+
+(`snapshotAsQueryResponse` already reads only fields present on `ResultSnapshot`, so the type change is safe.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test components/results/individual.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the share page is unaffected**
+
+Run: `pnpm --dir ./hyperglass/ui typecheck`
+Expected: PASS. `pages/result/[id].tsx` passes `readOnly` only → `showShare` defaults to `false` → Share stays hidden there (unchanged behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hyperglass/ui/components/results/individual.tsx hyperglass/ui/components/results/individual.test.tsx
+git commit -m "feat(ui): decouple Result readOnly/showShare; retype snapshot"
+```
+
+---
+
+### Task 12: Extract `SnapshotResults` and use it on the share page
+
+**Files:**
+- Create: `hyperglass/ui/components/results/snapshot-results.tsx`
+- Modify: `hyperglass/ui/components/results/index.ts` (export)
+- Modify: `hyperglass/ui/pages/result/[id].tsx` (use the component)
+- Test: `hyperglass/ui/components/results/snapshot-results.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/components/results/snapshot-results.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TestWrapper } from '~/test/wrapper'; // adjust to the actual shared helper
+import { SnapshotResults } from './snapshot-results';
+
+const snap = (location: string, output: string) =>
+  ({
+    id: `c-${location}`,
+    output,
+    format: 'text/plain',
+    level: 'success',
+    timestamp: 'now',
+    runtime: 1,
+    cached: true,
+    keywords: [],
+    queryLabels: { location },
+  }) as never;
+
+describe('SnapshotResults', () => {
+  it('renders one result per item', () => {
+    render(
+      <TestWrapper>
+        <SnapshotResults
+          items={[
+            { queryLocation: 'core1', snapshot: snap('Core 1', 'A') },
+            { queryLocation: 'edge2', snapshot: snap('Edge 2', 'B') },
+          ]}
+        />
+      </TestWrapper>,
+    );
+    expect(screen.getByText('Core 1')).toBeInTheDocument();
+    expect(screen.getByText('Edge 2')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test components/results/snapshot-results.test.tsx`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement `SnapshotResults`**
+
+Create `hyperglass/ui/components/results/snapshot-results.tsx` (mirrors the markup currently inline in `pages/result/[id].tsx`):
+
+```tsx
+import { Accordion } from '@chakra-ui/react';
+import { AnimatedDiv } from '~/elements';
+import { Result } from './individual';
+
+export interface SnapshotResultsItem {
+  queryLocation: string;
+  snapshot: ResultSnapshot;
+}
+
+interface SnapshotResultsProps {
+  items: SnapshotResultsItem[];
+  /** Show each result's ShareButton (history-open); default false (share page). */
+  showShare?: boolean;
+}
+
+export const SnapshotResults = (props: SnapshotResultsProps): JSX.Element => {
+  const { items, showShare = false } = props;
+  return (
+    <AnimatedDiv
+      p={0}
+      my={4}
+      w="100%"
+      mx="auto"
+      rounded="lg"
+      textAlign="left"
+      borderWidth="1px"
+      overflow="hidden"
+      initial={{ opacity: 1 }}
+      exit={{ opacity: 0, y: 300 }}
+      transition={{ duration: 0.3 }}
+      animate={{ opacity: 1, y: 0 }}
+      maxW={{ base: '100%', md: '75%' }}
+    >
+      <Accordion defaultIndex={items.map((_, i) => i)} allowMultiple>
+        {items.map((item, index) => (
+          <Result
+            key={item.queryLocation}
+            index={index}
+            queryLocation={item.queryLocation}
+            snapshot={item.snapshot}
+            readOnly
+            showShare={showShare}
+          />
+        ))}
+      </Accordion>
+    </AnimatedDiv>
+  );
+};
+```
+
+Add to `hyperglass/ui/components/results/index.ts`:
+
+```ts
+export * from './snapshot-results';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test components/results/snapshot-results.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Refactor the share page to use it**
+
+In `hyperglass/ui/pages/result/[id].tsx`, replace the inline `AnimatedDiv`/`Accordion`/`Result` block with:
+
+```tsx
+        <SnapshotResults items={[{ queryLocation: snapshot.query.query_location, snapshot }]} />
+```
+
+Add the import: `import { SnapshotResults } from '~/components/results/snapshot-results';` and drop the now-unused `Accordion`/`AnimatedDiv` imports if they are no longer referenced.
+
+- [ ] **Step 6: Verify the share page still works**
+
+Run: `pnpm --dir ./hyperglass/ui test pages/result` and `pnpm --dir ./hyperglass/ui typecheck`
+Expected: PASS (existing share-page tests still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hyperglass/ui/components/results/snapshot-results.tsx hyperglass/ui/components/results/index.ts hyperglass/ui/pages/result/\[id\].tsx hyperglass/ui/components/results/snapshot-results.test.tsx
+git commit -m "refactor(ui): extract SnapshotResults; reuse on share page"
+```
+
+---
+
+## Phase 5 — Form state: submissionId + prefillForm
+
+### Task 13: Add `submissionId` to the form store
+
+**Files:**
+- Modify: `hyperglass/ui/hooks/use-form-state.ts` (state shape, `reset`, a setter)
+- Test: `hyperglass/ui/hooks/use-form-state.test.ts` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/append `hyperglass/ui/hooks/use-form-state.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useFormState } from './use-form-state';
+
+beforeEach(async () => {
+  await useFormState.getState().reset();
+});
+
+describe('useFormState.submissionId', () => {
+  it('defaults to null and can be set', () => {
+    expect(useFormState.getState().submissionId).toBeNull();
+    useFormState.getState().setSubmissionId('abc');
+    expect(useFormState.getState().submissionId).toBe('abc');
+  });
+
+  it('is cleared by reset', async () => {
+    useFormState.getState().setSubmissionId('abc');
+    await useFormState.getState().reset();
+    expect(useFormState.getState().submissionId).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test hooks/use-form-state.test.ts`
+Expected: FAIL — `submissionId` is undefined / `setSubmissionId` missing.
+
+- [ ] **Step 3: Implement**
+
+In `hyperglass/ui/hooks/use-form-state.ts`:
+
+Add to `FormStateType` (interface):
+
+```ts
+  submissionId: string | null;
+  setSubmissionId(value: string | null): void;
+```
+
+Add to the initial state object (alongside `status`, `target`):
+
+```ts
+  submissionId: null,
+```
+
+Add the setter (alongside the other methods):
+
+```ts
+  setSubmissionId(submissionId: string | null): void {
+    set({ submissionId });
+  },
+```
+
+Add `submissionId: null,` to the object passed to `set({...})` inside `reset()`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test hooks/use-form-state.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/ui/hooks/use-form-state.ts hyperglass/ui/hooks/use-form-state.test.ts
+git commit -m "feat(ui): track submissionId in form state"
+```
+
+---
+
+### Task 14: Extract `prefillForm` from `locationChange`
+
+**Files:**
+- Modify: `hyperglass/ui/hooks/use-form-state.ts`
+- Test: `hyperglass/ui/hooks/use-form-state.test.ts` (extend)
+
+`prefillForm` sets `form`, `selections`, and `filtered` for a given query without touching react-hook-form. `locationChange`'s directive-intersection computation is the reusable core.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `hyperglass/ui/hooks/use-form-state.test.ts`:
+
+```ts
+import type { Device } from '~/types';
+
+const device = (id: string): Device =>
+  ({
+    id,
+    name: id.toUpperCase(),
+    directives: [{ id: 'bgp_route', name: 'BGP Route', groups: ['ip'] } as never],
+  }) as Device;
+
+describe('useFormState.prefillForm', () => {
+  it('sets form values and selections for valid locations', () => {
+    const getDevice = (id: string) => (id === 'core1' ? device('core1') : null);
+    useFormState.getState().prefillForm(
+      { queryLocation: ['core1'], queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
+      getDevice as never,
+    );
+    const state = useFormState.getState();
+    expect(state.form.queryLocation).toEqual(['core1']);
+    expect(state.form.queryType).toBe('bgp_route');
+    expect(state.form.queryTarget).toEqual(['8.8.8.0/24']);
+    expect(state.selections.queryLocation.map(o => o.value)).toEqual(['core1']);
+  });
+
+  it('drops unknown devices and returns the valid subset', () => {
+    const getDevice = (id: string) => (id === 'core1' ? device('core1') : null);
+    const valid = useFormState.getState().prefillForm(
+      { queryLocation: ['core1', 'ghost'], queryType: 'bgp_route', queryTarget: ['x'] },
+      getDevice as never,
+    );
+    expect(valid).toEqual(['core1']);
+    expect(useFormState.getState().form.queryLocation).toEqual(['core1']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test hooks/use-form-state.test.ts`
+Expected: FAIL — `prefillForm` is not a function.
+
+- [ ] **Step 3: Implement `prefillForm`**
+
+In `hyperglass/ui/hooks/use-form-state.ts`, add to `FormStateType`:
+
+```ts
+  prefillForm(
+    query: { queryLocation: string[]; queryType: string; queryTarget: string[] },
+    getDevice: UseDeviceReturn,
+  ): string[];
+```
+
+Implement it (reusing the intersection logic that `locationChange` already performs — `intersectionWith`, `dedupObjectArray` are already imported in this file):
+
+```ts
+  prefillForm(query, getDevice): string[] {
+    const validDevices = query.queryLocation
+      .map(getDevice)
+      .filter((device): device is Device => device !== null);
+    const validLocations = validDevices.map(d => d.id);
+
+    const allGroups = validDevices.map(dev =>
+      Array.from(new Set(dev.directives.flatMap(dir => dir.groups))),
+    );
+    const intersecting = validDevices.length ? intersectionWith(...allGroups, isEqual) : [];
+    const allDirectives = validDevices.map(device => device.directives);
+    const intersectingDirectives = validDevices.length
+      ? intersectionWith(...allDirectives, isEqual)
+      : [];
+    const directives = dedupObjectArray(intersectingDirectives, 'id');
+
+    set({
+      form: {
+        queryLocation: validLocations,
+        queryType: query.queryType,
+        queryTarget: query.queryTarget,
+      },
+      selections: {
+        queryLocation: validDevices.map(d => ({ value: d.id, label: d.name })),
+        queryType: null,
+      },
+      filtered: { groups: intersecting, types: directives },
+      target: { display: query.queryTarget.join(' ') },
+    });
+
+    return validLocations;
+  },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test hooks/use-form-state.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Sanity-check the form still works**
+
+Run: `pnpm --dir ./hyperglass/ui test components/looking-glass-form.test.tsx`
+Expected: PASS (we added a method; `locationChange` is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hyperglass/ui/hooks/use-form-state.ts hyperglass/ui/hooks/use-form-state.test.ts
+git commit -m "feat(ui): add prefillForm to form state"
+```
+
+---
+
+## Phase 6 — Recording wiring
+
+### Task 15: Record successful results from `Result`
+
+**Files:**
+- Modify: `hyperglass/ui/components/results/individual.tsx`
+- Test: `hyperglass/ui/components/results/individual.test.tsx` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `hyperglass/ui/components/results/individual.test.tsx` a test that asserts recording fires for a successful **live** result and is skipped for snapshot renders. Use a spy on `useRecordHistory`:
+
+```tsx
+import { vi } from 'vitest';
+
+const recordFn = vi.fn();
+vi.mock('~/hooks/use-record-history', () => ({
+  useRecordHistory: () => recordFn,
+}));
+
+// Within a describe block, after configuring useLGQuery to return a successful
+// live result for queryLocation 'core1' (mirror the mocking already used in
+// use-lg-query.test.tsx), assert:
+//   expect(recordFn).toHaveBeenCalledWith(expect.objectContaining({ deviceId: 'core1' }));
+// And for a snapshot render: expect(recordFn).not.toHaveBeenCalled();
+```
+
+(Implement the concrete `useLGQuery` mock by mirroring `hyperglass/ui/hooks/use-lg-query.test.tsx`; the key assertions are the two `recordFn` expectations.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test components/results/individual.test.tsx`
+Expected: FAIL — recording not wired.
+
+- [ ] **Step 3: Implement the recording effect**
+
+In `hyperglass/ui/components/results/individual.tsx`:
+
+Add imports:
+
+```ts
+import { useRecordHistory } from '~/hooks';
+```
+
+Inside `_Result`, after the existing hooks, derive the directive and recorder:
+
+```ts
+  const recordHistory = useRecordHistory();
+  const getDirective = useFormState(s => s.getDirective);
+  const submissionId = useFormState(s => s.submissionId);
+```
+
+Add the recording effect (place it after the `data` is resolved, near the other effects):
+
+```ts
+  useEffect(() => {
+    if (snapshot || readOnly) return;
+    if (data?.level === 'success' && submissionId && device !== null) {
+      const directive = getDirective();
+      recordHistory({
+        submissionId,
+        deviceId: device.id,
+        deviceLabel: device.name,
+        directiveHistory: directive?.history ?? true,
+        query: { queryType: form.queryType, queryTarget: form.queryTarget },
+        labels: { type: directive?.name ?? form.queryType, target: form.queryTarget.join(' ') },
+        snapshot: {
+          id: data.id,
+          output: data.output,
+          format: data.format,
+          level: data.level,
+          timestamp: data.timestamp,
+          runtime: data.runtime,
+          cached: data.cached,
+          keywords: data.keywords,
+          queryLabels: { location: device.name },
+        },
+      });
+    }
+    // dataUpdatedAt advances on every settle (fresh or cache-served); submissionId
+    // changes per submit. Both are sufficient to capture each run exactly once.
+  }, [dataUpdatedAt, submissionId]); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+(`historyEnabled` gating lives inside `useRecordHistory`; the directive flag is passed through.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test components/results/individual.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/ui/components/results/individual.tsx hyperglass/ui/components/results/individual.test.tsx
+git commit -m "feat(ui): record successful results into query history"
+```
+
+---
+
+### Task 16: Generate a `submissionId` on submit
+
+**Files:**
+- Modify: `hyperglass/ui/components/looking-glass-form.tsx` (`submitHandler`)
+- Test: covered indirectly; add an assertion to `components/looking-glass-form.test.tsx` if it already exercises submit.
+
+- [ ] **Step 1: Implement**
+
+In `hyperglass/ui/components/looking-glass-form.tsx`:
+
+Add imports / selectors:
+
+```ts
+import { makeSubmissionId } from '~/util';
+```
+```ts
+  const setSubmissionId = useFormState(s => s.setSubmissionId);
+```
+
+In `submitHandler`, set a fresh id immediately before transitioning to results (both the non-FQDN `setStatus('results')` branch and the FQDN `resolvedOpen()` branch should run after assigning it). The simplest correct placement is right after the greeting check passes:
+
+```ts
+    // Stamp this submission so its per-device results group into one history entry.
+    setSubmissionId(makeSubmissionId());
+```
+
+- [ ] **Step 2: Verify build/typecheck and form test**
+
+Run: `pnpm --dir ./hyperglass/ui test components/looking-glass-form.test.tsx && pnpm --dir ./hyperglass/ui typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hyperglass/ui/components/looking-glass-form.tsx
+git commit -m "feat(ui): stamp submissionId on query submit"
+```
+
+---
+
+## Phase 7 — History UI
+
+### Task 17: `HistoryDisabledHint`
+
+**Files:**
+- Create: `hyperglass/ui/components/history/history-disabled-hint.tsx`
+- Create: `hyperglass/ui/components/history/index.ts`
+- Modify: `hyperglass/ui/components/index.ts` (re-export history barrel)
+- Test: `hyperglass/ui/components/history/history-disabled-hint.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/components/history/history-disabled-hint.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TestWrapper } from '~/test/wrapper'; // adjust to actual shared helper
+import { HistoryDisabledHint } from './history-disabled-hint';
+
+// TestWrapper provides useConfig with cache.historyEnabled true and
+// web.text.historyDisabledHint set to a known string.
+
+describe('HistoryDisabledHint', () => {
+  it('renders when global history on and directive opts out', () => {
+    render(
+      <TestWrapper>
+        <HistoryDisabledHint directiveHistory={false} />
+      </TestWrapper>,
+    );
+    expect(screen.getByLabelText(/not saved to history/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when the directive allows history', () => {
+    const { container } = render(
+      <TestWrapper>
+        <HistoryDisabledHint directiveHistory={true} />
+      </TestWrapper>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test components/history/history-disabled-hint.test.tsx`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement**
+
+Create `hyperglass/ui/components/history/history-disabled-hint.tsx`:
+
+```tsx
+import { Box, Tooltip } from '@chakra-ui/react';
+import { useConfig } from '~/context';
+import { DynamicIcon } from '~/elements';
+
+interface HistoryDisabledHintProps {
+  directiveHistory: boolean;
+}
+
+export const HistoryDisabledHint = (props: HistoryDisabledHintProps): JSX.Element | null => {
+  const { directiveHistory } = props;
+  const { cache, web } = useConfig();
+
+  if (!cache.historyEnabled || directiveHistory) {
+    return null;
+  }
+
+  return (
+    <Tooltip hasArrow label={web.text.historyDisabledHint} placement="top">
+      <Box as="span" aria-label={web.text.historyDisabledHint} display="inline-flex">
+        <DynamicIcon icon={{ fi: 'FiEyeOff' }} boxSize="14px" />
+      </Box>
+    </Tooltip>
+  );
+};
+```
+
+Create `hyperglass/ui/components/history/index.ts`:
+
+```ts
+export * from './history-disabled-hint';
+```
+
+Add to `hyperglass/ui/components/index.ts`:
+
+```ts
+export * from './history';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test components/history/history-disabled-hint.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/ui/components/history/ hyperglass/ui/components/index.ts
+git commit -m "feat(ui): add HistoryDisabledHint component"
+```
+
+---
+
+### Task 18: `HistoryEntryRow`
+
+**Files:**
+- Create: `hyperglass/ui/components/history/history-entry-row.tsx`
+- Modify: `hyperglass/ui/components/history/index.ts`
+- Test: `hyperglass/ui/components/history/history-entry-row.test.tsx`
+
+The row reads everything it needs from the entry and calls store/form actions. `getDevice` comes from `useDevice()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/components/history/history-entry-row.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TestWrapper } from '~/test/wrapper'; // adjust to actual shared helper
+import { HistoryEntryRow } from './history-entry-row';
+import { useQueryHistory } from '~/hooks';
+import type { HistoryEntry } from '~/hooks/use-query-history';
+
+const baseSnap = {
+  id: 'cache-1',
+  output: 'x',
+  format: 'text/plain',
+  level: 'success',
+  timestamp: 'now',
+  runtime: 1,
+  cached: true,
+  keywords: [],
+  queryLabels: { location: 'Core 1' },
+};
+
+const singleEntry: HistoryEntry = {
+  id: 's1',
+  savedAt: Date.now(),
+  query: { queryLocation: ['core1'], queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
+  labels: { locations: ['Core 1'], type: 'BGP Route', target: '8.8.8.0/24' },
+  results: { core1: baseSnap as never },
+};
+
+const multiEntry: HistoryEntry = {
+  ...singleEntry,
+  id: 's2',
+  query: { ...singleEntry.query, queryLocation: ['core1', 'edge2'] },
+  labels: { ...singleEntry.labels, locations: ['Core 1', 'Edge 2'] },
+  results: { core1: baseSnap as never, edge2: baseSnap as never },
+};
+
+beforeEach(() => {
+  useQueryHistory.setState({ entries: [singleEntry, multiEntry], openId: null });
+});
+
+describe('HistoryEntryRow', () => {
+  it('shows the Share icon for single-device entries', () => {
+    render(<TestWrapper><HistoryEntryRow entry={singleEntry} /></TestWrapper>);
+    expect(screen.getByLabelText('Share')).toBeInTheDocument();
+  });
+
+  it('hides the Share icon for multi-device entries', () => {
+    render(<TestWrapper><HistoryEntryRow entry={multiEntry} /></TestWrapper>);
+    expect(screen.queryByLabelText('Share')).not.toBeInTheDocument();
+  });
+
+  it('Open sets openId', () => {
+    render(<TestWrapper><HistoryEntryRow entry={singleEntry} /></TestWrapper>);
+    fireEvent.click(screen.getByLabelText('Open'));
+    expect(useQueryHistory.getState().openId).toBe('s1');
+  });
+
+  it('Delete removes the entry', () => {
+    render(<TestWrapper><HistoryEntryRow entry={singleEntry} /></TestWrapper>);
+    fireEvent.click(screen.getByLabelText('Delete'));
+    expect(useQueryHistory.getState().entries.find(e => e.id === 's1')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test components/history/history-entry-row.test.tsx`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement**
+
+Create `hyperglass/ui/components/history/history-entry-row.tsx`:
+
+```tsx
+import { Button, Flex, HStack, Text, Tooltip, useToast } from '@chakra-ui/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { useConfig } from '~/context';
+import { DynamicIcon } from '~/elements';
+import { useDevice, useFormState, useQueryHistory } from '~/hooks';
+import { makeSubmissionId } from '~/util';
+import { ShareButton } from '~/components/results/share-button';
+import type { HistoryEntry } from '~/hooks/use-query-history';
+
+dayjs.extend(relativeTime);
+
+interface HistoryEntryRowProps {
+  entry: HistoryEntry;
+}
+
+const iconBtn = {
+  as: 'a' as const,
+  mx: 1,
+  size: 'sm' as const,
+  variant: 'ghost' as const,
+  colorScheme: 'secondary' as const,
+};
+
+export const HistoryEntryRow = (props: HistoryEntryRowProps): JSX.Element => {
+  const { entry } = props;
+  const { web, messages } = useConfig();
+  const toast = useToast();
+  const getDevice = useDevice();
+
+  const open = useQueryHistory(s => s.open);
+  const remove = useQueryHistory(s => s.remove);
+  const prefillForm = useFormState(s => s.prefillForm);
+  const setStatus = useFormState(s => s.setStatus);
+  const setSubmissionId = useFormState(s => s.setSubmissionId);
+
+  const deviceIds = Object.keys(entry.results);
+  const isSingleDevice = deviceIds.length === 1;
+  const hasOutput = deviceIds.some(id => 'output' in entry.results[id]);
+
+  const failStale = () =>
+    toast({ title: messages.historyDeviceUnavailable, status: 'error', isClosable: true });
+
+  const handleRerun = () => {
+    const valid = prefillForm(entry.query, getDevice);
+    if (valid.length === 0) return failStale();
+    setSubmissionId(makeSubmissionId());
+    setStatus('results');
+  };
+
+  const handleNewTarget = () => {
+    const valid = prefillForm({ ...entry.query, queryTarget: [] }, getDevice);
+    if (valid.length === 0) return failStale();
+    setStatus('form');
+  };
+
+  return (
+    <Flex
+      px={3}
+      py={2}
+      w="100%"
+      align="center"
+      justify="space-between"
+      borderTopWidth="1px"
+      _first={{ borderTopWidth: 0 }}
+    >
+      <Flex direction="column" textAlign="left" minW={0} mr={2}>
+        <Text fontSize="sm" fontWeight="medium" isTruncated>
+          {entry.labels.locations.join(', ')} · {entry.labels.type} · {entry.labels.target}
+        </Text>
+        <Text fontSize="xs" color="gray.500">
+          {dayjs(entry.savedAt).fromNow()}
+        </Text>
+      </Flex>
+      <HStack spacing={0} flex="0 0 auto">
+        {hasOutput && (
+          <Tooltip hasArrow label={web.text.historyOpen} placement="top">
+            <Button {...iconBtn} aria-label={web.text.historyOpen} onClick={() => open(entry.id)}>
+              <DynamicIcon icon={{ fi: 'FiEye' }} boxSize="16px" />
+            </Button>
+          </Tooltip>
+        )}
+        {isSingleDevice && <ShareButton cacheId={entry.results[deviceIds[0]].id} />}
+        <Tooltip hasArrow label={web.text.historyRerun} placement="top">
+          <Button {...iconBtn} aria-label={web.text.historyRerun} onClick={handleRerun}>
+            <DynamicIcon icon={{ fi: 'FiRepeat' }} boxSize="16px" />
+          </Button>
+        </Tooltip>
+        <Tooltip hasArrow label={web.text.historyNewTarget} placement="top">
+          <Button {...iconBtn} aria-label={web.text.historyNewTarget} onClick={handleNewTarget}>
+            <DynamicIcon icon={{ fi: 'FiEdit' }} boxSize="16px" />
+          </Button>
+        </Tooltip>
+        <Tooltip hasArrow label={web.text.historyDelete} placement="top">
+          <Button
+            {...iconBtn}
+            aria-label={web.text.historyDelete}
+            colorScheme="red"
+            onClick={() => remove(entry.id)}
+          >
+            <DynamicIcon icon={{ fi: 'FiTrash2' }} boxSize="16px" />
+          </Button>
+        </Tooltip>
+      </HStack>
+    </Flex>
+  );
+};
+```
+
+Note: `web.text` is camelCased at runtime (`CamelCasedProperties<_Text>`), so the property names used above are `historyOpen`, `historyRerun`, `historyNewTarget`, `historyDelete`. The test asserts the rendered `aria-label` **values** ("Open", "Share", "Delete"), which are the defaults those fields carry — so the assertions hold regardless of the property names.
+
+Add to `hyperglass/ui/components/history/index.ts`:
+
+```ts
+export * from './history-entry-row';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test components/history/history-entry-row.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/ui/components/history/history-entry-row.tsx hyperglass/ui/components/history/index.ts hyperglass/ui/components/history/history-entry-row.test.tsx
+git commit -m "feat(ui): add HistoryEntryRow with Open/Share/Re-run/New-target/Delete"
+```
+
+---
+
+### Task 19: `RecentQueries` container
+
+**Files:**
+- Create: `hyperglass/ui/components/history/recent-queries.tsx`
+- Modify: `hyperglass/ui/components/history/index.ts`
+- Test: `hyperglass/ui/components/history/recent-queries.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `hyperglass/ui/components/history/recent-queries.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TestWrapper } from '~/test/wrapper'; // adjust to actual shared helper
+import { RecentQueries } from './recent-queries';
+import { useQueryHistory } from '~/hooks';
+import type { HistoryEntry } from '~/hooks/use-query-history';
+
+// Force the "form is pristine" branch: mock useFormInteractive -> false.
+vi.mock('~/hooks/use-form-state', async (orig) => {
+  const actual = await orig<typeof import('~/hooks/use-form-state')>();
+  return { ...actual, useFormInteractive: () => false };
+});
+
+const entry: HistoryEntry = {
+  id: 's1',
+  savedAt: Date.now(),
+  query: { queryLocation: ['core1'], queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
+  labels: { locations: ['Core 1'], type: 'BGP Route', target: '8.8.8.0/24' },
+  results: { core1: {} as never },
+};
+
+beforeEach(() => {
+  useQueryHistory.setState({ entries: [], openId: null });
+});
+
+describe('RecentQueries', () => {
+  it('renders nothing when there are no entries', () => {
+    const { container } = render(<TestWrapper><RecentQueries /></TestWrapper>);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the title and rows when entries exist', () => {
+    useQueryHistory.setState({ entries: [entry], openId: null });
+    render(<TestWrapper><RecentQueries /></TestWrapper>);
+    expect(screen.getByText('Recent queries')).toBeInTheDocument();
+    expect(screen.getByText(/Core 1 · BGP Route · 8.8.8.0\/24/)).toBeInTheDocument();
+  });
+});
+```
+
+(`TestWrapper`'s `useConfig` must supply `cache.historyEnabled = true`. The component gates on a mounted flag — render-after-mount — so the test, which runs an effect flush, will show content on the second tick; `@testing-library` `render` flushes effects, so the mounted state resolves to `true`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir ./hyperglass/ui test components/history/recent-queries.test.tsx`
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement**
+
+Create `hyperglass/ui/components/history/recent-queries.tsx`:
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Box,
+  Button,
+  Flex,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { useEffect, useRef, useState } from 'react';
+import { useConfig } from '~/context';
+import { useFormInteractive, useQueryHistory } from '~/hooks';
+import { HistoryEntryRow } from './history-entry-row';
+
+export const RecentQueries = (): JSX.Element | null => {
+  const { cache, web } = useConfig();
+  const formInteractive = useFormInteractive();
+  const entries = useQueryHistory(s => s.entries);
+  const clear = useQueryHistory(s => s.clear);
+
+  // Render only after mount to avoid a next-export hydration mismatch
+  // (server sees no localStorage; client rehydrates).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  if (!mounted || !cache.historyEnabled || formInteractive || entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box w="100%" maxW={{ base: '100%', lg: '75%' }} mx="auto" my={4} textAlign="left">
+      <Flex px={3} py={2} align="center" justify="space-between">
+        <Text fontSize="sm" fontWeight="bold" textTransform="uppercase" color="gray.500">
+          {web.text.historyTitle}
+        </Text>
+        <Button size="xs" variant="ghost" colorScheme="red" onClick={onOpen}>
+          {web.text.historyClearAll}
+        </Button>
+      </Flex>
+      <Box borderWidth="1px" rounded="lg" overflow="hidden">
+        {entries.map(entry => (
+          <HistoryEntryRow key={entry.id} entry={entry} />
+        ))}
+      </Box>
+
+      <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={onClose}>
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader>{web.text.historyClearConfirm}</AlertDialogHeader>
+            <AlertDialogBody />
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose}>
+                {web.text.historyBack}
+              </Button>
+              <Button
+                colorScheme="red"
+                ml={3}
+                onClick={() => {
+                  clear();
+                  onClose();
+                }}
+              >
+                {web.text.historyClearAll}
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </Box>
+  );
+};
+```
+
+Add to `hyperglass/ui/components/history/index.ts`:
+
+```ts
+export * from './recent-queries';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --dir ./hyperglass/ui test components/history/recent-queries.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hyperglass/ui/components/history/recent-queries.tsx hyperglass/ui/components/history/index.ts hyperglass/ui/components/history/recent-queries.test.tsx
+git commit -m "feat(ui): add RecentQueries list container"
+```
+
+---
+
+## Phase 8 — Integration
+
+### Task 20: Render `RecentQueries` and the history-open view in `index.tsx`
+
+**Files:**
+- Modify: `hyperglass/ui/pages/index.tsx`
+- Test: manual + existing suite (the view logic is exercised by component tests; index wiring is verified by typecheck + a smoke test below).
+
+- [ ] **Step 1: Implement the view switch**
+
+Replace `hyperglass/ui/pages/index.tsx` with:
+
+```tsx
+import dynamic from 'next/dynamic';
+import { AnimatePresence } from 'framer-motion';
+import { Box, Button, Flex } from '@chakra-ui/react';
+import { If, Then, Else } from 'react-if';
+import { Loading } from '~/elements';
+import { useConfig } from '~/context';
+import { useQueryHistory, useView } from '~/hooks';
+import { SnapshotResults } from '~/components/results/snapshot-results';
+import type { SnapshotResultsItem } from '~/components/results/snapshot-results';
+
+import type { NextPage } from 'next';
+
+const LookingGlassForm = dynamic<Dict>(
+  () => import('~/components/looking-glass-form').then(i => i.LookingGlassForm),
+  { loading: Loading },
+);
+
+const Results = dynamic<Dict>(() => import('~/components/results').then(i => i.Results), {
+  loading: Loading,
+});
+
+const RecentQueries = dynamic<Dict>(
+  () => import('~/components/history').then(i => i.RecentQueries),
+  { ssr: false },
+);
+
+const Index: NextPage = () => {
+  const view = useView();
+  const { web } = useConfig();
+  const openId = useQueryHistory(s => s.openId);
+  const close = useQueryHistory(s => s.close);
+  const entries = useQueryHistory(s => s.entries);
+
+  const openEntry = openId ? entries.find(e => e.id === openId) : undefined;
+
+  if (openEntry) {
+    const items: SnapshotResultsItem[] = Object.entries(openEntry.results).map(
+      ([queryLocation, snapshot]) => ({ queryLocation, snapshot: snapshot as ResultSnapshot }),
+    );
+    return (
+      <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
+        <Flex justify="flex-start" mb={2}>
+          <Button size="sm" variant="ghost" onClick={close}>
+            {web.text.historyBack}
+          </Button>
+        </Flex>
+        <SnapshotResults items={items} showShare />
+      </Box>
+    );
+  }
+
+  return (
+    <If condition={view === 'results'}>
+      <Then>
+        <Results />
+      </Then>
+      <Else>
+        <AnimatePresence>
+          <LookingGlassForm />
+        </AnimatePresence>
+        <RecentQueries />
+      </Else>
+    </If>
+  );
+};
+
+export default Index;
+```
+
+- [ ] **Step 2: Typecheck + full UI test run**
+
+Run: `pnpm --dir ./hyperglass/ui typecheck && pnpm --dir ./hyperglass/ui test`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hyperglass/ui/pages/index.tsx
+git commit -m "feat(ui): wire RecentQueries and history-open view into landing page"
+```
+
+---
+
+### Task 21: Render the history hint in the form and result header
+
+**Files:**
+- Modify: `hyperglass/ui/components/looking-glass-form.tsx` (Query Type `labelAddOn`)
+- Modify: `hyperglass/ui/components/results/individual.tsx` (result header `HStack`)
+
+- [ ] **Step 1: Add the hint to the form**
+
+In `hyperglass/ui/components/looking-glass-form.tsx`, the Query Type `FormField` already has a `labelAddOn` rendering `DirectiveInfoModal`. Render the hint next to it. Import:
+
+```ts
+import { HistoryDisabledHint } from '~/components/history';
+```
+
+Change the `labelAddOn` expression to include the hint (wrap both in a fragment):
+
+```tsx
+              labelAddOn={
+                directive !== null && (
+                  <>
+                    <DirectiveInfoModal
+                      name="queryType"
+                      title={directive.name ?? null}
+                      item={directive.info ?? null}
+                      visible={selections.queryType !== null && directive.info !== null}
+                    />
+                    <HistoryDisabledHint directiveHistory={directive.history} />
+                  </>
+                )
+              }
+```
+
+- [ ] **Step 2: Add the hint to the live result header**
+
+In `hyperglass/ui/components/results/individual.tsx`, inside the header `HStack` (where `ShareButton`/`CopyButton`/`RequeryButton` render), add — only for live results (not snapshots):
+
+```tsx
+          {!snapshot && <HistoryDisabledHint directiveHistory={getDirective()?.history ?? true} />}
+```
+
+Add the import:
+
+```ts
+import { HistoryDisabledHint } from '~/components/history';
+```
+
+- [ ] **Step 3: Typecheck + tests**
+
+Run: `pnpm --dir ./hyperglass/ui typecheck && pnpm --dir ./hyperglass/ui test components/looking-glass-form.test.tsx components/results/individual.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hyperglass/ui/components/looking-glass-form.tsx hyperglass/ui/components/results/individual.tsx
+git commit -m "feat(ui): show history-disabled hint in form and result header"
+```
+
+---
+
+## Phase 9 — Verification & docs
+
+### Task 22: Full lint, typecheck, and test sweep
+
+- [ ] **Step 1: Backend**
+
+Run: `pytest hyperglass --ignore hyperglass/plugins/external -q`
+Expected: PASS (all new + existing tests).
+
+- [ ] **Step 2: Backend lint**
+
+Run: `task lint`
+Expected: zero Ruff errors.
+
+- [ ] **Step 3: Frontend**
+
+Run: `pnpm --dir ./hyperglass/ui test && pnpm --dir ./hyperglass/ui typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Frontend lint/format**
+
+Run: `task ui-lint`
+Expected: zero Biome errors. If formatting differs, run `task ui-format` and re-commit.
+
+- [ ] **Step 5: Commit any lint/format fixes**
+
+```bash
+git add -A
+git commit -m "chore: lint/format pass for query-history" || echo "nothing to commit"
+```
+
+---
+
+### Task 23: Manual verification (no automated coverage)
+
+- [ ] Start hyperglass against a dev install with at least two devices that share a directive.
+- [ ] Run a single-device query; return to the pristine form (click the title/reset); confirm the entry appears under "Recent queries" with a relative timestamp.
+- [ ] Click **Open**; confirm the cached output renders and each result shows a Share button.
+- [ ] Click **Share** on a single-device row; confirm a link is minted (or a graceful "expired" message after `cache.timeout`).
+- [ ] Click **Re-run**; confirm a fresh query runs and a new (distinct) entry is added.
+- [ ] Click **New target**; confirm the form is populated with the location/type and an empty target.
+- [ ] **Delete** one entry and **Clear all**; reload the page and confirm persistence/clearing behavior.
+- [ ] Run > `history_limit` distinct queries; confirm the oldest are evicted.
+- [ ] Set a directive `history: false`, rebuild the UI; confirm its queries are never recorded and the hint shows by Query Type and in the result header.
+- [ ] Set `cache.history_enabled: false`, rebuild the UI; confirm the list and the hint are both gone.
+
+---
+
+### Task 24: Docs and changelog
+
+**Files:**
+- Modify: operator configuration docs (the same doc that documents `cache.share_*` — find via `grep -rn "share_enabled" docs/`).
+- Modify: `CHANGELOG` (Keep a Changelog format, mirror the share-results entry).
+
+- [ ] **Step 1: Document the config**
+
+Add documentation for `cache.history_enabled` (default true), `cache.history_limit` (default 10), and the per-directive `history` flag (default true). Note that, like all UI config, changing these requires a UI rebuild. Note the privacy caution: history stores query targets in the browser; disable or lower the limit on shared/public terminals.
+
+- [ ] **Step 2: Changelog entry**
+
+Add an "Added" entry: "Per-browser query history on the landing page (Open / Share / Re-run / Re-run with new target / Delete), with an operator kill-switch (`cache.history_enabled`), retention limit (`cache.history_limit`), and per-directive opt-out (`directives.<id>.history`)."
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs CHANGELOG*
+git commit -m "docs: document query-history config and behavior"
+```
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **camelCase reminder:** backend `history_enabled` → UI `cache.historyEnabled`; `Text.history_open` → `web.text.historyOpen`; directive `history` stays `history`. All UI snippets in this plan already use the camelCased property names — match that when adding any further `web.text`/`cache`/`messages` access.
+- **`TestWrapper`/`~/test/wrapper`** is a placeholder for whatever shared render helper the UI tests already use — inspect `hyperglass/ui/components/looking-glass-form.test.tsx` and reuse its provider setup (Chakra + `HyperglassProvider`/config). If none is shared, factor one out in Task 11 Step 1 and reuse it.
+- **Recording-once invariant:** the effect deps `[dataUpdatedAt, submissionId]` capture both fresh and cache-served settles; `record()` is an idempotent upsert, so re-firing for the same `(submissionId, deviceId)` overwrites rather than duplicates.
+- **Eviction layering:** `record()` slices to `limit`; `historyStorage` handles the rarer "still too big" quota case by stripping outputs then dropping entries.

--- a/docs/superpowers/plans/2026-06-04-query-history.md
+++ b/docs/superpowers/plans/2026-06-04-query-history.md
@@ -12,6 +12,13 @@
 
 **Key environment facts:**
 - Zustand is **v3** (`^3.7.2`). The `persist` middleware uses `getStorage: () => StateStorage` (NOT v4's `createJSONStorage`). Mirror the existing store in `hyperglass/ui/hooks/use-greeting.ts`.
+
+> ⚠️ **Version assumption — READ FIRST.** This plan was authored against **zustand v3**. A separate PR/session may upgrade zustand to **v4/v5 first** (decided 2026-06-04). **Before implementing, check `hyperglass/ui/package.json`.** If zustand is now v4+, apply these deltas to the affected tasks:
+> - **Imports (Tasks 9):** `import create from 'zustand'` → `import { create } from 'zustand'`. (Match whatever style the upgraded `use-greeting.ts` / `use-form-state.ts` now use.)
+> - **Persist storage (Task 9):** replace `getStorage: () => historyStorage` with `storage: createJSONStorage(() => historyStorage)` — but note v4's `createJSONStorage` expects a `StateStorage` returning **strings**, which `historyStorage` already does; confirm the wrapper still receives the serialized blob so `shrinkSerialized` (Task 8) keeps working unchanged.
+> - **Hydration (Task 19):** the mounted-flag guard still works and remains the recommended approach; optionally simplify using v4's `useQueryHistory.persist.hasHydrated()` if the upgraded codebase adopts that pattern elsewhere.
+> - **`withDev` (Task 9 dependency):** if the upgrade rewrote `util/state.ts` for v4 middleware typing, ensure `withDev<QueryHistoryState>(...)` still composes inside `persist(...)`; mirror the post-upgrade `use-greeting.ts` composition order exactly.
+> Everything else in this plan (backend config, components, recording, prefillForm, SnapshotResults) is version-independent.
 - `Directive.frontend()` (`hyperglass/models/directive.py:334`) **whitelists** UI-visible fields — a new directive field must be added there explicitly.
 - `Params.frontend()` (`hyperglass/models/config/params.py:158`) includes `web` and `messages` wholesale (`"web": ...`, `"messages": ...`), so new `Text`/`Messages` fields reach the UI automatically; only the `cache` include set must be edited.
 - Backend attrs are snake_case; `HyperglassModel` camelCases JSON keys. UI config types are written snake_case and run through `CamelCasedProperties`.

--- a/docs/superpowers/specs/2026-06-03-query-history-design.md
+++ b/docs/superpowers/specs/2026-06-03-query-history-design.md
@@ -18,7 +18,8 @@ This builds directly on the already-merged **share-results** feature (`/api/quer
 - Surface them on the landing page, below the form, on the clean (pristine) form view.
 - Per entry, offer four actions plus delete: **Open** (locally-cached output), **Share** (single-device, reusing share-results), **Re-run**, **New target** (re-run with a different target), **Delete**.
 - Keep a **timeline** of runs — repeated runs of the same query are distinct entries so a user can see how output evolved.
-- Operator-configurable: a kill-switch and a retention count, flowing through the same build-time config path as `share_enabled`.
+- Operator-configurable: a global kill-switch, a retention count, and a **per-directive opt-out** (for sensitive query types), flowing through the existing config paths.
+- **Frontend hint** when the selected query type has history disabled, so the absence of a saved entry is explained rather than mysterious.
 - No hard-coded user-visible strings (CLAUDE.md).
 - Mobile-friendly and Lighthouse-100 accessible.
 
@@ -44,6 +45,7 @@ This builds directly on the already-merged **share-results** feature (`/api/quer
 | 7 | **Inline icon-button row per entry**, reusing the result-header idiom (ghost `Button` + `DynamicIcon` + `Tooltip`). | Visual consistency with the existing result controls. |
 | 8 | **Row Share only for single-device entries.** Multi-device entries' Share icon Opens the entry, where each rendered `Result` carries its own per-device `ShareButton`. | A multi-device entry has one `cacheId` per device — a single row-level share is ambiguous. |
 | 9 | **Zustand store + `persist` middleware** (Approach 1), not a bespoke hook or the existing form store. | Idiomatic here; `persist` handles serialization/versioning; keeps the ephemeral `useFormState` clean. |
+| 10 | **Per-directive history opt-out** via a `history: bool = True` field on the `Directive` model. Effective recording = `cache.history_enabled` **AND** `directive.history`. When the global is on but the directive opts out, the UI shows a hint that this query type isn't saved. | Some query types expose sensitive targets/output that shouldn't persist in localStorage; per-directive control is finer than the global switch, and directives already carry their own UI-affecting fields. |
 
 ## Architecture
 
@@ -108,12 +110,15 @@ Device results arrive asynchronously (each `Result` runs its own `useLGQuery`). 
 
 ```ts
 useEffect(() => {
-  if (!historyEnabled || snapshot || readOnly) return;        // skip share/history-open renders
+  // skip when disabled globally or per-directive, and on share/history-open renders
+  if (!historyEnabled || !directiveHistory || snapshot || readOnly) return;
   if (data?.level === 'success' && submissionId) {
     recordHistory({ submissionId, deviceId, deviceLabel, query, labels, snapshot: toSnapshot(data), limit });
   }
 }, [dataUpdatedAt, submissionId]);
 ```
+
+`directiveHistory` is the selected directive's `history` flag, looked up from `form.queryType`. `useRecordHistory` no-ops when either the global switch or the directive flag is off, so a directive opt-out is enforced at the recording site regardless of caller.
 
 `record()` is an **idempotent upsert** by `submissionId`: create the entry if absent (stamp `savedAt`), set `results[deviceId]`, merge the device label into `labels.locations`, add `deviceId` to `query.queryLocation`, and move the entry to the front. A force-refresh (same `submissionId`) just overwrites that run's snapshot. The existing in-memory `addResponse(device.id, data)` is left untouched.
 
@@ -156,6 +161,7 @@ interface QueryHistoryState {
 
 - **`components/history/recent-queries.tsx`** — list container. Renders only when `cache.historyEnabled` AND `entries.length > 0` AND `!useFormInteractive()` (pristine landing view), and only after `persist` rehydration (avoids `next export` hydration mismatch). Header: `historyTitle` label + a Clear-all button that confirms (Chakra `AlertDialog`/`Popover`) before `clear()`.
 - **`components/history/history-entry-row.tsx`** — one row per entry, result-header button idiom. Left: location label(s) · type label · target · prominent relative timestamp (`dayjs().fromNow()`). Right icon row: **Open** (`FiEye`), **Share** (`FiShare2`, single-device only — renders the existing `ShareButton` with `cacheId`), **Re-run** (`FiRepeat`), **New target** (`FiEdit`), **Delete** (`FiTrash2`). Icon-only buttons carry `aria-label`s from config.
+- **`components/history/history-disabled-hint.tsx`** — a small icon (`FiEyeOff`) + `Tooltip` carrying the config string `historyDisabledHint`. Rendered when `cache.historyEnabled && selectedDirective.history === false`. Placed (a) in the form next to the Query Type field, via the existing `labelAddOn` slot already used by `DirectiveInfoModal`, and (b) in the live result header, so the "not saved" state is visible both before and after submitting. Hidden entirely when global history is off (nothing is saved regardless, so the per-directive note would be noise).
 
 ### View switch — `pages/index.tsx`
 
@@ -181,14 +187,14 @@ else → <LookingGlassForm /> + <RecentQueries />
 - `Result.snapshot` prop type: `ShareResponse` → `ResultSnapshot` (`ShareResponse extends ResultSnapshot`; every field the component reads is already in `ResultSnapshot`).
 - Decouple the overloaded `readOnly`: add `showShare?: boolean` (default `!readOnly`). Share render → `{showShare && data?.id && <ShareButton/>}`; Requery stays `{!readOnly && …}`. History-open passes `readOnly` (no Requery) **+ `showShare`** (per-device Share visible) — enabling multi-device sharing after Open. `pages/result/[id].tsx` keeps `readOnly` (Share stays hidden there, unchanged behavior).
 
-### TypeScript types — `types/config.d.ts`, `types/globals.d.ts`
+### TypeScript types — `types/config.ts`, `types/globals.d.ts`
 
-- `config.d.ts`: add `historyEnabled: boolean`, `historyLimit: number` under `cache`; add the new `web.text` history strings; add `messages.historyDeviceUnavailable`.
+- `config.ts`: add `history_enabled: boolean`, `history_limit: number` under the cache type (camelized to `historyEnabled`/`historyLimit`); add `history: boolean` to `_DirectiveBase` (→ `directive.history`); add the new `web.text` history strings; add `messages.historyDeviceUnavailable`.
 - `globals.d.ts` (or wherever response types live): add `ResultSnapshot`; make `ShareResponse extends ResultSnapshot`.
 
 ### i18n — no hard-coded strings
 
-New `web.text` fields (defaults in the backend `Text` model, projected to the frontend, added to the UI `Text` type — same path share-results used): `historyTitle`, `historyClearAll`, `historyClearConfirm`, `historyBack`, `historyOpen`, `historyShare`, `historyRerun`, `historyNewTarget`, `historyDelete`. New `messages.historyDeviceUnavailable` (error-shaped). Relative time via `dayjs().fromNow()` — no literal copy.
+New `web.text` fields (defaults in the backend `Text` model, projected to the frontend, added to the UI `Text` type — same path share-results used): `historyTitle`, `historyClearAll`, `historyClearConfirm`, `historyBack`, `historyOpen`, `historyShare`, `historyRerun`, `historyNewTarget`, `historyDelete`, `historyDisabledHint`. New `messages.historyDeviceUnavailable` (error-shaped). Relative time via `dayjs().fromNow()` — no literal copy.
 
 ## Backend changes
 
@@ -217,6 +223,17 @@ Extend the `cache` include set so the two new fields ship in build-time `hypergl
 
 `/api/info` and `APIParams` are untouched. Like all UI config, flipping these requires a UI rebuild — documented alongside the feature.
 
+### `hyperglass/models/directive.py`
+
+Add `history: bool = True` to the `Directive` model. Project it to the UI by adding `"history": self.history` to the dict returned by `Directive.frontend()` (which whitelists UI-visible fields). `BuiltinDirective` inherits the field; built-ins default to `True`. In directive YAML it reads naturally:
+
+```yaml
+directives:
+  my-sensitive-directive:
+    name: Sensitive Lookup
+    history: false
+```
+
 ### Backend `Text` model
 
 Add the new history string fields (with defaults) to the `Text` model and ensure they project to the frontend `web.text`, mirroring how share-results added its strings.
@@ -225,7 +242,9 @@ Add the new history string fields (with defaults) to the `Text` model and ensure
 
 | Case | Behavior |
 |------|----------|
-| `history_enabled = false` | Recording no-ops; `RecentQueries` hidden. Existing localStorage entries remain but are never shown. |
+| `history_enabled = false` | Recording no-ops; `RecentQueries` hidden; per-directive hint suppressed. Existing localStorage entries remain but are never shown. |
+| Directive `history: false` | That query type is never recorded; the form (next to Query Type) and the result header show the hint — but only while global history is on. |
+| Directive toggled off after entries exist | Previously-recorded entries remain (no retroactive deletion); only future runs are skipped. |
 | Output too big to store | Entry kept without `output`; row swaps Open → Re-run (tooltip explains). |
 | Device renamed/removed | Open still works (frozen snapshot/labels). Re-run / New-target hit the stale-device guard → toast `historyDeviceUnavailable`. |
 | `cacheId` aged out of Redis | Share returns 410 → existing `shareCreateExpired` message. |
@@ -244,13 +263,15 @@ Add the new history string fields (with defaults) to the `Text` model and ensure
 - **Store** (mocked localStorage): upsert + group by `submissionId`; promote-to-front; N-cap eviction; quota → drop-oldest then strip-output; `remove`; `clear`; persist round-trip; `crypto.randomUUID` fallback.
 - **`RecentQueries`**: hidden when disabled / empty / form-interactive; renders rows; clear-all confirm flow; renders only after rehydration.
 - **`HistoryEntryRow`**: Share icon only on single-device entries; Open → `open()`; Delete → `remove()`; Re-run sets store + status + new `submissionId`; New-target sets store + empty target; stale-device guard toasts; output-stripped entry swaps Open → Re-run.
-- **`Result`**: `showShare` defaults to `!readOnly`; history mode (readOnly + showShare) shows Share, hides Requery; snapshot renders.
+- **`Result`**: `showShare` defaults to `!readOnly`; history mode (readOnly + showShare) shows Share, hides Requery; snapshot renders; recording is skipped when `directive.history === false`.
 - **`SnapshotResults`**: renders N results for a multi-device entry.
+- **`HistoryDisabledHint`**: renders when `historyEnabled && !directive.history`; hidden when global history is off or the directive allows history.
 
 ### Backend (pytest, `hyperglass/`)
 
 - `Cache` defaults: `history_enabled is True`, `history_limit == 10`.
 - `Params.frontend()` projects `history_enabled` / `history_limit` into the cache include set (and they appear in the serialized output).
+- `Directive.history` defaults to `True`; `Directive.frontend()` includes `history` in its output.
 - `Text` model exposes the new history string defaults and they project to the frontend.
 
 ### Manual
@@ -260,6 +281,7 @@ Add the new history string fields (with defaults) to the `Text` model and ensure
 - Single-device query: row Share mints a link (or 410s gracefully after `cache.timeout`).
 - Re-run and New-target prefill correctly, including multi-device.
 - Delete and Clear-all behave; survive reload; respect `history_limit`; `history_enabled=false` hides the list after a rebuild.
+- A directive with `history: false`: queries of that type never appear in history, and the hint shows next to Query Type and in the result header (and disappears entirely when global history is off).
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-06-03-query-history-design.md
+++ b/docs/superpowers/specs/2026-06-03-query-history-design.md
@@ -1,0 +1,277 @@
+# Query History — Design
+
+**Status:** Draft
+**Date:** 2026-06-03
+**Owner:** Jonathan Senecal
+
+## Problem
+
+A user who runs a query in hyperglass has no way to revisit it. The result lives only in the requesting browser's in-memory Zustand store (`useFormState.responses`) and is lost on reload or navigation. To re-run yesterday's `BGP Route` lookup, the user must re-enter location, type, and target by hand. There is no record of what was asked, no quick re-run, and no way to compare how a result evolved between runs.
+
+We want a **per-browser query history** surfaced on the landing page: a list of recent successful queries the user can click to re-open the locally-cached output, share (if still cached server-side), re-run, or re-run against a different target.
+
+This builds directly on the already-merged **share-results** feature (`/api/query/share/*`, the `ShareButton`, the read-only `Result` snapshot rendering, and `QueryResponse.id`).
+
+## Goals
+
+- Persist recent **successful** queries per browser (localStorage), surviving reloads and visits.
+- Surface them on the landing page, below the form, on the clean (pristine) form view.
+- Per entry, offer four actions plus delete: **Open** (locally-cached output), **Share** (single-device, reusing share-results), **Re-run**, **New target** (re-run with a different target), **Delete**.
+- Keep a **timeline** of runs — repeated runs of the same query are distinct entries so a user can see how output evolved.
+- Operator-configurable: a kill-switch and a retention count, flowing through the same build-time config path as `share_enabled`.
+- No hard-coded user-visible strings (CLAUDE.md).
+- Mobile-friendly and Lighthouse-100 accessible.
+
+## Non-goals
+
+- Server-side / cross-device history (history is per-browser localStorage only).
+- Recording **failed** queries (timeouts, device errors). Only successful device results are stored.
+- Cross-submission dedupe / collapsing identical queries (explicitly rejected — we keep each run as a timeline point).
+- Any new backend storage or endpoints beyond two config fields. History is a frontend feature; it reuses the existing share endpoints for the Share action.
+- Editing a stored query in place (other than the "New target" re-run affordance).
+- Syncing the retention limit at runtime — like all UI config, it ships at build time and a change requires a UI rebuild.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Per-submission grouping.** One history entry = one Submit click, holding the form query plus every successful device result. Clicking Open replays the exact multi-device accordion. | Mirrors today's in-memory `responses` map and the existing `Result`/`Accordion` rendering. |
+| 2 | **Successful results only.** Failed device results are never recorded. A fully-failed submission records nothing; a partially-failed one records the successful subset. | Matches share-results' "no failed queries" rule; Open always shows usable output. |
+| 3 | **No dedupe — keep a timeline.** Each Submit (including Re-run from history) is a distinct entry with its own timestamp. | For a looking glass, watching how a route/ping evolves across runs is valuable; dedupe would destroy that signal. |
+| 4 | **localStorage, on by default**, with an operator kill-switch (`history_enabled`), a configurable retention count (`history_limit`, default 10), a clear-all control, and a per-entry delete. | Convenient by default, operator-controlled on sensitive/public deployments, matching the `share_enabled` pattern. |
+| 5 | **Count cap + FIFO + graceful output drop.** Keep newest N; on quota error drop oldest, then (if a single entry is still too big) store it without its output so Open falls back to Re-run. | Predictable footprint; never throws; full BGP tables can be large. |
+| 6 | **Inline below the form, landing only.** The list shows on the pristine form view and unmounts once the form is interactive or results show. | Zero-click discoverability without cluttering the active query flow (chosen over a drawer / collapsed strip). |
+| 7 | **Inline icon-button row per entry**, reusing the result-header idiom (ghost `Button` + `DynamicIcon` + `Tooltip`). | Visual consistency with the existing result controls. |
+| 8 | **Row Share only for single-device entries.** Multi-device entries' Share icon Opens the entry, where each rendered `Result` carries its own per-device `ShareButton`. | A multi-device entry has one `cacheId` per device — a single row-level share is ambiguous. |
+| 9 | **Zustand store + `persist` middleware** (Approach 1), not a bespoke hook or the existing form store. | Idiomatic here; `persist` handles serialization/versioning; keeps the ephemeral `useFormState` clean. |
+
+## Architecture
+
+```
+                        ┌─────────────────────────────────────────────┐
+                        │ pages/index.tsx (view switch)                │
+                        │   openId? → SnapshotResults (history-open)   │
+                        │   else view==='results' → Results (live)     │
+                        │   else → LookingGlassForm + RecentQueries    │
+                        └───────────────┬─────────────────────────────┘
+                                        │
+        ┌───────────────────────────────┼───────────────────────────────┐
+        │                               │                               │
+┌───────▼────────┐            ┌─────────▼─────────┐           ┌─────────▼──────────┐
+│ RecentQueries  │            │ Result (in        │           │ useQueryHistory    │
+│  + EntryRow ×N │ actions →  │  Results view)    │ records → │  (zustand+persist) │
+│  Open/Share/   │            │  effect on        │           │  entries[]         │
+│  Re-run/New/Del│            │  dataUpdatedAt     │           │  record/remove/    │
+└───────┬────────┘            └───────────────────┘           │  clear/open/close  │
+        │ Open                                                 └─────────┬──────────┘
+        │ prefillForm (Re-run/New target) → useFormState                 │ persist
+        │ ShareButton (single-device) → /api/query/share/<cacheId>       ▼
+        ▼                                                       localStorage
+   SnapshotResults ← reused by pages/result/[id].tsx           "hyperglass.queryHistory"
+```
+
+History is entirely client-side. The only backend touch points are: (a) the existing share endpoints, used unchanged by the row Share action; and (b) two new config fields projected into the build-time `hyperglass.json`.
+
+## Data model
+
+localStorage key `hyperglass.queryHistory`, written through Zustand `persist` (`version: 1`, `migrate` stub, `partialize` → persist only `entries`).
+
+```ts
+// NEW shared interface. ShareResponse is refactored to `extends ResultSnapshot`.
+interface ResultSnapshot {
+  id: string;                       // backend cache id — used for share attempts
+  output: QueryResponse['output'];
+  format: QueryResponse['format'];
+  level: ResponseLevel;
+  timestamp: string;
+  runtime: number;
+  cached: boolean;
+  keywords: string[];
+  queryLabels: { location: string };
+}
+
+interface HistoryEntry {
+  id: string;                       // local id == submissionId (crypto.randomUUID)
+  savedAt: number;                  // epoch ms
+  query: { queryLocation: string[]; queryType: string; queryTarget: string[] };
+  labels: { locations: string[]; type: string; target: string }; // frozen display strings
+  results: Record<string, ResultSnapshot>;   // keyed by device id; successful results only
+}
+```
+
+- `query.queryLocation` and `labels.locations` reflect the **successful subset** (the keys of `results`). A partially-failed submission therefore re-runs only the devices that worked — the honest consequence of "successful only."
+- `labels.*` are frozen at write time so a later device rename/removal does not break the row display or Open.
+
+### Recording
+
+Device results arrive asynchronously (each `Result` runs its own `useLGQuery`). Recording is triggered by a small effect in `Result`, keyed on `dataUpdatedAt` + `submissionId` — **not** React Query's `onSuccess`, which does not fire when a result is served from RQ's in-memory cache without a refetch (which would silently skip recording on some re-runs):
+
+```ts
+useEffect(() => {
+  if (!historyEnabled || snapshot || readOnly) return;        // skip share/history-open renders
+  if (data?.level === 'success' && submissionId) {
+    recordHistory({ submissionId, deviceId, deviceLabel, query, labels, snapshot: toSnapshot(data), limit });
+  }
+}, [dataUpdatedAt, submissionId]);
+```
+
+`record()` is an **idempotent upsert** by `submissionId`: create the entry if absent (stamp `savedAt`), set `results[deviceId]`, merge the device label into `labels.locations`, add `deviceId` to `query.queryLocation`, and move the entry to the front. A force-refresh (same `submissionId`) just overwrites that run's snapshot. The existing in-memory `addResponse(device.id, data)` is left untouched.
+
+`submissionId` is a fresh `crypto.randomUUID()` (with a tiny fallback for environments lacking it) generated **once per Submit** in `LookingGlassForm.submitHandler` and on Re-run, stored on `useFormState`.
+
+### Retention & eviction
+
+- Keep the newest **N** entries (`history_limit`, default 10).
+- A custom `persist` `storage` (wrapping `createJSONStorage(() => localStorage)`):
+  - slices to N on every write;
+  - on `QuotaExceededError`, drops oldest entries one at a time and retries;
+  - if a single entry alone still won't fit, stores it with `results` stripped (metadata only). Such an entry's row swaps **Open → Re-run** (tooltip notes the local copy was dropped).
+  - all access is `try/catch`'d; if localStorage is unavailable (private mode), the feature degrades to in-memory for the session without crashing.
+
+## Frontend changes
+
+### Store — `hooks/use-query-history.ts`
+
+```ts
+interface QueryHistoryState {
+  entries: HistoryEntry[];
+  openId: string | null;            // UI-only, NOT persisted
+  record(input: RecordInput): void; // upsert by submissionId, promote to front, apply limit
+  remove(id: string): void;
+  clear(): void;
+  open(id: string): void;
+  close(): void;
+}
+```
+
+`record()` takes `limit` in its input (supplied by the calling hook from `useConfig()`), keeping the store config-agnostic. `useRecordHistory()` is a thin wrapper hook that reads `cache.historyEnabled` + `cache.historyLimit` and no-ops when disabled.
+
+### `useFormState` extraction — `prefillForm`
+
+`locationChange` currently bundles the directive-intersection computation (`filtered.types`) with react-hook-form error signaling. Extract the **pure state computation** into a reusable `prefillForm(query, getDevice)` store action (sets `form`, `selections`, `filtered`; no RHF). `locationChange` calls that core plus its error handling. History actions use `prefillForm` and need no FormProvider/RHF access — the Results view renders purely from store form values.
+
+`prefillForm` filters locations through `getDevice`; if no valid devices remain (renamed/removed), Re-run/New-target abort and toast `messages.historyDeviceUnavailable`.
+
+### Components
+
+- **`components/history/recent-queries.tsx`** — list container. Renders only when `cache.historyEnabled` AND `entries.length > 0` AND `!useFormInteractive()` (pristine landing view), and only after `persist` rehydration (avoids `next export` hydration mismatch). Header: `historyTitle` label + a Clear-all button that confirms (Chakra `AlertDialog`/`Popover`) before `clear()`.
+- **`components/history/history-entry-row.tsx`** — one row per entry, result-header button idiom. Left: location label(s) · type label · target · prominent relative timestamp (`dayjs().fromNow()`). Right icon row: **Open** (`FiEye`), **Share** (`FiShare2`, single-device only — renders the existing `ShareButton` with `cacheId`), **Re-run** (`FiRepeat`), **New target** (`FiEdit`), **Delete** (`FiTrash2`). Icon-only buttons carry `aria-label`s from config.
+
+### View switch — `pages/index.tsx`
+
+Add the in-place history-open mode:
+
+```
+if (openId && entry) → <SnapshotResults entries=[…] /> + Back (close())
+else if view === 'results' → <Results />
+else → <LookingGlassForm /> + <RecentQueries />
+```
+
+### Actions
+
+- **Open** — `open(entry.id)`; renders `SnapshotResults` from `entry.results`; no backend call. Back → `close()`.
+- **Re-run** — `prefillForm(entry.query, getDevice)` → set `queryTarget` → new `submissionId` → `setStatus('results')`. Concrete stored target skips the FQDN resolve modal.
+- **New target** — `prefillForm({ ...entry.query, queryTarget: [] }, getDevice)`, keep `status: 'form'`; the populated form appears with an empty Target field (best-effort focus once it slides in).
+- **Share** (single-device) — inline `<ShareButton cacheId={theSingleResult.id} />`; reuses its popover, copy, `410 → shareCreateExpired`, and `cache.shareEnabled` gate.
+- **Delete** — `remove(entry.id)`.
+
+### `Result` / `SnapshotResults` refactor
+
+- Extract **`SnapshotResults`** (`components/results/snapshot-results.tsx`) from the inline `AnimatedDiv + Accordion` markup in `pages/result/[id].tsx`. Takes `Array<{ queryLocation: string; snapshot: ResultSnapshot }>`, renders one `<Result>` each. Reused by the share page (single) and history-open (1..N).
+- `Result.snapshot` prop type: `ShareResponse` → `ResultSnapshot` (`ShareResponse extends ResultSnapshot`; every field the component reads is already in `ResultSnapshot`).
+- Decouple the overloaded `readOnly`: add `showShare?: boolean` (default `!readOnly`). Share render → `{showShare && data?.id && <ShareButton/>}`; Requery stays `{!readOnly && …}`. History-open passes `readOnly` (no Requery) **+ `showShare`** (per-device Share visible) — enabling multi-device sharing after Open. `pages/result/[id].tsx` keeps `readOnly` (Share stays hidden there, unchanged behavior).
+
+### TypeScript types — `types/config.d.ts`, `types/globals.d.ts`
+
+- `config.d.ts`: add `historyEnabled: boolean`, `historyLimit: number` under `cache`; add the new `web.text` history strings; add `messages.historyDeviceUnavailable`.
+- `globals.d.ts` (or wherever response types live): add `ResultSnapshot`; make `ShareResponse extends ResultSnapshot`.
+
+### i18n — no hard-coded strings
+
+New `web.text` fields (defaults in the backend `Text` model, projected to the frontend, added to the UI `Text` type — same path share-results used): `historyTitle`, `historyClearAll`, `historyClearConfirm`, `historyBack`, `historyOpen`, `historyShare`, `historyRerun`, `historyNewTarget`, `historyDelete`. New `messages.historyDeviceUnavailable` (error-shaped). Relative time via `dayjs().fromNow()` — no literal copy.
+
+## Backend changes
+
+### `hyperglass/models/config/cache.py`
+
+```python
+class Cache(HyperglassModel):
+    timeout: int = 600
+    show_text: bool = True
+    share_enabled: bool = True
+    share_timeout: int = 604800
+    share_sliding: bool = False
+    refresh_min_interval: int = 120
+    history_enabled: bool = True      # NEW — UI kill switch
+    history_limit: int = 10           # NEW — UI retention count
+```
+
+### `Params.frontend()` — `hyperglass/models/config/params.py`
+
+Extend the `cache` include set so the two new fields ship in build-time `hyperglass.json`:
+
+```python
+"cache": {"show_text", "timeout", "share_enabled", "share_timeout",
+          "refresh_min_interval", "history_enabled", "history_limit"},
+```
+
+`/api/info` and `APIParams` are untouched. Like all UI config, flipping these requires a UI rebuild — documented alongside the feature.
+
+### Backend `Text` model
+
+Add the new history string fields (with defaults) to the `Text` model and ensure they project to the frontend `web.text`, mirroring how share-results added its strings.
+
+## Edge cases
+
+| Case | Behavior |
+|------|----------|
+| `history_enabled = false` | Recording no-ops; `RecentQueries` hidden. Existing localStorage entries remain but are never shown. |
+| Output too big to store | Entry kept without `output`; row swaps Open → Re-run (tooltip explains). |
+| Device renamed/removed | Open still works (frozen snapshot/labels). Re-run / New-target hit the stale-device guard → toast `historyDeviceUnavailable`. |
+| `cacheId` aged out of Redis | Share returns 410 → existing `shareCreateExpired` message. |
+| Multi-device partial success | Entry holds the successful subset only. |
+| Fully-failed submission | No entry recorded. |
+| localStorage unavailable (private mode) | Storage adapter try/catches; in-memory for the session, no crash. |
+| `next export` hydration | `RecentQueries` renders only after `persist` rehydrates → no SSR mismatch. |
+| No `crypto.randomUUID` | Tiny fallback id generator. |
+| Force-refresh in the live Results view | Same `submissionId` → upsert overwrites that run's snapshot (not a new entry). |
+| Re-run from history | New Submit → new `submissionId` → new timeline entry. |
+
+## Testing
+
+### Frontend (Vitest, `hyperglass/ui/`)
+
+- **Store** (mocked localStorage): upsert + group by `submissionId`; promote-to-front; N-cap eviction; quota → drop-oldest then strip-output; `remove`; `clear`; persist round-trip; `crypto.randomUUID` fallback.
+- **`RecentQueries`**: hidden when disabled / empty / form-interactive; renders rows; clear-all confirm flow; renders only after rehydration.
+- **`HistoryEntryRow`**: Share icon only on single-device entries; Open → `open()`; Delete → `remove()`; Re-run sets store + status + new `submissionId`; New-target sets store + empty target; stale-device guard toasts; output-stripped entry swaps Open → Re-run.
+- **`Result`**: `showShare` defaults to `!readOnly`; history mode (readOnly + showShare) shows Share, hides Requery; snapshot renders.
+- **`SnapshotResults`**: renders N results for a multi-device entry.
+
+### Backend (pytest, `hyperglass/`)
+
+- `Cache` defaults: `history_enabled is True`, `history_limit == 10`.
+- `Params.frontend()` projects `history_enabled` / `history_limit` into the cache include set (and they appear in the serialized output).
+- `Text` model exposes the new history string defaults and they project to the frontend.
+
+### Manual
+
+- Run a query; confirm it appears in Recent queries on returning to the pristine form.
+- Multi-device query: Open replays all device results; each shows its own Share button.
+- Single-device query: row Share mints a link (or 410s gracefully after `cache.timeout`).
+- Re-run and New-target prefill correctly, including multi-device.
+- Delete and Clear-all behave; survive reload; respect `history_limit`; `history_enabled=false` hides the list after a rebuild.
+
+## Risks
+
+- **localStorage footprint.** Capped by `history_limit` and graceful eviction, but large structured outputs (full BGP tables) consume the per-origin quota quickly. Operators on shared kiosks may lower `history_limit` or disable the feature.
+- **Privacy on shared machines.** History persists query targets in the browser for the next user. Mitigated by the operator kill-switch, clear-all, and per-entry delete; documented in operator docs (the same caution share-results raised about sensitive output).
+- **Coupling to share-results internals.** The refactor touches `Result` and extracts `SnapshotResults` from `pages/result/[id].tsx`. A future change to either must keep the share page and history-open in sync (mitigated by `SnapshotResults` being the single rendering source).
+- **Recording-trigger correctness.** Relying on a `dataUpdatedAt`-keyed effect rather than `onSuccess` is deliberate (cache-served results). Tests must cover both fresh-fetch and cache-served paths to prevent silent non-recording regressions.
+
+## Deferred
+
+- Server-side / cross-device history.
+- Recording failed queries (for "retry what just failed").
+- A dedicated full-page history view or a results-view-reachable drawer (chosen against landing-only inline placement for v1).
+- Pinning / naming / annotating entries.
+- Exporting history.

--- a/hyperglass/models/config/cache.py
+++ b/hyperglass/models/config/cache.py
@@ -13,3 +13,5 @@ class Cache(HyperglassModel):
     share_timeout: int = 604800
     share_sliding: bool = False
     refresh_min_interval: int = 120
+    history_enabled: bool = True
+    history_limit: int = 10

--- a/hyperglass/models/config/messages.py
+++ b/hyperglass/models/config/messages.py
@@ -80,6 +80,11 @@ class Messages(HyperglassModel):
         title="No Output",
         description="Displayed when hyperglass can connect to a device and execute a query, but the response is empty.",
     )
+    history_device_unavailable: str = Field(
+        "The device for this saved query is no longer available.",
+        title="History Device Unavailable",
+        description="Displayed when re-running a saved query whose device no longer exists.",
+    )
 
     def has(self, attr: str) -> bool:
         """Determine if message type exists in Messages model."""

--- a/hyperglass/models/config/params.py
+++ b/hyperglass/models/config/params.py
@@ -166,6 +166,8 @@ class Params(ParamsPublic, HyperglassModel):
                     "share_enabled",
                     "share_timeout",
                     "refresh_min_interval",
+                    "history_enabled",
+                    "history_limit",
                 },
                 "developer_mode": ...,
                 "primary_asn": ...,

--- a/hyperglass/models/config/tests/test_cache.py
+++ b/hyperglass/models/config/tests/test_cache.py
@@ -25,16 +25,12 @@ def test_cache_share_disabled():
 
 
 def test_cache_history_defaults():
-    from hyperglass.models.config.cache import Cache
-
     cache = Cache()
     assert cache.history_enabled is True
     assert cache.history_limit == 10
 
 
 def test_cache_history_overrides():
-    from hyperglass.models.config.cache import Cache
-
     cache = Cache(history_enabled=False, history_limit=25)
     assert cache.history_enabled is False
     assert cache.history_limit == 25

--- a/hyperglass/models/config/tests/test_cache.py
+++ b/hyperglass/models/config/tests/test_cache.py
@@ -22,3 +22,19 @@ def test_cache_share_timeout_overridable():
 def test_cache_share_disabled():
     cache = Cache(share_enabled=False)
     assert cache.share_enabled is False
+
+
+def test_cache_history_defaults():
+    from hyperglass.models.config.cache import Cache
+
+    cache = Cache()
+    assert cache.history_enabled is True
+    assert cache.history_limit == 10
+
+
+def test_cache_history_overrides():
+    from hyperglass.models.config.cache import Cache
+
+    cache = Cache(history_enabled=False, history_limit=25)
+    assert cache.history_enabled is False
+    assert cache.history_limit == 25

--- a/hyperglass/models/config/tests/test_params_frontend.py
+++ b/hyperglass/models/config/tests/test_params_frontend.py
@@ -34,6 +34,8 @@ def test_ui_params_cache_projection_excludes_private_fields():
         "shareEnabled",
         "shareTimeout",
         "refreshMinInterval",
+        "historyEnabled",
+        "historyLimit",
     }
 
 
@@ -45,3 +47,11 @@ def test_ui_params_export_excludes_public_url():
 
     ui = init_ui_params(params=Params(), devices=Devices())
     assert "publicUrl" not in ui.export_dict(by_alias=True)
+
+
+def test_frontend_includes_cache_history_fields():
+    """Cache history fields must be projected to frontend()."""
+    p = Params()
+    fe = p.frontend()
+    assert fe["cache"]["history_enabled"] is True
+    assert fe["cache"]["history_limit"] == 10

--- a/hyperglass/models/config/web.py
+++ b/hyperglass/models/config/web.py
@@ -134,6 +134,16 @@ class Text(HyperglassModel):
     share_run_fresh_query: str = "Run a fresh query"
     refresh_cooldown: str = "Refresh available in {seconds}s"  # Formatted by Javascript
     requery_tooltip: str = "Reload Query"
+    history_title: str = "Recent queries"
+    history_clear_all: str = "Clear all"
+    history_clear_confirm: str = "Clear all saved queries?"
+    history_back: str = "Back"
+    history_open: str = "Open"
+    history_share: str = "Share"
+    history_rerun: str = "Run again"
+    history_new_target: str = "Run with a new target"
+    history_delete: str = "Delete"
+    history_disabled_hint: str = "Results for this query type are not saved to history."
 
     @field_validator("cache_prefix")
     def validate_cache_prefix(cls: "Text", value: str) -> str:

--- a/hyperglass/models/directive.py
+++ b/hyperglass/models/directive.py
@@ -271,6 +271,7 @@ class Directive(HyperglassUniqueModel, unique_by=("id", "table_output")):
     groups: t.List[str] = []
     multiple: bool = False
     multiple_separator: str = " "
+    history: bool = True
 
     @field_validator("rules", mode="before")
     @classmethod
@@ -341,6 +342,7 @@ class Directive(HyperglassUniqueModel, unique_by=("id", "table_output")):
             "groups": self.groups,
             "description": self.field.description if self.field is not None else '',
             "info": None,
+            "history": self.history,
         }
 
         if self.info is not None:

--- a/hyperglass/models/tests/test_directive_history.py
+++ b/hyperglass/models/tests/test_directive_history.py
@@ -1,0 +1,25 @@
+"""Tests for the per-directive history opt-out field."""
+
+from hyperglass.models.directive import Directive
+
+
+def _directive(**kwargs):
+    base = {"id": "test", "name": "Test", "field": None}
+    base.update(kwargs)
+    return Directive(**base)
+
+
+def test_directive_history_defaults_true():
+    assert _directive().history is True
+
+
+def test_directive_history_can_be_disabled():
+    assert _directive(history=False).history is False
+
+
+def test_directive_frontend_includes_history():
+    fe = _directive(history=False).frontend()
+    assert fe["history"] is False
+
+    fe_default = _directive().frontend()
+    assert fe_default["history"] is True

--- a/hyperglass/models/tests/test_web.py
+++ b/hyperglass/models/tests/test_web.py
@@ -2,6 +2,7 @@
 
 # Project
 from hyperglass.models.config.web import Text
+from hyperglass.models.config.messages import Messages
 
 
 def test_text_share_defaults():
@@ -12,3 +13,17 @@ def test_text_share_defaults():
     assert t.share_not_found
     assert t.refresh_cooldown
     assert t.requery_tooltip == "Reload Query"
+
+
+def test_text_history_string_defaults():
+    text = Text()
+    assert text.history_title == "Recent queries"
+    assert text.history_clear_all == "Clear all"
+    assert text.history_disabled_hint == "Results for this query type are not saved to history."
+    assert text.history_open == "Open"
+    assert text.history_delete == "Delete"
+
+
+def test_messages_history_device_unavailable_default():
+    msgs = Messages()
+    assert msgs.history_device_unavailable == "The device for this saved query is no longer available."

--- a/hyperglass/models/ui.py
+++ b/hyperglass/models/ui.py
@@ -35,6 +35,7 @@ class UIDirective(HyperglassModel):
     description: str
     info: t.Optional[str] = None
     options: t.Optional[t.List[t.Dict[str, t.Any]]] = None
+    history: bool = True
 
 
 class UILocation(HyperglassModel):

--- a/hyperglass/models/ui.py
+++ b/hyperglass/models/ui.py
@@ -21,6 +21,8 @@ class UICache(HyperglassModel):
     share_enabled: bool
     share_timeout: int
     refresh_min_interval: int
+    history_enabled: bool
+    history_limit: int
 
 
 class UIDirective(HyperglassModel):

--- a/hyperglass/ui/components/history/history-disabled-hint.test.tsx
+++ b/hyperglass/ui/components/history/history-disabled-hint.test.tsx
@@ -1,0 +1,58 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const cfg = vi.hoisted(() => ({ historyEnabled: true }));
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    cache: { historyEnabled: cfg.historyEnabled },
+    web: { text: { historyDisabledHint: 'Results for this query type are not saved to history.' } },
+  }),
+}));
+
+import { HistoryDisabledHint } from './history-disabled-hint';
+
+const renderHint = (directiveHistory: boolean) =>
+  render(
+    <ChakraProvider>
+      <HistoryDisabledHint directiveHistory={directiveHistory} />
+    </ChakraProvider>,
+  );
+
+describe('HistoryDisabledHint', () => {
+  beforeEach(() => {
+    cfg.historyEnabled = true;
+  });
+
+  it('renders when global history on and directive opts out', () => {
+    renderHint(false);
+    expect(screen.getByLabelText(/not saved to history/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when the directive allows history', () => {
+    renderHint(true);
+    expect(screen.queryByLabelText(/not saved to history/i)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when global history is disabled', () => {
+    cfg.historyEnabled = false;
+    renderHint(false);
+    expect(screen.queryByLabelText(/not saved to history/i)).not.toBeInTheDocument();
+  });
+});

--- a/hyperglass/ui/components/history/history-disabled-hint.tsx
+++ b/hyperglass/ui/components/history/history-disabled-hint.tsx
@@ -1,0 +1,24 @@
+import { Box, Tooltip } from '@chakra-ui/react';
+import { useConfig } from '~/context';
+import { DynamicIcon } from '~/elements';
+
+interface HistoryDisabledHintProps {
+  directiveHistory: boolean;
+}
+
+export const HistoryDisabledHint = (props: HistoryDisabledHintProps): JSX.Element | null => {
+  const { directiveHistory } = props;
+  const { cache, web } = useConfig();
+
+  if (!cache.historyEnabled || directiveHistory) {
+    return null;
+  }
+
+  return (
+    <Tooltip hasArrow label={web.text.historyDisabledHint} placement="top">
+      <Box as="span" aria-label={web.text.historyDisabledHint} display="inline-flex">
+        <DynamicIcon icon={{ fi: 'FiEyeOff' }} boxSize="14px" />
+      </Box>
+    </Tooltip>
+  );
+};

--- a/hyperglass/ui/components/history/history-entry-row.test.tsx
+++ b/hyperglass/ui/components/history/history-entry-row.test.tsx
@@ -1,0 +1,128 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI requires it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock('~/components/results/share-button', () => ({
+  ShareButton: () => <div data-testid="share-button" />,
+}));
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    devices: [],
+    web: {
+      text: {
+        historyOpen: 'Open',
+        historyRerun: 'Run again',
+        historyNewTarget: 'Run with a new target',
+        historyDelete: 'Delete',
+      },
+    },
+    messages: {
+      historyDeviceUnavailable: 'Device unavailable.',
+    },
+  }),
+}));
+
+import { useQueryHistory } from '~/hooks/use-query-history';
+import type { HistoryEntry } from '~/hooks/use-query-history';
+import { HistoryEntryRow } from './history-entry-row';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const snapshot = (id: string): ResultSnapshot =>
+  ({
+    id,
+    output: 'some output',
+    format: 'text/plain',
+    level: 'success',
+    timestamp: new Date().toISOString(),
+    runtime: 1,
+    cached: false,
+    keywords: [],
+    queryLabels: { location: 'Core 1', type: 'BGP Route' },
+  }) as never;
+
+const singleEntry: HistoryEntry = {
+  id: 'entry-single',
+  savedAt: Date.now() - 60_000,
+  query: { queryLocation: ['core1'], queryType: 'bgp_route', queryTarget: ['192.0.2.1'] },
+  labels: { locations: ['Core 1'], type: 'BGP Route', target: '192.0.2.1' },
+  results: { core1: snapshot('cache-single') },
+};
+
+const multiEntry: HistoryEntry = {
+  id: 'entry-multi',
+  savedAt: Date.now() - 120_000,
+  query: {
+    queryLocation: ['core1', 'edge2'],
+    queryType: 'bgp_route',
+    queryTarget: ['192.0.2.1'],
+  },
+  labels: { locations: ['Core 1', 'Edge 2'], type: 'BGP Route', target: '192.0.2.1' },
+  results: {
+    core1: snapshot('cache-multi-1'),
+    edge2: snapshot('cache-multi-2'),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const renderRow = (entry: HistoryEntry) =>
+  render(
+    <ChakraProvider>
+      <HistoryEntryRow entry={entry} />
+    </ChakraProvider>,
+  );
+
+beforeEach(() => {
+  useQueryHistory.setState({ entries: [singleEntry, multiEntry], openId: null });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HistoryEntryRow', () => {
+  it('renders the ShareButton sentinel for a single-device entry', () => {
+    renderRow(singleEntry);
+    expect(screen.getByTestId('share-button')).toBeInTheDocument();
+  });
+
+  it('does NOT render the ShareButton sentinel for a multi-device entry', () => {
+    renderRow(multiEntry);
+    expect(screen.queryByTestId('share-button')).not.toBeInTheDocument();
+  });
+
+  it('clicking Open sets openId on the store', () => {
+    renderRow(singleEntry);
+    fireEvent.click(screen.getByLabelText('Open'));
+    expect(useQueryHistory.getState().openId).toBe(singleEntry.id);
+  });
+
+  it('clicking Delete removes the entry from the store', () => {
+    renderRow(singleEntry);
+    fireEvent.click(screen.getByLabelText('Delete'));
+    const ids = useQueryHistory.getState().entries.map(e => e.id);
+    expect(ids).not.toContain(singleEntry.id);
+  });
+});

--- a/hyperglass/ui/components/history/history-entry-row.tsx
+++ b/hyperglass/ui/components/history/history-entry-row.tsx
@@ -1,0 +1,108 @@
+import { Button, Flex, HStack, Text, Tooltip, useToast } from '@chakra-ui/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { ShareButton } from '~/components/results/share-button';
+import { useConfig } from '~/context';
+import { DynamicIcon } from '~/elements';
+import { useDevice, useFormState, useQueryHistory } from '~/hooks';
+import { makeSubmissionId } from '~/util';
+
+import type { HistoryEntry } from '~/hooks/use-query-history';
+
+dayjs.extend(relativeTime);
+
+interface HistoryEntryRowProps {
+  entry: HistoryEntry;
+}
+
+const iconBtn = {
+  as: 'a' as const,
+  mx: 1,
+  size: 'sm' as const,
+  variant: 'ghost' as const,
+  colorScheme: 'secondary' as const,
+};
+
+export const HistoryEntryRow = (props: HistoryEntryRowProps): JSX.Element => {
+  const { entry } = props;
+  const { web, messages } = useConfig();
+  const toast = useToast();
+  const getDevice = useDevice();
+
+  const open = useQueryHistory(s => s.open);
+  const remove = useQueryHistory(s => s.remove);
+  const prefillForm = useFormState(s => s.prefillForm);
+  const setStatus = useFormState(s => s.setStatus);
+  const setSubmissionId = useFormState(s => s.setSubmissionId);
+
+  const deviceIds = Object.keys(entry.results);
+  const isSingleDevice = deviceIds.length === 1;
+  const hasOutput = deviceIds.some(id => 'output' in entry.results[id]);
+
+  const failStale = () =>
+    toast({ title: messages.historyDeviceUnavailable, status: 'error', isClosable: true });
+
+  const handleRerun = () => {
+    const valid = prefillForm(entry.query, getDevice);
+    if (valid.length === 0) return failStale();
+    setSubmissionId(makeSubmissionId());
+    setStatus('results');
+  };
+
+  const handleNewTarget = () => {
+    const valid = prefillForm({ ...entry.query, queryTarget: [] }, getDevice);
+    if (valid.length === 0) return failStale();
+    setStatus('form');
+  };
+
+  return (
+    <Flex
+      px={3}
+      py={2}
+      w="100%"
+      align="center"
+      justify="space-between"
+      borderTopWidth="1px"
+      _first={{ borderTopWidth: 0 }}
+    >
+      <Flex direction="column" textAlign="left" minW={0} mr={2}>
+        <Text fontSize="sm" fontWeight="medium" isTruncated>
+          {entry.labels.locations.join(', ')} · {entry.labels.type} · {entry.labels.target}
+        </Text>
+        <Text fontSize="xs" color="gray.500">
+          {dayjs(entry.savedAt).fromNow()}
+        </Text>
+      </Flex>
+      <HStack spacing={0} flex="0 0 auto">
+        {hasOutput && (
+          <Tooltip hasArrow label={web.text.historyOpen} placement="top">
+            <Button {...iconBtn} aria-label={web.text.historyOpen} onClick={() => open(entry.id)}>
+              <DynamicIcon icon={{ fi: 'FiEye' }} boxSize="16px" />
+            </Button>
+          </Tooltip>
+        )}
+        {isSingleDevice && <ShareButton cacheId={entry.results[deviceIds[0]].id} />}
+        <Tooltip hasArrow label={web.text.historyRerun} placement="top">
+          <Button {...iconBtn} aria-label={web.text.historyRerun} onClick={handleRerun}>
+            <DynamicIcon icon={{ fi: 'FiRepeat' }} boxSize="16px" />
+          </Button>
+        </Tooltip>
+        <Tooltip hasArrow label={web.text.historyNewTarget} placement="top">
+          <Button {...iconBtn} aria-label={web.text.historyNewTarget} onClick={handleNewTarget}>
+            <DynamicIcon icon={{ fi: 'FiEdit' }} boxSize="16px" />
+          </Button>
+        </Tooltip>
+        <Tooltip hasArrow label={web.text.historyDelete} placement="top">
+          <Button
+            {...iconBtn}
+            aria-label={web.text.historyDelete}
+            colorScheme="red"
+            onClick={() => remove(entry.id)}
+          >
+            <DynamicIcon icon={{ fi: 'FiTrash2' }} boxSize="16px" />
+          </Button>
+        </Tooltip>
+      </HStack>
+    </Flex>
+  );
+};

--- a/hyperglass/ui/components/history/index.ts
+++ b/hyperglass/ui/components/history/index.ts
@@ -1,0 +1,1 @@
+export * from './history-disabled-hint';

--- a/hyperglass/ui/components/history/index.ts
+++ b/hyperglass/ui/components/history/index.ts
@@ -1,1 +1,2 @@
 export * from './history-disabled-hint';
+export * from './history-entry-row';

--- a/hyperglass/ui/components/history/index.ts
+++ b/hyperglass/ui/components/history/index.ts
@@ -1,2 +1,3 @@
 export * from './history-disabled-hint';
 export * from './history-entry-row';
+export * from './recent-queries';

--- a/hyperglass/ui/components/history/recent-queries.test.tsx
+++ b/hyperglass/ui/components/history/recent-queries.test.tsx
@@ -1,0 +1,82 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI requires it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    cache: { historyEnabled: true },
+    web: {
+      text: {
+        historyTitle: 'Recent queries',
+        historyClearAll: 'Clear all',
+        historyClearConfirm: 'Clear all saved queries?',
+        historyBack: 'Back',
+      },
+    },
+  }),
+}));
+
+vi.mock('./history-entry-row', () => ({
+  HistoryEntryRow: ({
+    entry,
+  }: { entry: { labels: { locations: string[]; type: string; target: string } } }) => (
+    <div data-testid="row">{`${entry.labels.locations.join(', ')} · ${entry.labels.type} · ${
+      entry.labels.target
+    }`}</div>
+  ),
+}));
+
+import { useFormState } from '~/hooks/use-form-state';
+import { useQueryHistory } from '~/hooks/use-query-history';
+import { RecentQueries } from './recent-queries';
+
+const entry = {
+  id: 's1',
+  savedAt: Date.now(),
+  query: { queryLocation: ['core1'], queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
+  labels: { locations: ['Core 1'], type: 'BGP Route', target: '8.8.8.0/24' },
+  results: { core1: {} },
+} as never;
+
+const renderComponent = () =>
+  render(
+    <ChakraProvider>
+      <RecentQueries />
+    </ChakraProvider>,
+  );
+
+beforeEach(() => {
+  useFormState.getState().reset();
+  useQueryHistory.setState({ entries: [], openId: null });
+});
+
+describe('RecentQueries', () => {
+  it('renders nothing when there are no entries', () => {
+    const { container } = renderComponent();
+    expect(container.querySelector('[data-testid="row"]')).toBeNull();
+    expect(screen.queryByText('Recent queries')).not.toBeInTheDocument();
+  });
+
+  it('renders the title and a row when an entry exists', () => {
+    useQueryHistory.setState({ entries: [entry], openId: null });
+    renderComponent();
+    expect(screen.getByText('Recent queries')).toBeInTheDocument();
+    expect(screen.getByText(/Core 1 · BGP Route · 8.8.8.0\/24/)).toBeInTheDocument();
+  });
+});

--- a/hyperglass/ui/components/history/recent-queries.tsx
+++ b/hyperglass/ui/components/history/recent-queries.tsx
@@ -1,0 +1,78 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Box,
+  Button,
+  Flex,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { useEffect, useRef, useState } from 'react';
+import { useConfig } from '~/context';
+import { useFormInteractive, useQueryHistory } from '~/hooks';
+import { HistoryEntryRow } from './history-entry-row';
+
+export const RecentQueries = (): JSX.Element | null => {
+  const { cache, web } = useConfig();
+  const formInteractive = useFormInteractive();
+  const entries = useQueryHistory(s => s.entries);
+  const clear = useQueryHistory(s => s.clear);
+
+  // Render only after mount to avoid a next-export hydration mismatch
+  // (server sees no localStorage; client rehydrates).
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  if (!mounted || !cache.historyEnabled || formInteractive || entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box w="100%" maxW={{ base: '100%', lg: '75%' }} mx="auto" my={4} textAlign="left">
+      <Flex px={3} py={2} align="center" justify="space-between">
+        <Text fontSize="sm" fontWeight="bold" textTransform="uppercase" color="gray.500">
+          {web.text.historyTitle}
+        </Text>
+        <Button size="xs" variant="ghost" colorScheme="red" onClick={onOpen}>
+          {web.text.historyClearAll}
+        </Button>
+      </Flex>
+      <Box borderWidth="1px" rounded="lg" overflow="hidden">
+        {entries.map(entry => (
+          <HistoryEntryRow key={entry.id} entry={entry} />
+        ))}
+      </Box>
+
+      <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={onClose}>
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader>{web.text.historyClearConfirm}</AlertDialogHeader>
+            <AlertDialogBody />
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose}>
+                {web.text.historyBack}
+              </Button>
+              <Button
+                colorScheme="red"
+                ml={3}
+                onClick={() => {
+                  clear();
+                  onClose();
+                }}
+              >
+                {web.text.historyClearAll}
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </Box>
+  );
+};

--- a/hyperglass/ui/components/index.ts
+++ b/hyperglass/ui/components/index.ts
@@ -11,6 +11,7 @@ export * from './footer';
 export * from './form-field';
 export * from './greeting';
 export * from './header';
+export * from './history';
 export * from './layout';
 export * from './location-card';
 export * from './looking-glass-form';

--- a/hyperglass/ui/components/looking-glass-form.submit.test.tsx
+++ b/hyperglass/ui/components/looking-glass-form.submit.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Tests that submitHandler stamps a fresh submissionId into form state on each
+ * submit.  These live in a separate file so vi.mock hoisting does not conflict
+ * with the prefill-focused mocks in looking-glass-form.test.tsx.
+ */
+
+import { ChakraProvider } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI requires it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import type { Config } from '~/types';
+import { LookingGlassForm } from './looking-glass-form';
+
+// ---------------------------------------------------------------------------
+// next/router mock — form pre-fill params so the submit button appears
+// ---------------------------------------------------------------------------
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {
+      location: 'test1',
+      target: '192.0.2.0/24',
+      type: 'juniper_bgp_route',
+    },
+    isReady: true,
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Minimal device + directive matching the query params above
+// ---------------------------------------------------------------------------
+const mockDirective = {
+  id: 'juniper_bgp_route',
+  name: 'BGP Route',
+  fieldType: 'text',
+  description: 'IP prefix / host',
+  groups: [],
+  info: null,
+};
+
+const mockDevice = {
+  id: 'test1',
+  name: 'Test Router 1',
+  group: null,
+  avatar: null,
+  description: null,
+  directives: [mockDirective],
+};
+
+const mockConfig: Config = {
+  developerMode: false,
+  primaryAsn: '65000',
+  requestTimeout: 30,
+  orgName: 'Test Org',
+  siteTitle: 'hyperglass',
+  siteDescription: 'Looking Glass',
+  version: '2.0.0',
+  parsedDataFields: [],
+  devices: [{ group: null, locations: [mockDevice] }],
+  content: { credit: '', greeting: '' },
+  messages: {
+    noInput: '{field} is required.',
+    featureNotEnabled: 'Feature not enabled.',
+    invalidInput: 'Invalid input.',
+    general: 'An error occurred.',
+    requestTimeout: 'Request timed out.',
+    connectionError: 'Connection error.',
+    authenticationError: 'Authentication error.',
+    noOutput: 'No output.',
+  },
+  cache: {
+    showText: false,
+    timeout: 600,
+    shareEnabled: false,
+    shareTimeout: 604800,
+    refreshMinInterval: 120,
+  },
+  web: {
+    credit: { enable: false },
+    dnsProvider: { name: 'Cloudflare', url: 'https://cloudflare-dns.com/dns-query' },
+    links: [],
+    menus: [],
+    greeting: {
+      enable: false,
+      title: 'Welcome',
+      button: 'Continue',
+      required: false,
+    },
+    logo: {
+      width: '100%',
+      height: null,
+      lightFormat: 'png',
+      darkFormat: 'png',
+    },
+    text: {
+      titleMode: 'logo',
+      title: 'hyperglass',
+      subtitle: 'Looking Glass',
+      queryLocation: 'Location',
+      queryType: 'Query Type',
+      queryTarget: 'Query Target',
+      fqdnTooltip: 'Resolve hostname',
+      fqdnMessage: 'Resolving hostname',
+      fqdnError: 'Could not resolve hostname',
+      fqdnErrorButton: 'Try Again',
+      cachePrefix: 'Cached',
+      cacheIcon: '',
+      completeTime: 'Completed in {time}',
+      rpkiInvalid: 'INVALID',
+      rpkiValid: 'VALID',
+      rpkiUnknown: 'UNKNOWN',
+      rpkiUnverified: 'UNVERIFIED',
+      noCommunities: 'No communities',
+      ipError: 'IP address error',
+      noIp: 'No IP address detected',
+      ipSelect: 'Select IP address',
+      ipButton: 'Use My IP',
+      shareButton: 'Share',
+      sharePopoverTitle: 'Share this result',
+      shareCopyLink: 'Copy link',
+      shareLinkCopied: 'Copied!',
+      shareExpiresAt: 'Expires {expires}',
+      shareCreateError: 'Could not create share link.',
+      shareCreateExpired: 'Result expired.',
+      shareNotFound: 'Result not found.',
+      shareSnapshotBanner: 'Snapshot',
+      shareRunFreshQuery: 'Run a fresh query',
+      refreshCooldown: 'Wait {seconds}s',
+      requeryTooltip: 'Reload Query',
+    },
+    theme: {
+      colors: { primary: '#40C057' },
+      defaultColorMode: 'light',
+      fonts: { body: 'Inter', mono: 'Fira Mono' },
+    },
+    locationDisplayMode: 'gallery',
+    highlight: [],
+  },
+} as unknown as Config;
+
+// ---------------------------------------------------------------------------
+// ~/context mock
+// ---------------------------------------------------------------------------
+vi.mock('~/context', async () => {
+  const { QueryClient } =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    useConfig: () => mockConfig,
+    queryClient: new QueryClient(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <ChakraProvider>{children}</ChakraProvider>
+    </QueryClientProvider>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Reset both form state and greeting state before each test.
+// ---------------------------------------------------------------------------
+beforeEach(async () => {
+  const { useFormState } = await import('~/hooks');
+  const { useGreeting } = await import('~/hooks/use-greeting');
+  await act(async () => {
+    await useFormState.getState().reset();
+    // Reset greeting to un-acknowledged so each test starts clean.
+    useGreeting.setState({ isAck: false, greetingReady: false, isOpen: false });
+  });
+});
+
+describe('LookingGlassForm — submissionId stamped on submit', () => {
+  it('sets a non-null submissionId in form state after a valid submit', async () => {
+    const { useFormState } = await import('~/hooks');
+    const { useGreeting } = await import('~/hooks/use-greeting');
+
+    // Mark greeting as acknowledged so submitHandler does not bail out.
+    act(() => {
+      useGreeting.setState({ isAck: true, greetingReady: true, isOpen: false });
+    });
+
+    render(<LookingGlassForm />, { wrapper });
+
+    // Wait for the prefill useEffect to fire — the target display value is the sentinel.
+    await screen.findAllByDisplayValue('192.0.2.0/24');
+
+    // Confirm submissionId is still null before submit.
+    expect(useFormState.getState().submissionId).toBeNull();
+
+    // Submit the form by clicking the submit button.
+    const submitBtn = screen.getByRole('button', { name: /submit query/i });
+    await userEvent.click(submitBtn);
+
+    // submitHandler should have called setSubmissionId(makeSubmissionId()).
+    expect(useFormState.getState().submissionId).toBeTruthy();
+  });
+
+  it('stamps a new submissionId on each submit (not reusing the previous value)', async () => {
+    const { useFormState } = await import('~/hooks');
+    const { useGreeting } = await import('~/hooks/use-greeting');
+
+    act(() => {
+      useGreeting.setState({ isAck: true, greetingReady: true, isOpen: false });
+    });
+
+    render(<LookingGlassForm />, { wrapper });
+    await screen.findAllByDisplayValue('192.0.2.0/24');
+
+    const submitBtn = screen.getByRole('button', { name: /submit query/i });
+
+    // First submit.
+    await userEvent.click(submitBtn);
+    const firstId = useFormState.getState().submissionId;
+    expect(firstId).toBeTruthy();
+
+    // Reset back to form view so the button is still accessible.
+    act(() => {
+      useFormState.getState().setStatus('form');
+    });
+
+    // Second submit.
+    await userEvent.click(submitBtn);
+    const secondId = useFormState.getState().submissionId;
+    expect(secondId).toBeTruthy();
+    expect(secondId).not.toBe(firstId);
+  });
+});

--- a/hyperglass/ui/components/looking-glass-form.tsx
+++ b/hyperglass/ui/components/looking-glass-form.tsx
@@ -13,6 +13,7 @@ import {
   QueryType,
   SubmitButton,
 } from '~/components';
+import { HistoryDisabledHint } from '~/components/history/history-disabled-hint';
 import { useConfig } from '~/context';
 import { FormRow } from '~/elements';
 import { useDevice, useFormState, useGreeting, useStrf } from '~/hooks';
@@ -231,12 +232,15 @@ export const LookingGlassForm = (): JSX.Element => {
               label={web.text.queryType}
               labelAddOn={
                 directive !== null && (
-                  <DirectiveInfoModal
-                    name="queryType"
-                    title={directive.name ?? null}
-                    item={directive.info ?? null}
-                    visible={selections.queryType !== null && directive.info !== null}
-                  />
+                  <>
+                    <DirectiveInfoModal
+                      name="queryType"
+                      title={directive.name ?? null}
+                      item={directive.info ?? null}
+                      visible={selections.queryType !== null && directive.info !== null}
+                    />
+                    <HistoryDisabledHint directiveHistory={directive.history} />
+                  </>
                 )
               }
             >

--- a/hyperglass/ui/components/looking-glass-form.tsx
+++ b/hyperglass/ui/components/looking-glass-form.tsx
@@ -17,7 +17,7 @@ import { useConfig } from '~/context';
 import { FormRow } from '~/elements';
 import { useDevice, useFormState, useGreeting, useStrf } from '~/hooks';
 import { Directive, isQueryField, isString } from '~/types';
-import { isFQDN } from '~/util';
+import { isFQDN, makeSubmissionId } from '~/util';
 
 import type { FormData, OnChangeArgs } from '~/types';
 
@@ -39,6 +39,7 @@ export const LookingGlassForm = (): JSX.Element => {
     useShallow(({ form, filtered, selections }) => ({ form, filtered, selections })),
   );
 
+  const setSubmissionId = useFormState(s => s.setSubmissionId);
   const getDirective = useFormState(useCallback(s => s.getDirective, []));
   const resolvedOpen = useFormState(useCallback(s => s.resolvedOpen, []));
   const resetForm = useFormState(useCallback(s => s.reset, []));
@@ -106,6 +107,9 @@ export const LookingGlassForm = (): JSX.Element => {
       location.reload();
       return;
     }
+
+    // Stamp this submission so its per-device results group into one history entry.
+    setSubmissionId(makeSubmissionId());
 
     // Determine if queryTarget is an FQDN.
     const isFqdn = isFqdnQuery(form.queryTarget, directive?.fieldType ?? null);

--- a/hyperglass/ui/components/results/index.ts
+++ b/hyperglass/ui/components/results/index.ts
@@ -1,1 +1,2 @@
 export * from './group';
+export * from './snapshot-results';

--- a/hyperglass/ui/components/results/individual.recording.test.tsx
+++ b/hyperglass/ui/components/results/individual.recording.test.tsx
@@ -1,0 +1,288 @@
+/**
+ * Tests that the history-recording effect in <Result> fires correctly:
+ *   - Snapshot/read-only renders do NOT record.
+ *   - A live successful result DOES record with the expected payload.
+ *
+ * These live in a separate file so their vi.mock() calls don't bleed into
+ * individual.test.tsx, which uses different (or no) mocks for the same modules.
+ */
+
+import { Accordion, ChakraProvider } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI requires it.
+// Use beforeAll + vi.stubGlobal so the stub persists across all tests
+// and cannot be cleared by jsdom re-initialization between tests.
+const matchMediaMock = vi.fn().mockImplementation((q: string) => ({
+  matches: false,
+  media: q,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+beforeAll(() => {
+  vi.stubGlobal('matchMedia', matchMediaMock);
+});
+
+// ── Module-level control variables ─────────────────────────────────────────
+// vi.mock() is hoisted before imports; these variables let individual tests
+// change what the mocked hooks return without re-importing the module.
+const recordSpy = vi.fn();
+
+// Default LG query result: still loading / no data.
+// Cast through unknown to avoid a generic-parameter mismatch on refetch's
+// TPageData type parameter — the mock never exercises refetch in these tests.
+let lgQueryResult: ReturnType<typeof import('~/hooks').useLGQuery> = {
+  data: undefined,
+  error: null,
+  isLoading: true,
+  isFetching: true,
+  isFetchedAfterMount: false,
+  dataUpdatedAt: 0,
+  refetch: vi.fn() as unknown as ReturnType<typeof import('~/hooks').useLGQuery>['refetch'],
+} as unknown as ReturnType<typeof import('~/hooks').useLGQuery>;
+
+// ── device group shape expected by useDevice (config.devices[].locations) ──
+const testDirective = {
+  id: 'bgp_route',
+  name: 'BGP Route',
+  fieldType: 'text' as const,
+  description: '',
+  groups: [],
+  info: null,
+  history: true,
+};
+
+const testDevice = {
+  id: 'core1',
+  name: 'Core 1',
+  group: null,
+  avatar: null,
+  description: null,
+  directives: [testDirective],
+};
+
+// ── Mocks (hoisted) ─────────────────────────────────────────────────────────
+
+vi.mock('./share-button', () => ({
+  ShareButton: () => <div data-testid="share-button" />,
+}));
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    requestTimeout: 30,
+    devices: [{ group: null, locations: [testDevice] }],
+    web: {
+      highlight: [],
+      text: {
+        cacheIcon: '',
+        cachePrefix: 'Cached',
+        completeTime: 'Completed in {time}',
+        requeryTooltip: 'Reload Query',
+        refreshCooldown: 'Wait {seconds}s',
+        shareButton: 'Share',
+        sharePopoverTitle: 'Share this result',
+        shareCopyLink: 'Copy link',
+        shareLinkCopied: 'Copied!',
+        shareExpiresAt: 'Expires {expires}',
+        shareCreateError: 'Could not create share link.',
+        shareCreateExpired: 'Result expired.',
+        shareNotFound: 'Result not found.',
+        shareSnapshotBanner: 'Snapshot',
+        shareRunFreshQuery: 'Run a fresh query',
+      },
+    },
+    messages: {
+      general: 'An error occurred.',
+      requestTimeout: 'Request timed out.',
+      noOutput: 'No output.',
+    },
+    cache: {
+      showText: true,
+      timeout: 600,
+      shareEnabled: true,
+      shareTimeout: 604800,
+      refreshMinInterval: 120,
+      historyEnabled: true,
+      historyLimit: 20,
+    },
+  }),
+  // queryClient is used inside use-form-state's reset() — provide a stub.
+  queryClient: {
+    removeQueries: vi.fn(),
+    setQueryData: vi.fn(),
+  },
+}));
+
+vi.mock('~/hooks', async importOriginal => {
+  const actual = await importOriginal<typeof import('~/hooks')>();
+  return {
+    ...actual,
+    // useRecordHistory always returns our spy; guards inside the real hook are
+    // bypassed intentionally — we only need to assert the effect calls it.
+    useRecordHistory: () => recordSpy,
+    // useLGQuery is controlled by lgQueryResult, mutated per-test.
+    useLGQuery: () => lgQueryResult,
+  };
+});
+
+// Import AFTER mocks are established.
+import { useFormState } from '~/hooks/use-form-state';
+import { Result } from './individual';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const snapshotFixture = {
+  id: 'cache-snap',
+  output: 'hello',
+  format: 'text/plain',
+  level: 'success',
+  timestamp: 'now',
+  runtime: 1,
+  cached: true,
+  keywords: [],
+  queryLabels: { location: 'Core 1', type: 'BGP Route' },
+} as never;
+
+const successData: QueryResponse = {
+  id: 'cache-1',
+  random: '',
+  output: 'hi',
+  format: 'text/plain',
+  level: 'success',
+  timestamp: 'now',
+  runtime: 1,
+  cached: false,
+  keywords: [],
+};
+
+// ── Render helper ────────────────────────────────────────────────────────────
+
+function renderResult(props: Record<string, unknown>) {
+  return render(
+    <ChakraProvider>
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <Accordion>
+          <Result index={0} queryLocation="core1" {...props} />
+        </Accordion>
+      </QueryClientProvider>
+    </ChakraProvider>,
+  );
+}
+
+// ── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  recordSpy.mockClear();
+  // Reset to loading/no-data baseline.
+  lgQueryResult = {
+    data: undefined,
+    error: null,
+    isLoading: true,
+    isFetching: true,
+    isFetchedAfterMount: false,
+    dataUpdatedAt: 0,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof import('~/hooks').useLGQuery>;
+  // Reset form state.
+  useFormState.setState({
+    submissionId: null,
+    form: { queryLocation: [], queryTarget: [], queryType: '' },
+    filtered: { groups: [], types: [] },
+  } as never);
+});
+
+afterEach(() => {
+  // NOTE: Do NOT call vi.restoreAllMocks() here — it would restore (i.e. remove)
+  // the vi.stubGlobal('matchMedia', ...) that Chakra's useMediaQuery requires,
+  // causing the remaining tests to crash with "Cannot read properties of undefined".
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Result history recording', () => {
+  it('does NOT record when rendered in snapshot mode', () => {
+    renderResult({ snapshot: snapshotFixture });
+    expect(recordSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT record when rendered in readOnly mode', () => {
+    renderResult({ snapshot: snapshotFixture, readOnly: true });
+    expect(recordSpy).not.toHaveBeenCalled();
+  });
+
+  it('records a successful live result with the expected payload', () => {
+    // Set up LG query to return a settled successful response.
+    lgQueryResult = {
+      data: successData,
+      error: null,
+      isLoading: false,
+      isFetching: false,
+      isFetchedAfterMount: true,
+      dataUpdatedAt: 1234,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof import('~/hooks').useLGQuery>;
+
+    // Prime form state so the effect guard passes.
+    useFormState.setState({
+      submissionId: 's1',
+      form: { queryLocation: ['core1'], queryTarget: ['8.8.8.0/24'], queryType: 'bgp_route' },
+      filtered: { groups: [], types: [testDirective] },
+    } as never);
+
+    renderResult({});
+
+    expect(recordSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        submissionId: 's1',
+        deviceId: 'core1',
+        deviceLabel: 'Core 1',
+        directiveHistory: true,
+        snapshot: expect.objectContaining({
+          id: 'cache-1',
+          level: 'success',
+          queryLabels: { location: 'Core 1', type: 'BGP Route' },
+        }),
+      }),
+    );
+  });
+
+  it('does NOT record when submissionId is null', () => {
+    lgQueryResult = {
+      data: successData,
+      error: null,
+      isLoading: false,
+      isFetching: false,
+      isFetchedAfterMount: true,
+      dataUpdatedAt: 1234,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof import('~/hooks').useLGQuery>;
+    // submissionId stays null from beforeEach.
+    renderResult({});
+    expect(recordSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT record when the result level is not success', () => {
+    lgQueryResult = {
+      data: { ...successData, level: 'error' },
+      error: null,
+      isLoading: false,
+      isFetching: false,
+      isFetchedAfterMount: true,
+      dataUpdatedAt: 1234,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof import('~/hooks').useLGQuery>;
+    useFormState.setState({ submissionId: 's2' } as never);
+    renderResult({});
+    expect(recordSpy).not.toHaveBeenCalled();
+  });
+});

--- a/hyperglass/ui/components/results/individual.test.tsx
+++ b/hyperglass/ui/components/results/individual.test.tsx
@@ -78,7 +78,9 @@ const snapshot = {
 const renderResult = (props: Record<string, unknown>) =>
   render(
     <ChakraProvider>
-      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
         <Accordion>
           <Result index={0} queryLocation="core1" snapshot={snapshot} {...props} />
         </Accordion>

--- a/hyperglass/ui/components/results/individual.test.tsx
+++ b/hyperglass/ui/components/results/individual.test.tsx
@@ -1,0 +1,99 @@
+import { Accordion, ChakraProvider } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI requires it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock('./share-button', () => ({
+  ShareButton: () => <div data-testid="share-button" />,
+}));
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    devices: [],
+    web: {
+      highlight: [],
+      text: {
+        cacheIcon: '',
+        cachePrefix: 'Cached',
+        completeTime: 'Completed in {time}',
+        requeryTooltip: 'Reload Query',
+        refreshCooldown: 'Wait {seconds}s',
+        shareButton: 'Share',
+        sharePopoverTitle: 'Share this result',
+        shareCopyLink: 'Copy link',
+        shareLinkCopied: 'Copied!',
+        shareExpiresAt: 'Expires {expires}',
+        shareCreateError: 'Could not create share link.',
+        shareCreateExpired: 'Result expired.',
+        shareNotFound: 'Result not found.',
+        shareSnapshotBanner: 'Snapshot',
+        shareRunFreshQuery: 'Run a fresh query',
+      },
+    },
+    messages: {
+      general: 'An error occurred.',
+      requestTimeout: 'Request timed out.',
+      noOutput: 'No output.',
+    },
+    cache: {
+      showText: true,
+      timeout: 600,
+      shareEnabled: true,
+      shareTimeout: 604800,
+      refreshMinInterval: 120,
+    },
+  }),
+}));
+
+import { Result } from './individual';
+
+const snapshot = {
+  id: 'cache-1',
+  output: 'hello',
+  format: 'text/plain',
+  level: 'success',
+  timestamp: 'now',
+  runtime: 1,
+  cached: true,
+  keywords: [],
+  queryLabels: { location: 'Core 1', type: 'BGP Route' },
+} as never;
+
+const renderResult = (props: Record<string, unknown>) =>
+  render(
+    <ChakraProvider>
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <Accordion>
+          <Result index={0} queryLocation="core1" snapshot={snapshot} {...props} />
+        </Accordion>
+      </QueryClientProvider>
+    </ChakraProvider>,
+  );
+
+describe('Result share visibility', () => {
+  it('hides Share when readOnly and showShare not set', () => {
+    renderResult({ readOnly: true });
+    expect(screen.queryByTestId('share-button')).not.toBeInTheDocument();
+  });
+
+  it('shows Share in history mode (readOnly + showShare)', () => {
+    renderResult({ readOnly: true, showShare: true });
+    expect(screen.getByTestId('share-button')).toBeInTheDocument();
+  });
+});

--- a/hyperglass/ui/components/results/individual.tsx
+++ b/hyperglass/ui/components/results/individual.tsx
@@ -43,9 +43,11 @@ interface ResultProps {
   index: number;
   queryLocation: string;
   /** Snapshot from a share link — skips the live LG query and renders directly. */
-  snapshot?: ShareResponse;
-  /** When true, hides the ShareButton and RequeryButton (used on the share view page). */
+  snapshot?: ResultSnapshot;
+  /** When true, hides the RequeryButton (used on the share view page). */
   readOnly?: boolean;
+  /** Controls ShareButton visibility; defaults to !readOnly. */
+  showShare?: boolean;
 }
 
 const AnimatedAccordionItem = motion(AccordionItem);
@@ -63,7 +65,7 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
   props: ResultProps,
   ref,
 ) => {
-  const { index, queryLocation, snapshot, readOnly = false } = props;
+  const { index, queryLocation, snapshot, readOnly = false, showShare = !readOnly } = props;
   const toast = useToast();
   const { web, cache, messages } = useConfig();
   const { index: indices, setIndex } = useAccordionContext();
@@ -291,7 +293,7 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
           {!snapshot && isStructuredOutput(data) && data.level === 'success' && tableComponent && (
             <Path device={deviceId} />
           )}
-          {!readOnly && data?.id && <ShareButton cacheId={data.id} />}
+          {showShare && data?.id && <ShareButton cacheId={data.id} />}
           <CopyButton copyValue={copyValue} isDisabled={!snapshot && isLoading} />
           {!readOnly && (
             <RequeryButton

--- a/hyperglass/ui/components/results/individual.tsx
+++ b/hyperglass/ui/components/results/individual.tsx
@@ -26,6 +26,7 @@ import {
   useFormState,
   useLGQuery,
   useMobile,
+  useRecordHistory,
   useStrf,
   useTableToString,
 } from '~/hooks';
@@ -82,6 +83,9 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
 
   const addResponse = useFormState(s => s.addResponse);
   const form = useFormState(s => s.form);
+  const recordHistory = useRecordHistory();
+  const getDirective = useFormState(s => s.getDirective);
+  const submissionId = useFormState(s => s.submissionId);
   const [errorLevel, _setErrorLevel] = useState<ErrorLevels>('error');
   const [force, setForce] = useState<true | undefined>(undefined);
   // Track when data last arrived for the cooldown gate. Initialise to mount
@@ -178,6 +182,37 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
     // fetch cycle. Re-running on any of those would risk double-firing the
     // setQueryData / setForce(undefined) calls.
   }, [dataUpdatedAt, isFetching]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Record a successful result into query history. Keyed on dataUpdatedAt +
+  // submissionId so it fires for both fresh and cache-served settles, once per
+  // run. Skipped for snapshot/read-only renders. The global + per-directive
+  // gates live inside useRecordHistory.
+  useEffect(() => {
+    if (snapshot || readOnly) return;
+    if (data?.level === 'success' && submissionId && device !== null) {
+      const directive = getDirective();
+      recordHistory({
+        submissionId,
+        deviceId: device.id,
+        deviceLabel: device.name,
+        directiveHistory: directive?.history ?? true,
+        query: { queryType: form.queryType, queryTarget: form.queryTarget },
+        labels: { type: directive?.name ?? form.queryType, target: form.queryTarget.join(' ') },
+        snapshot: {
+          id: data.id,
+          output: data.output,
+          format: data.format,
+          level: data.level,
+          timestamp: data.timestamp,
+          runtime: data.runtime,
+          cached: data.cached,
+          keywords: data.keywords ?? [],
+          queryLabels: { location: device.name, type: directive?.name ?? form.queryType },
+        },
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataUpdatedAt, submissionId]);
 
   const isError = useMemo(() => isLGOutputOrError(data), [data, error]);
 

--- a/hyperglass/ui/components/results/individual.tsx
+++ b/hyperglass/ui/components/results/individual.tsx
@@ -18,6 +18,7 @@ import { forwardRef, memo, useEffect, useMemo, useState } from 'react';
 import isEqual from 'react-fast-compare';
 import { Else, If, Then } from 'react-if';
 import { BGPTable, Path, TextOutput } from '~/components';
+import { HistoryDisabledHint } from '~/components/history/history-disabled-hint';
 import { useConfig } from '~/context';
 import { Countdown, DynamicIcon } from '~/elements';
 import {
@@ -329,6 +330,7 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
             <Path device={deviceId} />
           )}
           {showShare && data?.id && <ShareButton cacheId={data.id} />}
+          {!snapshot && <HistoryDisabledHint directiveHistory={getDirective()?.history ?? true} />}
           <CopyButton copyValue={copyValue} isDisabled={!snapshot && isLoading} />
           {!readOnly && (
             <RequeryButton

--- a/hyperglass/ui/components/results/snapshot-results.test.tsx
+++ b/hyperglass/ui/components/results/snapshot-results.test.tsx
@@ -78,7 +78,9 @@ const snap = (location: string, output: string) =>
 
 const Providers = ({ children }: { children: React.ReactNode }) => (
   <ChakraProvider>
-    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
       {children}
     </QueryClientProvider>
   </ChakraProvider>

--- a/hyperglass/ui/components/results/snapshot-results.test.tsx
+++ b/hyperglass/ui/components/results/snapshot-results.test.tsx
@@ -1,0 +1,100 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI requires it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+vi.mock('./share-button', () => ({
+  ShareButton: () => <div data-testid="share-button" />,
+}));
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    devices: [],
+    web: {
+      highlight: [],
+      text: {
+        cacheIcon: '',
+        cachePrefix: 'Cached',
+        completeTime: 'Completed in {time}',
+        requeryTooltip: 'Reload Query',
+        refreshCooldown: 'Wait {seconds}s',
+        shareButton: 'Share',
+        sharePopoverTitle: 'Share this result',
+        shareCopyLink: 'Copy link',
+        shareLinkCopied: 'Copied!',
+        shareExpiresAt: 'Expires {expires}',
+        shareCreateError: 'Could not create share link.',
+        shareCreateExpired: 'Result expired.',
+        shareNotFound: 'Result not found.',
+        shareSnapshotBanner: 'Snapshot',
+        shareRunFreshQuery: 'Run a fresh query',
+      },
+    },
+    messages: {
+      general: 'An error occurred.',
+      requestTimeout: 'Request timed out.',
+      noOutput: 'No output.',
+    },
+    cache: {
+      showText: true,
+      timeout: 600,
+      shareEnabled: true,
+      shareTimeout: 604800,
+      refreshMinInterval: 120,
+    },
+  }),
+}));
+
+import { SnapshotResults } from './snapshot-results';
+
+const snap = (location: string, output: string) =>
+  ({
+    id: `c-${location}`,
+    output,
+    format: 'text/plain',
+    level: 'success',
+    timestamp: 'now',
+    runtime: 1,
+    cached: true,
+    keywords: [],
+    queryLabels: { location, type: 'BGP Route' },
+  }) as never;
+
+const Providers = ({ children }: { children: React.ReactNode }) => (
+  <ChakraProvider>
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      {children}
+    </QueryClientProvider>
+  </ChakraProvider>
+);
+
+it('renders one result per item', () => {
+  render(
+    <Providers>
+      <SnapshotResults
+        items={[
+          { queryLocation: 'core1', snapshot: snap('Core 1', 'A') },
+          { queryLocation: 'edge2', snapshot: snap('Edge 2', 'B') },
+        ]}
+      />
+    </Providers>,
+  );
+  expect(screen.getByText('Core 1')).toBeInTheDocument();
+  expect(screen.getByText('Edge 2')).toBeInTheDocument();
+});

--- a/hyperglass/ui/components/results/snapshot-results.tsx
+++ b/hyperglass/ui/components/results/snapshot-results.tsx
@@ -1,0 +1,47 @@
+import { Accordion } from '@chakra-ui/react';
+import { AnimatedDiv } from '~/elements';
+import { Result } from './individual';
+
+export interface SnapshotResultsItem {
+  queryLocation: string;
+  snapshot: ResultSnapshot;
+}
+
+interface SnapshotResultsProps {
+  items: SnapshotResultsItem[];
+  /** Show each result's ShareButton (history-open); default false (share page). */
+  showShare?: boolean;
+}
+
+export const SnapshotResults = (props: SnapshotResultsProps): JSX.Element => {
+  const { items, showShare = false } = props;
+  return (
+    <AnimatedDiv
+      p={0}
+      my={4}
+      w="100%"
+      mx="auto"
+      rounded="lg"
+      textAlign="left"
+      borderWidth="1px"
+      overflow="hidden"
+      initial={{ opacity: 1 }}
+      exit={{ opacity: 0, y: 300 }}
+      transition={{ duration: 0.3 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <Accordion defaultIndex={items.map((_, i) => i)} allowMultiple>
+        {items.map((item, index) => (
+          <Result
+            key={item.queryLocation}
+            index={index}
+            queryLocation={item.queryLocation}
+            snapshot={item.snapshot}
+            readOnly
+            showShare={showShare}
+          />
+        ))}
+      </Accordion>
+    </AnimatedDiv>
+  );
+};

--- a/hyperglass/ui/hooks/index.ts
+++ b/hyperglass/ui/hooks/index.ts
@@ -14,3 +14,4 @@ export * from './use-strf';
 export * from './use-table-to-string';
 export * from './use-wtf';
 export * from './use-query-history';
+export * from './use-record-history';

--- a/hyperglass/ui/hooks/index.ts
+++ b/hyperglass/ui/hooks/index.ts
@@ -13,3 +13,4 @@ export * from './use-share';
 export * from './use-strf';
 export * from './use-table-to-string';
 export * from './use-wtf';
+export * from './use-query-history';

--- a/hyperglass/ui/hooks/use-form-state.test.tsx
+++ b/hyperglass/ui/hooks/use-form-state.test.tsx
@@ -98,10 +98,12 @@ describe('useFormState.prefillForm', () => {
 
   it('sets form values and selections for valid locations', () => {
     const getDevice = (id: string) => (id === 'core1' ? device('core1') : null);
-    useFormState.getState().prefillForm(
-      { queryLocation: ['core1'], queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
-      getDevice as never,
-    );
+    useFormState
+      .getState()
+      .prefillForm(
+        { queryLocation: ['core1'], queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
+        getDevice as never,
+      );
     const state = useFormState.getState();
     expect(state.form.queryLocation).toEqual(['core1']);
     expect(state.form.queryType).toBe('bgp_route');
@@ -111,10 +113,12 @@ describe('useFormState.prefillForm', () => {
 
   it('drops unknown devices and returns the valid subset', () => {
     const getDevice = (id: string) => (id === 'core1' ? device('core1') : null);
-    const valid = useFormState.getState().prefillForm(
-      { queryLocation: ['core1', 'ghost'], queryType: 'bgp_route', queryTarget: ['x'] },
-      getDevice as never,
-    );
+    const valid = useFormState
+      .getState()
+      .prefillForm(
+        { queryLocation: ['core1', 'ghost'], queryType: 'bgp_route', queryTarget: ['x'] },
+        getDevice as never,
+      );
     expect(valid).toEqual(['core1']);
     expect(useFormState.getState().form.queryLocation).toEqual(['core1']);
   });

--- a/hyperglass/ui/hooks/use-form-state.test.tsx
+++ b/hyperglass/ui/hooks/use-form-state.test.tsx
@@ -83,3 +83,39 @@ describe('useFormState.submissionId', () => {
     expect(useFormState.getState().submissionId).toBeNull();
   });
 });
+
+describe('useFormState.prefillForm', () => {
+  beforeEach(async () => {
+    await useFormState.getState().reset();
+  });
+
+  const device = (id: string) =>
+    ({
+      id,
+      name: id.toUpperCase(),
+      directives: [{ id: 'bgp_route', name: 'BGP Route', groups: ['ip'] }],
+    }) as never;
+
+  it('sets form values and selections for valid locations', () => {
+    const getDevice = (id: string) => (id === 'core1' ? device('core1') : null);
+    useFormState.getState().prefillForm(
+      { queryLocation: ['core1'], queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
+      getDevice as never,
+    );
+    const state = useFormState.getState();
+    expect(state.form.queryLocation).toEqual(['core1']);
+    expect(state.form.queryType).toBe('bgp_route');
+    expect(state.form.queryTarget).toEqual(['8.8.8.0/24']);
+    expect(state.selections.queryLocation.map(o => o.value)).toEqual(['core1']);
+  });
+
+  it('drops unknown devices and returns the valid subset', () => {
+    const getDevice = (id: string) => (id === 'core1' ? device('core1') : null);
+    const valid = useFormState.getState().prefillForm(
+      { queryLocation: ['core1', 'ghost'], queryType: 'bgp_route', queryTarget: ['x'] },
+      getDevice as never,
+    );
+    expect(valid).toEqual(['core1']);
+    expect(useFormState.getState().form.queryLocation).toEqual(['core1']);
+  });
+});

--- a/hyperglass/ui/hooks/use-form-state.test.tsx
+++ b/hyperglass/ui/hooks/use-form-state.test.tsx
@@ -65,3 +65,21 @@ describe('useFormInteractive', () => {
     expect(result.current).toBe(true);
   });
 });
+
+describe('useFormState.submissionId', () => {
+  beforeEach(async () => {
+    await useFormState.getState().reset();
+  });
+
+  it('defaults to null and can be set', () => {
+    expect(useFormState.getState().submissionId).toBeNull();
+    useFormState.getState().setSubmissionId('abc');
+    expect(useFormState.getState().submissionId).toBe('abc');
+  });
+
+  it('is cleared by reset', async () => {
+    useFormState.getState().setSubmissionId('abc');
+    await useFormState.getState().reset();
+    expect(useFormState.getState().submissionId).toBeNull();
+  });
+});

--- a/hyperglass/ui/hooks/use-form-state.ts
+++ b/hyperglass/ui/hooks/use-form-state.ts
@@ -79,6 +79,10 @@ interface FormStateType<Opt extends SingleOption = SingleOption> {
       text: Text;
     },
   ): void;
+  prefillForm(
+    query: { queryLocation: string[]; queryType: string; queryTarget: string[] },
+    getDevice: UseDeviceReturn,
+  ): string[];
 }
 
 const formState: StateCreator<FormStateType> = (set, get) => ({
@@ -195,6 +199,43 @@ const formState: StateCreator<FormStateType> = (set, get) => ({
     } else if (intersectingDirectives.length === 1) {
       set(state => ({ form: { ...state.form, queryType: intersectingDirectives[0].id } }));
     }
+  },
+
+  prefillForm(
+    query: { queryLocation: string[]; queryType: string; queryTarget: string[] },
+    getDevice: UseDeviceReturn,
+  ): string[] {
+    const validDevices = query.queryLocation
+      .map(getDevice)
+      .filter((device): device is Device => device !== null);
+    const validLocations = validDevices.map(d => d.id);
+
+    const allGroups = validDevices.map(dev =>
+      Array.from(new Set(dev.directives.flatMap(dir => dir.groups))),
+    );
+    const intersecting = validDevices.length ? intersectionWith(...allGroups, isEqual) : [];
+
+    const allDirectives = validDevices.map(device => device.directives);
+    const intersectingDirectives = validDevices.length
+      ? intersectionWith(...allDirectives, isEqual)
+      : [];
+    const directives = dedupObjectArray(intersectingDirectives, 'id');
+
+    set({
+      form: {
+        queryLocation: validLocations,
+        queryType: query.queryType,
+        queryTarget: query.queryTarget,
+      },
+      selections: {
+        queryLocation: validDevices.map(d => ({ value: d.id, label: d.name })),
+        queryType: null,
+      },
+      filtered: { groups: intersecting, types: directives },
+      target: { display: query.queryTarget.join(' ') },
+    });
+
+    return validLocations;
   },
 
   response(deviceId: string): QueryResponse | null {

--- a/hyperglass/ui/hooks/use-form-state.ts
+++ b/hyperglass/ui/hooks/use-form-state.ts
@@ -50,6 +50,7 @@ interface FormStateType<Opt extends SingleOption = SingleOption> {
   responses: Responses;
   selections: FormSelections<Opt>;
   status: FormStatus;
+  submissionId: string | null;
   target: Target;
   resolvedIsOpen: boolean;
 
@@ -64,6 +65,7 @@ interface FormStateType<Opt extends SingleOption = SingleOption> {
     Opt extends SingleOption,
     K extends keyof FormSelections<Opt> = keyof FormSelections<Opt>,
   >(field: K, value: FormSelections[K]): void;
+  setSubmissionId(value: string | null): void;
   setTarget(update: Partial<Target>): void;
   getDirective(): Directive | null;
   reset(): Promise<void>;
@@ -86,6 +88,7 @@ const formState: StateCreator<FormStateType> = (set, get) => ({
   responses: {},
   selections: { queryLocation: [], queryType: null },
   status: 'form',
+  submissionId: null,
   target: { display: '' },
   resolvedIsOpen: false,
 
@@ -110,6 +113,10 @@ const formState: StateCreator<FormStateType> = (set, get) => ({
 
   setTarget(update: Partial<Target>): void {
     set(state => ({ target: { ...state.target, ...update } }));
+  },
+
+  setSubmissionId(submissionId: string | null): void {
+    set({ submissionId });
   },
 
   resolvedOpen(): void {
@@ -209,6 +216,7 @@ const formState: StateCreator<FormStateType> = (set, get) => ({
       responses: {},
       selections: { queryLocation: [], queryType: null },
       status: 'form',
+      submissionId: null,
       target: { display: '' },
       resolvedIsOpen: false,
     });

--- a/hyperglass/ui/hooks/use-query-history.test.ts
+++ b/hyperglass/ui/hooks/use-query-history.test.ts
@@ -42,9 +42,9 @@ describe('useQueryHistory.record', () => {
 
   it('groups multiple devices of the same submission into one entry', () => {
     useQueryHistory.getState().record(input());
-    useQueryHistory.getState().record(
-      input({ deviceId: 'edge2', deviceLabel: 'Edge 2', snapshot: snapshot('B') }),
-    );
+    useQueryHistory
+      .getState()
+      .record(input({ deviceId: 'edge2', deviceLabel: 'Edge 2', snapshot: snapshot('B') }));
     const { entries } = useQueryHistory.getState();
     expect(entries).toHaveLength(1);
     expect(Object.keys(entries[0].results).sort()).toEqual(['core1', 'edge2']);

--- a/hyperglass/ui/hooks/use-query-history.test.ts
+++ b/hyperglass/ui/hooks/use-query-history.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useQueryHistory } from './use-query-history';
+import type { RecordInput } from './use-query-history';
+
+const snapshot = (output: string) => ({
+  id: 'cache-1',
+  output,
+  format: 'text/plain' as const,
+  level: 'success' as const,
+  timestamp: 'now',
+  runtime: 1,
+  cached: false,
+  keywords: [] as string[],
+  queryLabels: { location: 'Core 1', type: 'BGP Route' },
+});
+
+const input = (over: Partial<RecordInput> = {}): RecordInput => ({
+  submissionId: 's1',
+  deviceId: 'core1',
+  deviceLabel: 'Core 1',
+  query: { queryType: 'bgp_route', queryTarget: ['8.8.8.0/24'] },
+  labels: { type: 'BGP Route', target: '8.8.8.0/24' },
+  snapshot: snapshot('A'),
+  limit: 10,
+  ...over,
+});
+
+beforeEach(() => {
+  useQueryHistory.setState({ entries: [], openId: null });
+  window.localStorage.clear();
+});
+
+describe('useQueryHistory.record', () => {
+  it('creates an entry keyed by submissionId', () => {
+    useQueryHistory.getState().record(input());
+    const { entries } = useQueryHistory.getState();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('s1');
+    expect(entries[0].results.core1.output).toBe('A');
+    expect(entries[0].query.queryLocation).toEqual(['core1']);
+  });
+
+  it('groups multiple devices of the same submission into one entry', () => {
+    useQueryHistory.getState().record(input());
+    useQueryHistory.getState().record(
+      input({ deviceId: 'edge2', deviceLabel: 'Edge 2', snapshot: snapshot('B') }),
+    );
+    const { entries } = useQueryHistory.getState();
+    expect(entries).toHaveLength(1);
+    expect(Object.keys(entries[0].results).sort()).toEqual(['core1', 'edge2']);
+    expect(entries[0].query.queryLocation.sort()).toEqual(['core1', 'edge2']);
+  });
+
+  it('keeps distinct submissions as separate entries, newest first', () => {
+    useQueryHistory.getState().record(input({ submissionId: 's1' }));
+    useQueryHistory.getState().record(input({ submissionId: 's2' }));
+    const { entries } = useQueryHistory.getState();
+    expect(entries.map(e => e.id)).toEqual(['s2', 's1']);
+  });
+
+  it('enforces the limit, evicting oldest', () => {
+    for (let i = 0; i < 12; i++) {
+      useQueryHistory.getState().record(input({ submissionId: `s${i}`, limit: 10 }));
+    }
+    const { entries } = useQueryHistory.getState();
+    expect(entries).toHaveLength(10);
+    expect(entries[0].id).toBe('s11');
+    expect(entries.find(e => e.id === 's0')).toBeUndefined();
+  });
+});
+
+describe('useQueryHistory remove/clear/open/close', () => {
+  it('remove deletes by id', () => {
+    useQueryHistory.getState().record(input({ submissionId: 's1' }));
+    useQueryHistory.getState().record(input({ submissionId: 's2' }));
+    useQueryHistory.getState().remove('s1');
+    expect(useQueryHistory.getState().entries.map(e => e.id)).toEqual(['s2']);
+  });
+
+  it('clear empties entries', () => {
+    useQueryHistory.getState().record(input());
+    useQueryHistory.getState().clear();
+    expect(useQueryHistory.getState().entries).toHaveLength(0);
+  });
+
+  it('open/close set and reset openId', () => {
+    useQueryHistory.getState().open('s1');
+    expect(useQueryHistory.getState().openId).toBe('s1');
+    useQueryHistory.getState().close();
+    expect(useQueryHistory.getState().openId).toBeNull();
+  });
+});

--- a/hyperglass/ui/hooks/use-query-history.ts
+++ b/hyperglass/ui/hooks/use-query-history.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { historyStorage } from '~/util/history-storage';
+import { withDev } from '~/util';
+
+export interface HistoryEntry {
+  id: string;
+  savedAt: number;
+  query: { queryLocation: string[]; queryType: string; queryTarget: string[] };
+  labels: { locations: string[]; type: string; target: string };
+  results: Record<string, ResultSnapshot>;
+}
+
+export interface RecordInput {
+  submissionId: string;
+  deviceId: string;
+  deviceLabel: string;
+  query: { queryType: string; queryTarget: string[] };
+  labels: { type: string; target: string };
+  snapshot: ResultSnapshot;
+  limit: number;
+}
+
+interface QueryHistoryState {
+  entries: HistoryEntry[];
+  openId: string | null;
+  record(input: RecordInput): void;
+  remove(id: string): void;
+  clear(): void;
+  open(id: string): void;
+  close(): void;
+}
+
+const uniq = (values: string[]): string[] => Array.from(new Set(values));
+
+export const useQueryHistory = create<QueryHistoryState>()(
+  persist(
+    withDev<QueryHistoryState>(
+      (set, get) => ({
+        entries: [],
+        openId: null,
+
+        record(input: RecordInput): void {
+          const { submissionId, deviceId, deviceLabel, query, labels, snapshot, limit } = input;
+          const existing = get().entries.find(e => e.id === submissionId);
+
+          const entry: HistoryEntry = existing
+            ? {
+                ...existing,
+                results: { ...existing.results, [deviceId]: snapshot },
+                query: {
+                  ...existing.query,
+                  queryLocation: uniq([...existing.query.queryLocation, deviceId]),
+                },
+                labels: {
+                  ...existing.labels,
+                  locations: uniq([...existing.labels.locations, deviceLabel]),
+                },
+              }
+            : {
+                id: submissionId,
+                savedAt: Date.now(),
+                query: {
+                  queryLocation: [deviceId],
+                  queryType: query.queryType,
+                  queryTarget: query.queryTarget,
+                },
+                labels: { locations: [deviceLabel], type: labels.type, target: labels.target },
+                results: { [deviceId]: snapshot },
+              };
+
+          const others = get().entries.filter(e => e.id !== submissionId);
+          set({ entries: [entry, ...others].slice(0, Math.max(0, limit)) });
+        },
+
+        remove(id: string): void {
+          set(state => ({ entries: state.entries.filter(e => e.id !== id) }));
+        },
+
+        clear(): void {
+          set({ entries: [] });
+        },
+
+        open(id: string): void {
+          set({ openId: id });
+        },
+
+        close(): void {
+          set({ openId: null });
+        },
+      }),
+      'useQueryHistory',
+    ),
+    {
+      name: 'hyperglass.queryHistory',
+      version: 1,
+      storage: createJSONStorage(() => historyStorage),
+      partialize: (state): Pick<QueryHistoryState, 'entries'> => ({ entries: state.entries }),
+    },
+  ),
+);

--- a/hyperglass/ui/hooks/use-query-history.ts
+++ b/hyperglass/ui/hooks/use-query-history.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
-import { historyStorage } from '~/util/history-storage';
+import { createJSONStorage, persist } from 'zustand/middleware';
 import { withDev } from '~/util';
+import { historyStorage } from '~/util/history-storage';
 
 export interface HistoryEntry {
   id: string;

--- a/hyperglass/ui/hooks/use-record-history.test.tsx
+++ b/hyperglass/ui/hooks/use-record-history.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRecordHistory } from './use-record-history';
+import { useQueryHistory } from './use-query-history';
+
+const recordSpy = vi.fn();
+
+vi.mock('~/context', () => ({
+  useConfig: () => ({ cache: { historyEnabled: true, historyLimit: 10 } }),
+}));
+
+beforeEach(() => {
+  recordSpy.mockClear();
+  useQueryHistory.setState({
+    entries: [],
+    openId: null,
+    record: recordSpy,
+  } as never);
+});
+
+const payload = {
+  submissionId: 's1',
+  deviceId: 'core1',
+  deviceLabel: 'Core 1',
+  directiveHistory: true,
+  query: { queryType: 'bgp_route', queryTarget: ['x'] },
+  labels: { type: 'BGP Route', target: 'x' },
+  snapshot: {} as never,
+};
+
+describe('useRecordHistory', () => {
+  it('records when global + directive both allow it', () => {
+    const { result } = renderHook(() => useRecordHistory());
+    result.current(payload);
+    expect(recordSpy).toHaveBeenCalledOnce();
+    expect(recordSpy.mock.calls[0][0].limit).toBe(10);
+  });
+
+  it('no-ops when the directive opts out', () => {
+    const { result } = renderHook(() => useRecordHistory());
+    result.current({ ...payload, directiveHistory: false });
+    expect(recordSpy).not.toHaveBeenCalled();
+  });
+});

--- a/hyperglass/ui/hooks/use-record-history.ts
+++ b/hyperglass/ui/hooks/use-record-history.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+import { useConfig } from '~/context';
+import { useQueryHistory } from './use-query-history';
+
+interface RecordHistoryArgs {
+  submissionId: string;
+  deviceId: string;
+  deviceLabel: string;
+  directiveHistory: boolean;
+  query: { queryType: string; queryTarget: string[] };
+  labels: { type: string; target: string };
+  snapshot: ResultSnapshot;
+}
+
+/**
+ * Returns a callback that records a successful result into query history,
+ * unless history is disabled globally or for the directive.
+ */
+export function useRecordHistory(): (args: RecordHistoryArgs) => void {
+  const { cache } = useConfig();
+  const record = useQueryHistory(s => s.record);
+
+  return useCallback(
+    (args: RecordHistoryArgs): void => {
+      if (!cache.historyEnabled || !args.directiveHistory) return;
+      const { directiveHistory, ...rest } = args;
+      record({ ...rest, limit: cache.historyLimit });
+    },
+    [cache.historyEnabled, cache.historyLimit, record],
+  );
+}

--- a/hyperglass/ui/pages/index.tsx
+++ b/hyperglass/ui/pages/index.tsx
@@ -1,10 +1,14 @@
-import dynamic from 'next/dynamic';
+import { Box, Button, Flex } from '@chakra-ui/react';
 import { AnimatePresence } from 'framer-motion';
-import { If, Then, Else } from 'react-if';
+import dynamic from 'next/dynamic';
+import { Else, If, Then } from 'react-if';
+import { SnapshotResults } from '~/components/results/snapshot-results';
+import { useConfig } from '~/context';
 import { Loading } from '~/elements';
-import { useView } from '~/hooks';
+import { useQueryHistory, useView } from '~/hooks';
 
 import type { NextPage } from 'next';
+import type { SnapshotResultsItem } from '~/components/results/snapshot-results';
 
 const LookingGlassForm = dynamic<Dict>(
   () => import('~/components/looking-glass-form').then(i => i.LookingGlassForm),
@@ -17,8 +21,36 @@ const Results = dynamic<Dict>(() => import('~/components/results').then(i => i.R
   loading: Loading,
 });
 
+const RecentQueries = dynamic<Dict>(
+  () => import('~/components/history').then(i => i.RecentQueries),
+  { ssr: false },
+);
+
 const Index: NextPage = () => {
   const view = useView();
+  const { web } = useConfig();
+  const openId = useQueryHistory(s => s.openId);
+  const close = useQueryHistory(s => s.close);
+  const entries = useQueryHistory(s => s.entries);
+
+  const openEntry = openId ? entries.find(e => e.id === openId) : undefined;
+
+  if (openEntry) {
+    const items: SnapshotResultsItem[] = Object.entries(openEntry.results).map(
+      ([queryLocation, snapshot]) => ({ queryLocation, snapshot }),
+    );
+    return (
+      <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
+        <Flex justify="flex-start" mb={2}>
+          <Button size="sm" variant="ghost" onClick={close}>
+            {web.text.historyBack}
+          </Button>
+        </Flex>
+        <SnapshotResults items={items} showShare />
+      </Box>
+    );
+  }
+
   return (
     <If condition={view === 'results'}>
       <Then>
@@ -28,6 +60,7 @@ const Index: NextPage = () => {
         <AnimatePresence>
           <LookingGlassForm />
         </AnimatePresence>
+        <RecentQueries />
       </Else>
     </If>
   );

--- a/hyperglass/ui/pages/result/[id].tsx
+++ b/hyperglass/ui/pages/result/[id].tsx
@@ -1,16 +1,15 @@
-import { Accordion, Box, Flex, Text } from '@chakra-ui/react';
+import { Box, Flex, Text } from '@chakra-ui/react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { Result } from '~/components/results/individual';
+import { SnapshotResults } from '~/components/results/snapshot-results';
 import { useConfig } from '~/context';
-import { AnimatedDiv } from '~/elements';
 import { useShareGet, useStrf } from '~/hooks';
 
 import type { NextPage } from 'next';
 
 const ResultPage: NextPage = () => {
   const router = useRouter();
-  const { web, messages } = useConfig();
+  const { web } = useConfig();
   const strF = useStrf();
 
   const id = typeof router.query.id === 'string' ? router.query.id : undefined;
@@ -69,30 +68,7 @@ const ResultPage: NextPage = () => {
         <Text>{banner}</Text>
         <Text>{expires}</Text>
       </Flex>
-      <AnimatedDiv
-        p={0}
-        my={4}
-        w="100%"
-        mx="auto"
-        rounded="lg"
-        textAlign="left"
-        borderWidth="1px"
-        overflow="hidden"
-        initial={{ opacity: 1 }}
-        exit={{ opacity: 0, y: 300 }}
-        transition={{ duration: 0.3 }}
-        animate={{ opacity: 1, y: 0 }}
-      >
-        {/* Result is an AccordionItem — it must live inside an Accordion */}
-        <Accordion defaultIndex={[0]} allowMultiple>
-          <Result
-            index={0}
-            queryLocation={snapshot.query.query_location}
-            snapshot={snapshot}
-            readOnly
-          />
-        </Accordion>
-      </AnimatedDiv>
+      <SnapshotResults items={[{ queryLocation: snapshot.query.query_location, snapshot }]} />
       <Flex justifyContent="center" mt={4}>
         <Link href={freshUrl}>{web.text.shareRunFreshQuery}</Link>
       </Flex>

--- a/hyperglass/ui/types/config.ts
+++ b/hyperglass/ui/types/config.ts
@@ -14,6 +14,7 @@ interface _Messages {
   connection_error: string;
   authentication_error: string;
   no_output: string;
+  history_device_unavailable: string;
 }
 
 interface _ThemeConfig {
@@ -57,6 +58,16 @@ interface _Text {
   share_run_fresh_query: string;
   refresh_cooldown: string;
   requery_tooltip: string;
+  history_title: string;
+  history_clear_all: string;
+  history_clear_confirm: string;
+  history_back: string;
+  history_open: string;
+  history_share: string;
+  history_rerun: string;
+  history_new_target: string;
+  history_delete: string;
+  history_disabled_hint: string;
 }
 
 interface _Greeting {
@@ -118,6 +129,7 @@ type _DirectiveBase = {
   description: string;
   groups: string[];
   info: string | null;
+  history: boolean;
 };
 
 type _DirectiveOption = {
@@ -152,6 +164,8 @@ interface _Cache {
   share_enabled: boolean;
   share_timeout: number;
   refresh_min_interval: number;
+  history_enabled: boolean;
+  history_limit: number;
 }
 
 type _Config = _ConfigDeep & _ConfigShallow;

--- a/hyperglass/ui/types/globals.d.ts
+++ b/hyperglass/ui/types/globals.d.ts
@@ -53,24 +53,26 @@ export declare global {
     format: 'text/plain' | 'application/json';
   };
 
-  type ShareResponse = {
+  interface ResultSnapshot {
     id: string;
-    output: string | StructuredResponse;
-    cached: boolean;
-    shared: boolean;
-    runtime: number;
-    timestamp: string;
-    format: string;
-    // Backend declares level as a plain string and always stores 'success' today;
-    // typed as ResponseLevel to allow future warning/error shares.
+    output: QueryResponse['output'];
+    format: QueryResponse['format'];
     level: ResponseLevel;
+    timestamp: string;
+    runtime: number;
+    cached: boolean;
     keywords: string[];
     // Nested dict keys are NOT camelCased by backend pydantic; keep snake_case.
-    query: { query_location: string; query_target: string | string[]; query_type: string };
     queryLabels: { location: string; type: string };
+  }
+
+  interface ShareResponse extends ResultSnapshot {
+    shared: boolean;
+    // Nested dict keys are NOT camelCased by backend pydantic; keep snake_case.
+    query: { query_location: string; query_target: string | string[]; query_type: string };
     createdAt: string;
     expiresAt: string;
-  };
+  }
 
   type ShareCreateResponse = {
     id: string;

--- a/hyperglass/ui/types/globals.d.ts
+++ b/hyperglass/ui/types/globals.d.ts
@@ -57,6 +57,7 @@ export declare global {
     id: string;
     output: QueryResponse['output'];
     format: QueryResponse['format'];
+    // Backend stores 'success' for cached/shared results; typed as ResponseLevel for future warning/error support.
     level: ResponseLevel;
     timestamp: string;
     runtime: number;

--- a/hyperglass/ui/util/history-id.test.ts
+++ b/hyperglass/ui/util/history-id.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { makeSubmissionId } from './history-id';
 
 describe('makeSubmissionId', () => {

--- a/hyperglass/ui/util/history-id.test.ts
+++ b/hyperglass/ui/util/history-id.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { makeSubmissionId } from './history-id';
+
+describe('makeSubmissionId', () => {
+  it('returns a non-empty string', () => {
+    expect(typeof makeSubmissionId()).toBe('string');
+    expect(makeSubmissionId().length).toBeGreaterThan(0);
+  });
+
+  it('returns unique values across calls', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => makeSubmissionId()));
+    expect(ids.size).toBe(100);
+  });
+});

--- a/hyperglass/ui/util/history-id.ts
+++ b/hyperglass/ui/util/history-id.ts
@@ -1,0 +1,10 @@
+/**
+ * Generate a unique submission id. Prefers crypto.randomUUID, with a fallback
+ * for environments that lack it.
+ */
+export function makeSubmissionId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/hyperglass/ui/util/history-storage.test.ts
+++ b/hyperglass/ui/util/history-storage.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { shrinkSerialized } from './history-storage';
+
+const make = (entries: unknown[]) =>
+  JSON.stringify({ state: { entries }, version: 1 });
+
+describe('shrinkSerialized', () => {
+  it('strips output from the oldest entry that still has one', () => {
+    const serialized = make([
+      { id: 'new', results: { d1: { output: 'A' } } },
+      { id: 'old', results: { d1: { output: 'B' } } },
+    ]);
+    const out = JSON.parse(shrinkSerialized(serialized) as string);
+    // oldest (last) entry stripped first
+    expect('output' in out.state.entries[1].results.d1).toBe(false);
+    expect(out.state.entries[0].results.d1.output).toBe('A');
+  });
+
+  it('drops the oldest entry once no outputs remain to strip', () => {
+    const serialized = make([
+      { id: 'new', results: { d1: {} } },
+      { id: 'old', results: { d1: {} } },
+    ]);
+    const out = JSON.parse(shrinkSerialized(serialized) as string);
+    expect(out.state.entries).toHaveLength(1);
+    expect(out.state.entries[0].id).toBe('new');
+  });
+
+  it('returns null when nothing remains', () => {
+    expect(shrinkSerialized(make([]))).toBeNull();
+    expect(shrinkSerialized('not json')).toBeNull();
+  });
+});

--- a/hyperglass/ui/util/history-storage.test.ts
+++ b/hyperglass/ui/util/history-storage.test.ts
@@ -1,8 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { shrinkSerialized } from './history-storage';
 
-const make = (entries: unknown[]) =>
-  JSON.stringify({ state: { entries }, version: 1 });
+const make = (entries: unknown[]) => JSON.stringify({ state: { entries }, version: 1 });
 
 describe('shrinkSerialized', () => {
   it('strips output from the oldest entry that still has one', () => {

--- a/hyperglass/ui/util/history-storage.ts
+++ b/hyperglass/ui/util/history-storage.ts
@@ -1,0 +1,82 @@
+import type { StateStorage } from 'zustand/middleware';
+
+/**
+ * Incrementally shrink a serialized persisted-history blob to fit under the
+ * localStorage quota: first strip `output` from the oldest entry that still has
+ * one, then (when no outputs remain) drop the oldest entry. Returns the new
+ * serialized string, or null when nothing remains / input is unparseable.
+ */
+export function shrinkSerialized(serialized: string): string | null {
+  let parsed: { state?: { entries?: unknown[] } };
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    return null;
+  }
+  const entries = parsed?.state?.entries;
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return null;
+  }
+  // Entries are stored newest-first, so the oldest is at the end.
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i] as { results?: Record<string, { output?: unknown }> };
+    const results = entry.results ?? {};
+    for (const key of Object.keys(results)) {
+      if (results[key] && 'output' in results[key]) {
+        delete results[key].output;
+        return JSON.stringify(parsed);
+      }
+    }
+  }
+  entries.pop();
+  return JSON.stringify(parsed);
+}
+
+/**
+ * A zustand StateStorage backed by localStorage that never throws: reads and
+ * writes are guarded, and a QuotaExceededError on write triggers incremental
+ * shrink-and-retry via shrinkSerialized.
+ */
+export const historyStorage: StateStorage = {
+  getItem(name: string): string | null {
+    try {
+      return typeof window === 'undefined' ? null : window.localStorage.getItem(name);
+    } catch {
+      return null;
+    }
+  },
+  setItem(name: string, value: string): void {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(name, value);
+      return;
+    } catch {
+      let current: string | null = value;
+      // Shrink until it fits or there is nothing left to store.
+      while (current !== null) {
+        current = shrinkSerialized(current);
+        if (current === null) {
+          try {
+            window.localStorage.removeItem(name);
+          } catch {
+            /* ignore */
+          }
+          return;
+        }
+        try {
+          window.localStorage.setItem(name, current);
+          return;
+        } catch {
+          /* keep shrinking */
+        }
+      }
+    }
+  },
+  removeItem(name: string): void {
+    try {
+      if (typeof window !== 'undefined') window.localStorage.removeItem(name);
+    } catch {
+      /* ignore */
+    }
+  },
+};

--- a/hyperglass/ui/util/history-storage.ts
+++ b/hyperglass/ui/util/history-storage.ts
@@ -23,6 +23,7 @@ export function shrinkSerialized(serialized: string): string | null {
     const results = entry.results ?? {};
     for (const key of Object.keys(results)) {
       if (results[key] && 'output' in results[key]) {
+        // biome-ignore lint/performance/noDelete: key must be absent (not undefined) so JSON.stringify omits it; verified by test
         delete results[key].output;
         return JSON.stringify(parsed);
       }

--- a/hyperglass/ui/util/index.ts
+++ b/hyperglass/ui/util/index.ts
@@ -1,4 +1,5 @@
 export * from './common';
 export * from './config';
+export * from './history-id';
 export * from './state';
 export * from './theme';


### PR DESCRIPTION
## Summary

Adds a **per-browser query history** to the hyperglass landing page. Recent *successful* queries are stored in `localStorage` and shown below the form on the pristine landing view. Each entry can be:

- **Open** — replay the locally-cached output (read-only, no backend call)
- **Share** — mint a share link (single-device entries; reuses the share-results endpoints)
- **Re-run** — run the same query again (new timeline entry)
- **New target** — pre-fill location + type, change the target
- **Delete** — remove the entry (plus a Clear-all)

History is a frontend feature (Zustand `persist` + a quota-aware storage adapter); the only backend changes are config knobs.

### Operator config (all ship via build-time `hyperglass.json` — changing them needs a UI rebuild)
- `cache.history_enabled` (bool, default `true`) — global kill-switch
- `cache.history_limit` (int, default `10`) — retained entries per browser
- per-directive `history` (bool, default `true`) — set `false` to keep a sensitive query type out of history; the UI then shows a "not saved to history" hint

### Notable design points
- One history entry = one Submit (grouped by a generated `submissionId`); repeated runs are kept as a **timeline** (no dedupe).
- Successful results only; partially-failed submissions keep the successful subset.
- Count cap + FIFO; on localStorage quota pressure the adapter strips oldest outputs, then drops oldest entries (never throws).
- Reuses the share-results read-only render path via a new extracted `SnapshotResults` component; `Result` gains a `showShare` prop (decoupled from `readOnly`).
- `RecentQueries` is `ssr:false` + mounted-gated to avoid `next export` hydration mismatch.
- Privacy: history stores query targets in the browser; documented guidance to lower the limit or disable on shared/kiosk terminals.

Built on the already-merged share-results feature; rebased on top of the zustand v5 migration (#116).

Spec: `docs/superpowers/specs/2026-06-03-query-history-design.md` · Plan: `docs/superpowers/plans/2026-06-04-query-history.md`

## Test Plan

Automated (all green on this branch):
- [x] Backend: `uv run pytest hyperglass --ignore hyperglass/plugins/external` (104 passed / 1 skipped) + `ruff check` clean
- [x] Frontend: `pnpm --dir ./hyperglass/ui test` (109 passed) + `typecheck` clean + `biome lint` clean

Manual (reviewer, on a live deploy with ≥2 devices sharing a directive):
- [ ] Run a query; confirm it appears under "Recent queries" on returning to the pristine form
- [ ] Open replays the cached output; multi-device entries show each device's own Share button
- [ ] Single-device row Share mints a link (or 410s gracefully after `cache.timeout`)
- [ ] Re-run and New-target pre-fill correctly (incl. multi-device); Re-run adds a new timeline entry
- [ ] Delete + Clear-all behave; survive reload; respect `history_limit`
- [ ] Set a directive `history: false` (rebuild UI) → that type is never recorded and the hint shows; set `cache.history_enabled: false` (rebuild) → list + hint gone

## Follow-ups (non-blocking)
- `web.text.historyShare` is currently unused (row uses the existing ShareButton label) — wire or remove
- Add component-level tests for the Re-run / New-target row actions (core `prefillForm` logic is already covered)