### PR TITLE
fix(ui): unreachable 'error' branch in response-level mapping (closes #106)

### DIFF
--- a/hyperglass/ui/components/results/individual.tsx
+++ b/hyperglass/ui/components/results/individual.tsx
@@ -30,6 +30,7 @@ import {
   useTableToString,
 } from '~/hooks';
 import { isStringOutput, isStructuredOutput } from '~/types';
+import { levelToStatus } from '~/util';
 import { CopyButton } from './copy-button';
 import { FormattedError } from './formatted-error';
 import { isFetchError, isLGError, isLGOutputOrError, isStackError } from './guards';
@@ -87,16 +88,7 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
   const [lastResponseAt, setLastResponseAt] = useState<number>(() => Date.now());
 
   const setErrorLevel = (level: ResponseLevel): void => {
-    let e: ErrorLevels = 'error';
-    switch (level) {
-      case 'success':
-        e = level;
-        break;
-      case 'warning' || 'error':
-        e = 'warning';
-        break;
-    }
-    _setErrorLevel(e);
+    _setErrorLevel(levelToStatus(level));
   };
 
   // When snapshot is provided, coerce it to a QueryResponse shape so all

--- a/hyperglass/ui/util/common.test.ts
+++ b/hyperglass/ui/util/common.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it, test } from 'vitest';
-import { all, andJoin, chunkArray, dedupObjectArray, entries, isFQDN } from './common';
+import {
+  all,
+  andJoin,
+  chunkArray,
+  dedupObjectArray,
+  entries,
+  isFQDN,
+  levelToStatus,
+} from './common';
+
+describe('levelToStatus - map backend response level to alert status', () => {
+  it('passes success through', () => {
+    expect(levelToStatus('success')).toBe('success');
+  });
+  it('passes warning through', () => {
+    expect(levelToStatus('warning')).toBe('warning');
+  });
+  it('maps error to error (regression: was unreachable via `warning || error` case)', () => {
+    expect(levelToStatus('error')).toBe('error');
+  });
+  it("maps danger to error (no 'danger' alert status exists)", () => {
+    expect(levelToStatus('danger')).toBe('error');
+  });
+});
 
 test('all - all items are truthy', () => {
   // biome-ignore lint/suspicious/noSelfCompare: because this is a test, duh

--- a/hyperglass/ui/util/common.ts
+++ b/hyperglass/ui/util/common.ts
@@ -1,3 +1,22 @@
+import type { ErrorLevels } from '~/types';
+
+/**
+ * Map a backend response level onto an alert status.
+ *
+ * `ResponseLevel` includes `danger`, which has no alert-status equivalent and
+ * renders as `error`. (Regression guard: an earlier `case 'warning' || 'error'`
+ * expression made the `error` branch unreachable — see issue #106.)
+ */
+export function levelToStatus(level: ResponseLevel): ErrorLevels {
+  switch (level) {
+    case 'success':
+    case 'warning':
+      return level;
+    default:
+      return 'error';
+  }
+}
+
 export function all<I extends unknown>(...iter: I[]): boolean {
   for (const i of iter) {
     if (!i) {


### PR DESCRIPTION
Closes #106.

## The bug

```ts
case 'warning' || 'error':   // evaluates to 'warning' — the 'error' arm is dead
```

TypeScript 5.8+ flags this as TS2872 ("always truthy"), which is what's blocking Renovate #44 (TS 5.9.3) and is a prerequisite for #78 (TS 6).

## Intent analysis — one correction to the issue text

The issue suggested splitting into `case 'warning': case 'error':` (the author's literal text, mapping **error → 'warning'**). On inspection that would be wrong: `errorLevel` feeds Chakra `<Alert status={...}>`, and `ErrorLevels` has no `'danger'`. The **shipped** behavior — `error` (and `danger`) falling through to the `'error'` status — is the correct mapping; an error-level response should render as an error, not a warning.

So the fix **preserves runtime behavior exactly** while removing the dead expression.

## Change

- New pure helper `levelToStatus(level: ResponseLevel): ErrorLevels` in `util/common.ts` (success/warning pass through; everything else → `'error'`), with a doc comment marking the regression
- 4 unit tests in `util/common.test.ts` — including an explicit regression case for `error → 'error'` and `danger → 'error'` (TDD: confirmed failing before the helper existed)
- `individual.tsx`'s `setErrorLevel` reduced to a one-liner using the helper

## Verification

- vitest: **76 passed** (72 + 4 new)
- `tsc --noEmit` clean; `biome lint` clean (147 files); `biome format` clean

## Unblocks

Renovate **#44** (TS 5.9.3 — a minor, automerges once it rebases past this) and removes one of the two prerequisites for **#112**'s TS 6 step.