### PR TITLE
chore(ui): remove unused web.text.historyShare string

### DIFF
--- a/hyperglass/models/config/web.py
+++ b/hyperglass/models/config/web.py
@@ -139,7 +139,6 @@ class Text(HyperglassModel):
     history_clear_confirm: str = "Clear all saved queries?"
     history_back: str = "Back"
     history_open: str = "Open"
-    history_share: str = "Share"
     history_rerun: str = "Run again"
     history_new_target: str = "Run with a new target"
     history_delete: str = "Delete"

--- a/hyperglass/ui/types/config.ts
+++ b/hyperglass/ui/types/config.ts
@@ -63,7 +63,6 @@ interface _Text {
   history_clear_confirm: string;
   history_back: string;
   history_open: string;
-  history_share: string;
   history_rerun: string;
   history_new_target: string;
   history_delete: string;


### PR DESCRIPTION
## Summary
Follow-up from the query-history feature (#117), taking the recommended option from #119: remove the dead `history_share` config string.

`HistoryEntryRow` renders the existing `ShareButton`, which uses `web.text.shareButton` for its label — `web.text.historyShare` was never consumed anywhere.

- Drop `history_share` from `Text` in `hyperglass/models/config/web.py`
- Drop `history_share` from `_Text` in `hyperglass/ui/types/config.ts`

No live docs referenced the key (only historical design/plan artifacts, left untouched).

## Testing
- `ruff check` clean on the edited file
- `pnpm vitest run components/history` — 9 passed
- `pytest hyperglass/models` — 26 passed

Closes #119