### PR TITLE
ci(frontend): add next build step and refresh Node matrix (drop EOL 21, add 24)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,7 +19,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [20.x, 21.x, 22.x]
+                node-version: [20.x, 22.x, 24.x]
                 pnpm-version: [9, 10]
                 os: [ubuntu-latest]
         runs-on: ${{ matrix.os }}
@@ -43,9 +43,12 @@ jobs:
               working-directory: ${{ env.working-directory }}
               run: pnpm install
 
-            - name: Create empty hyperglass.json
+            # next build prerenders pages that import hyperglass.json at build
+            # time, so an empty stub isn't enough — use a realistic fixture
+            # generated from the .tests config (see .tests/hyperglass.json).
+            - name: Create hyperglass.json from fixture
               working-directory: ${{ env.working-directory }}
-              run: echo '{}' > hyperglass.json
+              run: cp ../../.tests/hyperglass.json hyperglass.json
 
             - name: Formatting
               working-directory: ${{ env.working-directory }}
@@ -62,3 +65,9 @@ jobs:
             - name: Tests
               working-directory: ${{ env.working-directory }}
               run: pnpm run test:coverage
+
+            # Catch production-build breakage (webpack/prerender) that
+            # format/lint/typecheck/vitest don't exercise.
+            - name: Production Build
+              working-directory: ${{ env.working-directory }}
+              run: pnpm exec next build

--- a/.tests/hyperglass.json
+++ b/.tests/hyperglass.json
@@ -1,0 +1,262 @@
+{
+  "requestTimeout": 90,
+  "primaryAsn": "65001",
+  "orgName": "Beloved Hyperglass User",
+  "siteTitle": "hyperglass",
+  "siteDescription": "Beloved Hyperglass User Network Looking Glass",
+  "cache": {
+    "timeout": 600,
+    "showText": true,
+    "shareEnabled": true,
+    "shareTimeout": 604800,
+    "refreshMinInterval": 120,
+    "historyEnabled": true,
+    "historyLimit": 10
+  },
+  "web": {
+    "credit": {
+      "enable": true
+    },
+    "dnsProvider": {
+      "name": "cloudflare",
+      "url": "https://cloudflare-dns.com/dns-query"
+    },
+    "links": [
+      {
+        "title": "PeeringDB",
+        "url": "https://www.peeringdb.com/asn/65001",
+        "showIcon": true,
+        "side": "left",
+        "order": 0
+      }
+    ],
+    "menus": [
+      {
+        "title": "Terms",
+        "content": "\nBy using hyperglass, you agree to be bound by the following terms of use:\n\nAll queries executed on this page are logged for analysis and troubleshooting. Users are prohibited from automating queries, or attempting to process queries in bulk. This service is provided on a best effort basis, and Beloved Hyperglass User makes no availability or performance warranties or guarantees whatsoever.\n",
+        "side": "left",
+        "order": 0
+      },
+      {
+        "title": "Help",
+        "content": "\n##### BGP Route\n\nPerforms BGP table lookup based on IPv4/IPv6 prefix.\n\n---\n\n##### BGP Community\n\nPerforms BGP table lookup based on [Extended](https://tools.ietf.org/html/rfc4360) or [Large](https://tools.ietf.org/html/rfc8195) community value.\n\n---\n\n##### BGP AS Path\n\nPerforms BGP table lookup based on `AS_PATH` regular expression.\n\n---\n\n##### Ping\n\nSends 5 ICMP echo requests to the target.\n\n---\n\n##### Traceroute\n\nPerforms UDP Based traceroute to the target.\n\nFor information about how to interpret traceroute results, [click here](https://hyperglass.dev/traceroute_nanog.pdf).\n",
+        "side": "left",
+        "order": 0
+      }
+    ],
+    "greeting": {
+      "enable": false,
+      "file": null,
+      "title": "Welcome",
+      "button": "Continue",
+      "required": false
+    },
+    "logo": {
+      "light": "hyperglass-light.svg",
+      "dark": "hyperglass-dark.svg",
+      "favicon": "hyperglass-icon.svg",
+      "width": "50%",
+      "height": null,
+      "lightFormat": ".svg",
+      "darkFormat": ".svg"
+    },
+    "opengraph": {
+      "image": "/home/jsenecal/Code/hyperglass/hyperglass/images/hyperglass-opengraph.jpg"
+    },
+    "text": {
+      "titleMode": "logo_only",
+      "title": "hyperglass",
+      "subtitle": "Network Looking Glass",
+      "queryLocation": "Location",
+      "queryType": "Query Type",
+      "queryTarget": "Target",
+      "fqdnTooltip": "Use {protocol}",
+      "fqdnMessage": "Your browser has resolved {fqdn} to",
+      "fqdnError": "Unable to resolve {fqdn}",
+      "fqdnErrorButton": "Try Again",
+      "cachePrefix": "Results cached for ",
+      "cacheIcon": "Cached from {time} UTC",
+      "completeTime": "Completed in {seconds}",
+      "rpkiInvalid": "Invalid",
+      "rpkiValid": "Valid",
+      "rpkiUnknown": "No ROAs Exist",
+      "rpkiUnverified": "Not Verified",
+      "noCommunities": "No Communities",
+      "ipError": "Unable to determine IP Address",
+      "noIp": "No {protocol} Address",
+      "ipSelect": "Select an IP Address",
+      "ipButton": "My IP",
+      "shareButton": "Share",
+      "sharePopoverTitle": "Share this result",
+      "shareCopyLink": "Copy link",
+      "shareLinkCopied": "Copied!",
+      "shareExpiresAt": "Expires {expires}",
+      "shareCreateError": "Could not create share link.",
+      "shareCreateExpired": "This result has expired from cache. Refresh and try again.",
+      "shareNotFound": "Share not found or expired.",
+      "shareSnapshotBanner": "Snapshot taken at {timestamp}",
+      "shareRunFreshQuery": "Run a fresh query",
+      "refreshCooldown": "Refresh available in {seconds}s",
+      "requeryTooltip": "Reload Query",
+      "historyTitle": "Recent queries",
+      "historyClearAll": "Clear all",
+      "historyClearConfirm": "Clear all saved queries?",
+      "historyBack": "Back",
+      "historyOpen": "Open",
+      "historyRerun": "Run again",
+      "historyNewTarget": "Run with a new target",
+      "historyDelete": "Delete",
+      "historyDisabledHint": "Results for this query type are not saved to history."
+    },
+    "theme": {
+      "colors": {
+        "black": "black",
+        "white": "white",
+        "dark": "#010101",
+        "light": "#f5f6f7",
+        "gray": "#c1c7cc",
+        "red": "#d84b4b",
+        "orange": "#ff6b35",
+        "yellow": "#edae49",
+        "green": "#35b246",
+        "blue": "#314cb6",
+        "teal": "#35b299",
+        "cyan": "#118ab2",
+        "pink": "#f2607d",
+        "purple": "#8d30b5",
+        "primary": "#118ab2",
+        "secondary": "#314cb6",
+        "success": "#35b246",
+        "warning": "#edae49",
+        "error": "#ff6b35",
+        "danger": "#d84b4b"
+      },
+      "defaultColorMode": null,
+      "fonts": {
+        "body": "Nunito",
+        "mono": "Fira Code"
+      }
+    },
+    "locationDisplayMode": "auto",
+    "customJavascript": null,
+    "customHtml": null,
+    "highlight": []
+  },
+  "messages": {
+    "noInput": "{field} must be specified.",
+    "targetNotAllowed": "{target} is not allowed.",
+    "featureNotEnabled": "{feature} is not enabled.",
+    "invalidInput": "{target} is not valid.",
+    "invalidQuery": "{target} is not a valid {query_type} target.",
+    "invalidField": "{input} is an invalid {field}.",
+    "general": "Something went wrong.",
+    "notFound": "{type} '{name}' not found.",
+    "requestTimeout": "Request timed out.",
+    "connectionError": "Error connecting to {device_name}: {error}",
+    "authenticationError": "Authentication error occurred.",
+    "noResponse": "No response.",
+    "noOutput": "The query completed, but no matching results were found.",
+    "historyDeviceUnavailable": "The device for this saved query is no longer available."
+  },
+  "version": "2.1.0.dev0",
+  "devices": [
+    {
+      "group": "Test",
+      "locations": [
+        {
+          "id": "example_device",
+          "name": "Example Device",
+          "group": "Test",
+          "avatar": null,
+          "description": null,
+          "directives": [
+            {
+              "id": "juniper_bgp_route",
+              "name": "BGP Route",
+              "fieldType": "text",
+              "groups": [
+                "Global"
+              ],
+              "description": "IP Address or Prefix",
+              "info": null,
+              "options": null,
+              "history": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "parsedDataFields": [
+    [
+      "Prefix",
+      "prefix",
+      "left"
+    ],
+    [
+      "Active",
+      "active",
+      null
+    ],
+    [
+      "RPKI State",
+      "rpki_state",
+      "center"
+    ],
+    [
+      "AS Path",
+      "as_path",
+      "left"
+    ],
+    [
+      "Next Hop",
+      "next_hop",
+      "left"
+    ],
+    [
+      "Origin",
+      "source_as",
+      null
+    ],
+    [
+      "Weight",
+      "weight",
+      "center"
+    ],
+    [
+      "Local Preference",
+      "local_preference",
+      "center"
+    ],
+    [
+      "MED",
+      "med",
+      "center"
+    ],
+    [
+      "Communities",
+      "communities",
+      "center"
+    ],
+    [
+      "Originator",
+      "source_rid",
+      "right"
+    ],
+    [
+      "Peer",
+      "peer_rid",
+      "right"
+    ],
+    [
+      "Age",
+      "age",
+      "right"
+    ]
+  ],
+  "content": {
+    "credit": "\nPowered by [**hyperglass**](https://hyperglass.dev) version 2.1.0.dev0. Source code licensed [_BSD 3-Clause Clear_](https://hyperglass.dev/license/).\n",
+    "greeting": ""
+  },
+  "developerMode": false
+}

--- a/hyperglass/ui/hooks/use-dns-query.test.tsx
+++ b/hyperglass/ui/hooks/use-dns-query.test.tsx
@@ -1,5 +1,5 @@
-import 'isomorphic-fetch';
-import { expect, describe, it } from 'vitest';
+import isomorphicFetch from 'isomorphic-fetch';
+import { expect, describe, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { renderHook } from '@testing-library/react-hooks';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
@@ -7,6 +7,13 @@ import { HyperglassContext } from '~/context';
 import { useDNSQuery } from './use-dns-query';
 
 import type { Config } from '~/types';
+
+// These tests perform live DNS-over-HTTPS queries. Node's native fetch (undici) brand-checks
+// `RequestInit.signal` and rejects jsdom's AbortSignal (enforced as of Node 24), so the
+// isomorphic-fetch (node-fetch) implementation — which accepts cross-realm signals — must be
+// explicitly stubbed in; its side-effect global assignment is a no-op when a global fetch
+// already exists (always, since Node 18).
+vi.stubGlobal('fetch', isomorphicFetch);
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, cacheTime: Infinity } },

--- a/hyperglass/ui/package.json
+++ b/hyperglass/ui/package.json
@@ -60,12 +60,14 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.11.0",
     "@biomejs/biome": "1.5.3",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.5.2",
     "@types/dagre": "^0.7.44",
+    "@types/isomorphic-fetch": "^0.0.39",
     "@types/lodash": "^4.14.177",
     "@types/node": "^20.11.20",
     "@types/react": "^18.2.60",
@@ -76,7 +78,6 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "1.3.1",
     "@vitest/ui": "^1.3.1",
-    "@babel/eslint-parser": "^7.11.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",

--- a/hyperglass/ui/pnpm-lock.yaml
+++ b/hyperglass/ui/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@types/dagre':
         specifier: ^0.7.44
         version: 0.7.54
+      '@types/isomorphic-fetch':
+        specifier: ^0.0.39
+        version: 0.0.39
       '@types/lodash':
         specifier: ^4.14.177
         version: 4.14.177
@@ -1577,6 +1580,9 @@ packages:
 
   '@types/geojson@7946.0.7':
     resolution: {integrity: sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==}
+
+  '@types/isomorphic-fetch@0.0.39':
+    resolution: {integrity: sha512-I0gou/ZdA1vMG7t7gMzL7VYu2xAKU78rW9U1l10MI0nn77pEHq3tQqHQ8hMmXdMpBlkxZOorjI4sO594Z3kKJw==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -5735,6 +5741,8 @@ snapshots:
   '@types/estree@1.0.5': {}
 
   '@types/geojson@7946.0.7': {}
+
+  '@types/isomorphic-fetch@0.0.39': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 

--- a/hyperglass/ui/util/common.test.ts
+++ b/hyperglass/ui/util/common.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, test } from 'vitest';
+import { afterEach, describe, expect, it, test, vi } from 'vitest';
 import {
   all,
   andJoin,
   chunkArray,
   dedupObjectArray,
   entries,
+  fetchWithTimeout,
   isFQDN,
   levelToStatus,
 } from './common';
@@ -119,5 +120,40 @@ describe('isFQDN - determine if a string is an FQDN pattern', () => {
   });
   it('is an array of FQDNs and should be true', () => {
     expect(isFQDN(['www.example.com'])).toBe(true);
+  });
+});
+
+describe('fetchWithTimeout - fetch with abort timeout', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('passes the controller signal to fetch', async () => {
+    const controller = new AbortController();
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchSpy);
+    await fetchWithTimeout('https://example.com', {}, 1_000, controller);
+    // Identity check — deep equality cannot distinguish AbortSignal instances.
+    expect(fetchSpy.mock.calls[0][1].signal).toBe(controller.signal);
+  });
+
+  it('aborts the controller when the timeout elapses', () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    // A fetch that never settles on its own.
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    fetchWithTimeout('https://example.com', {}, 1_000, controller);
+    vi.advanceTimersByTime(1_000);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('does not abort the controller after the fetch settles', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    await fetchWithTimeout('https://example.com', {}, 1_000, controller);
+    vi.advanceTimersByTime(2_000);
+    expect(controller.signal.aborted).toBe(false);
   });
 });

--- a/hyperglass/ui/util/common.ts
+++ b/hyperglass/ui/util/common.ts
@@ -60,19 +60,24 @@ export async function fetchWithTimeout(
   controller: AbortController,
 ): Promise<Response> {
   /**
-   * Lets set up our `AbortController`, and create a request options object that includes the
-   * controller's `signal` to pass to `fetch`.
+   * Create a request options object that includes the controller's `signal` to pass to `fetch`,
+   * unless the caller provided its own `signal`.
    */
-  const { signal = new AbortController().signal, ...allOptions } = options;
+  const { signal = controller.signal, ...allOptions } = options;
   const config = { ...allOptions, signal };
   /**
    * Set a timeout limit for the request using `setTimeout`. If the body of this timeout is
-   * reached before the request is completed, it will be cancelled.
+   * reached before the request is completed, it will be cancelled. Clear the timer once the
+   * request settles so a completed request doesn't abort the controller afterwards.
    */
-  setTimeout(() => {
+  const timer = setTimeout(() => {
     controller.abort();
   }, timeout);
-  return await fetch(uri, config);
+  try {
+    return await fetch(uri, config);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export function dedupObjectArray<E extends Record<string, unknown>, P extends keyof E = keyof E>(


### PR DESCRIPTION
Closes #115

## What

1. **Adds a `Production Build` step** (`pnpm exec next build`) to the Frontend Testing job. Previously, production-build breakage (e.g. #97 react-icons v5's webpack failure, #100 vest's module crash) sailed through format/lint/typecheck/vitest and was only caught incidentally by the Backend job's "Run hyperglass" step.
2. **Replaces the empty `{}` `hyperglass.json` stub with a realistic fixture.** `next build` prerenders `_app`/`_document`, which import `hyperglass.json` at build time — an empty stub crashes prerendering (`Cannot read properties of undefined (reading 'theme')`). The fixture (`.tests/hyperglass.json`) is the `UIParameters` export generated from the same `.tests/` devices/directives config the Backend job already uses, with machine-specific logo paths sanitized (the frontend only reads the `lightFormat`/`darkFormat` suffixes — see `components/header/logo.tsx`).
3. **Node matrix: `[20.x, 21.x, 22.x]` → `[20.x, 22.x, 24.x]`** — Node 21 is EOL (June 2024) and outside jsdom 29's `engines` range; 24 is current LTS-track.

## Node 24 fallout fixed along the way

The first CI run failed on Node 24 only: all 4 `use-dns-query` tests timed out. Root cause analysis:

- In the vitest jsdom env, `AbortController` is jsdom's implementation but `fetch` is Node's native fetch — the `import 'isomorphic-fetch'` in the test has been a no-op since Node 18 (it only assigns `global.fetch` when missing).
- Node 24's undici brand-checks `RequestInit.signal` and rejects jsdom's `AbortSignal` with a synchronous `TypeError` (Node 20/22 tolerated cross-realm signals), so the query errored instantly and the test waited for `isSuccess` until timeout. **The tests never reached the network.**
- Fix: explicitly stub isomorphic-fetch's node-fetch implementation (which accepts cross-realm signals) as the global fetch — the tests stay live DNS-over-HTTPS integration tests on all Node versions.

The investigation also surfaced a real bug in `fetchWithTimeout` (`util/common.ts`): the timeout aborted the caller's controller, but the signal handed to `fetch` came from a brand-new unrelated `AbortController` — so the request timeout and `use-lg-query`'s unmount cancellation have never actually aborted anything. Fixed (signal defaults to `controller.signal`, timer cleared once the request settles so a reused controller isn't aborted post-completion) with unit tests covering all three behaviors.

## Verification

- Full vitest suite: **120/120 on Node 24** (clean `pnpm install --frozen-lockfile` in a `node:24` container) and locally.
- `pnpm exec next build` with the committed fixture: exit 0 (static export of all pages).
- `tsc --noEmit`, `biome lint`, `biome format` all clean.

## Notes

- Fixture regeneration, should the `UIParameters` schema change: point `HYPERGLASS_APP_PATH` at a dir containing the `.tests` YAML files, run `init_user_config()`, and export `use_state('ui_params').export_json(by_alias=True)`.
- Side-finding: `.tests/ga-backend-app.sh` runs `hyperglass.console setup -d`, but `-d` is not a valid option — the script swallows the error and only works because `config.yaml` is optional. Filed under the #105 CLI modernization umbrella.
