### PR TITLE
chore(ui): vest 6 + react-hook-form 7.77, replace @hookform/resolvers with in-repo resolver

### DIFF
--- a/hyperglass/ui/components/looking-glass-form.tsx
+++ b/hyperglass/ui/components/looking-glass-form.tsx
@@ -1,9 +1,8 @@
 import { Flex, ScaleFade, SlideFade, chakra } from '@chakra-ui/react';
-import { vestResolver } from '@hookform/resolvers/vest';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import vest, { test, enforce } from 'vest';
+import { create, enforce, test } from 'vest';
 import { useShallow } from 'zustand/react/shallow';
 import {
   DirectiveInfoModal,
@@ -18,7 +17,7 @@ import { useConfig } from '~/context';
 import { FormRow } from '~/elements';
 import { useDevice, useFormState, useGreeting, useStrf } from '~/hooks';
 import { Directive, isQueryField, isString } from '~/types';
-import { isFQDN, makeSubmissionId } from '~/util';
+import { isFQDN, makeSubmissionId, vestResolver } from '~/util';
 
 import type { FormData, OnChangeArgs } from '~/types';
 
@@ -51,7 +50,7 @@ export const LookingGlassForm = (): JSX.Element => {
 
   const queryTypes = useMemo(() => filtered.types.map(t => t.id), [filtered.types]);
 
-  const formSchema = vest.create((data: FormData = {} as FormData) => {
+  const formSchema = create((data: FormData = {} as FormData) => {
     test('queryLocation', noQueryLoc, () => {
       enforce(data.queryLocation).isArrayOf(enforce.isString()).isNotEmpty();
     });
@@ -64,7 +63,7 @@ export const LookingGlassForm = (): JSX.Element => {
   });
 
   const formInstance = useForm<FormData>({
-    resolver: vestResolver(formSchema),
+    resolver: vestResolver<FormData>(formSchema),
     defaultValues: {
       queryTarget: [],
       queryLocation: [],

--- a/hyperglass/ui/components/looking-glass-form.validation.test.tsx
+++ b/hyperglass/ui/components/looking-glass-form.validation.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * Tests the form validation path: the vest suite wired through our
+ * vestResolver (~/util/vest-resolver) must block submission and surface the
+ * configured error messages when fields are missing.  These live in a
+ * separate file so vi.mock hoisting does not conflict with the mocks in the
+ * other looking-glass-form test files.
+ */
+
+import { ChakraProvider } from '@chakra-ui/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// jsdom does not implement window.matchMedia; Chakra UI requires it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import type { Config } from '~/types';
+import { LookingGlassForm } from './looking-glass-form';
+
+// ---------------------------------------------------------------------------
+// next/router mock — query params are mutable so each test controls which
+// fields are pre-filled.
+// ---------------------------------------------------------------------------
+let mockRouterQuery: Record<string, string> = {};
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    query: mockRouterQuery,
+    isReady: true,
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Minimal device + directive matching the query params above
+// ---------------------------------------------------------------------------
+const mockDirective = {
+  id: 'juniper_bgp_route',
+  name: 'BGP Route',
+  fieldType: 'text',
+  description: 'IP prefix / host',
+  groups: [],
+  info: null,
+};
+
+const mockDevice = {
+  id: 'test1',
+  name: 'Test Router 1',
+  group: null,
+  avatar: null,
+  description: null,
+  directives: [mockDirective],
+};
+
+const mockConfig: Config = {
+  developerMode: false,
+  primaryAsn: '65000',
+  requestTimeout: 30,
+  orgName: 'Test Org',
+  siteTitle: 'hyperglass',
+  siteDescription: 'Looking Glass',
+  version: '2.0.0',
+  parsedDataFields: [],
+  devices: [{ group: null, locations: [mockDevice] }],
+  content: { credit: '', greeting: '' },
+  messages: {
+    noInput: '{field} is required.',
+    featureNotEnabled: 'Feature not enabled.',
+    invalidInput: 'Invalid input.',
+    general: 'An error occurred.',
+    requestTimeout: 'Request timed out.',
+    connectionError: 'Connection error.',
+    authenticationError: 'Authentication error.',
+    noOutput: 'No output.',
+  },
+  cache: {
+    showText: false,
+    timeout: 600,
+    shareEnabled: false,
+    shareTimeout: 604800,
+    refreshMinInterval: 120,
+  },
+  web: {
+    credit: { enable: false },
+    dnsProvider: { name: 'Cloudflare', url: 'https://cloudflare-dns.com/dns-query' },
+    links: [],
+    menus: [],
+    greeting: {
+      enable: false,
+      title: 'Welcome',
+      button: 'Continue',
+      required: false,
+    },
+    logo: {
+      width: '100%',
+      height: null,
+      lightFormat: 'png',
+      darkFormat: 'png',
+    },
+    text: {
+      titleMode: 'logo',
+      title: 'hyperglass',
+      subtitle: 'Looking Glass',
+      queryLocation: 'Location',
+      queryType: 'Query Type',
+      queryTarget: 'Query Target',
+      fqdnTooltip: 'Resolve hostname',
+      fqdnMessage: 'Resolving hostname',
+      fqdnError: 'Could not resolve hostname',
+      fqdnErrorButton: 'Try Again',
+      cachePrefix: 'Cached',
+      cacheIcon: '',
+      completeTime: 'Completed in {time}',
+      rpkiInvalid: 'INVALID',
+      rpkiValid: 'VALID',
+      rpkiUnknown: 'UNKNOWN',
+      rpkiUnverified: 'UNVERIFIED',
+      noCommunities: 'No communities',
+      ipError: 'IP address error',
+      noIp: 'No IP address detected',
+      ipSelect: 'Select IP address',
+      ipButton: 'Use My IP',
+      shareButton: 'Share',
+      sharePopoverTitle: 'Share this result',
+      shareCopyLink: 'Copy link',
+      shareLinkCopied: 'Copied!',
+      shareExpiresAt: 'Expires {expires}',
+      shareCreateError: 'Could not create share link.',
+      shareCreateExpired: 'Result expired.',
+      shareNotFound: 'Result not found.',
+      shareSnapshotBanner: 'Snapshot',
+      shareRunFreshQuery: 'Run a fresh query',
+      refreshCooldown: 'Wait {seconds}s',
+      requeryTooltip: 'Reload Query',
+    },
+    theme: {
+      colors: { primary: '#40C057' },
+      defaultColorMode: 'light',
+      fonts: { body: 'Inter', mono: 'Fira Mono' },
+    },
+    locationDisplayMode: 'gallery',
+    highlight: [],
+  },
+} as unknown as Config;
+
+// ---------------------------------------------------------------------------
+// ~/context mock
+// ---------------------------------------------------------------------------
+vi.mock('~/context', async () => {
+  const { QueryClient } =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    useConfig: () => mockConfig,
+    queryClient: new QueryClient(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={qc}>
+      <ChakraProvider>{children}</ChakraProvider>
+    </QueryClientProvider>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Reset form state and mark the greeting acknowledged before each test, so
+// validation is the only thing standing between a submit and submitHandler.
+// ---------------------------------------------------------------------------
+beforeEach(async () => {
+  const { useFormState } = await import('~/hooks');
+  const { useGreeting } = await import('~/hooks/use-greeting');
+  await act(async () => {
+    await useFormState.getState().reset();
+    useGreeting.setState({ isAck: true, greetingReady: true, isOpen: false });
+  });
+});
+
+describe('LookingGlassForm — vest validation blocks invalid submissions', () => {
+  it('shows the configured message and does not submit when queryTarget is empty', async () => {
+    const { useFormState } = await import('~/hooks');
+
+    // Location and type pre-filled; target left empty.
+    mockRouterQuery = { location: 'test1', type: 'juniper_bgp_route' };
+
+    const { container } = render(<LookingGlassForm />, { wrapper });
+
+    // Wait for the prefill effect — the directive-driven target field is the sentinel.
+    await screen.findByPlaceholderText('IP prefix / host');
+
+    fireEvent.submit(container.querySelector('form')!);
+
+    // messages.noInput ('{field} is required.') interpolated with web.text.queryTarget.
+    expect(await screen.findByText('Query Target is required.')).toBeInTheDocument();
+
+    // submitHandler stamps a submissionId on every run — null proves it never ran.
+    expect(useFormState.getState().submissionId).toBeNull();
+  });
+
+  it('shows the configured message and does not submit when the form is empty', async () => {
+    const { useFormState } = await import('~/hooks');
+
+    mockRouterQuery = {};
+
+    const { container } = render(<LookingGlassForm />, { wrapper });
+
+    fireEvent.submit(container.querySelector('form')!);
+
+    expect(await screen.findByText('Location is required.')).toBeInTheDocument();
+    expect(useFormState.getState().submissionId).toBeNull();
+  });
+
+  it('submits when all fields are valid', async () => {
+    const { useFormState } = await import('~/hooks');
+
+    mockRouterQuery = { location: 'test1', type: 'juniper_bgp_route', target: '192.0.2.0/24' };
+
+    const { container } = render(<LookingGlassForm />, { wrapper });
+    await screen.findAllByDisplayValue('192.0.2.0/24');
+
+    fireEvent.submit(container.querySelector('form')!);
+
+    // The vest suite passed: submitHandler ran and stamped a submissionId.
+    await vi.waitFor(() => {
+      expect(useFormState.getState().submissionId).toBeTruthy();
+    });
+
+    // And no validation error is shown.
+    expect(screen.queryByText('Query Target is required.')).not.toBeInTheDocument();
+  });
+});

--- a/hyperglass/ui/package.json
+++ b/hyperglass/ui/package.json
@@ -31,7 +31,6 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
     "@hookform/devtools": "^4.3.0",
-    "@hookform/resolvers": "^2.9.10",
     "@tanstack/react-query": "^4.22.0",
     "dagre": "^0.8.5",
     "dayjs": "^1.10.4",
@@ -46,7 +45,7 @@
     "react-device-detect": "^2.0.0",
     "react-dom": "^18.2.0",
     "react-fast-compare": "^3.2.1",
-    "react-hook-form": "^7.42.1",
+    "react-hook-form": "^7.77.0",
     "react-icons": "^4.3.1",
     "react-if": "^4.1.4",
     "react-markdown": "^5.0.3",
@@ -56,7 +55,7 @@
     "reactflow": "^11.10.4",
     "remark-gfm": "^1.0.0",
     "string-format": "^2.0.0",
-    "vest": "^3.2.8",
+    "vest": "^6.3.2",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/hyperglass/ui/pnpm-lock.yaml
+++ b/hyperglass/ui/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@hookform/devtools':
         specifier: ^4.3.0
         version: 4.3.0(@types/react@18.2.60)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@hookform/resolvers':
-        specifier: ^2.9.10
-        version: 2.9.11(react-hook-form@7.42.1(react@18.2.0))
       '@tanstack/react-query':
         specifier: ^4.22.0
         version: 4.22.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -75,8 +72,8 @@ importers:
         specifier: ^3.2.1
         version: 3.2.2
       react-hook-form:
-        specifier: ^7.42.1
-        version: 7.42.1(react@18.2.0)
+        specifier: ^7.77.0
+        version: 7.77.0(react@18.2.0)
       react-icons:
         specifier: ^4.3.1
         version: 4.3.1(react@18.2.0)
@@ -105,8 +102,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       vest:
-        specifier: ^3.2.8
-        version: 3.2.8
+        specifier: ^6.3.2
+        version: 6.3.2
       zustand:
         specifier: ^5.0.8
         version: 5.0.14(@types/react@18.2.60)(react@18.2.0)(use-sync-external-store@1.2.0(react@18.2.0))
@@ -1141,11 +1138,6 @@ packages:
       react: ^16.8.0 || ^17 || ^18
       react-dom: ^16.8.0 || ^17 || ^18
 
-  '@hookform/resolvers@2.9.11':
-    resolution: {integrity: sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ==}
-    peerDependencies:
-      react-hook-form: ^7.0.0
-
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
@@ -2014,6 +2006,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  context@4.0.17:
+    resolution: {integrity: sha512-SM/Rmr9egp0N3+t0kfIFz1Dayfcl+8bussTdW0lw9gU+KUe3v+QPVyxvr+KzVx13U5Ac0dCdjGacWION6NuRUQ==}
 
   convert-source-map@1.8.0:
     resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
@@ -3114,6 +3109,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  n4s@6.2.1:
+    resolution: {integrity: sha512-j1kYy6fD0wfIsvUiaSnKGQxKJ9ZWJDwwbX8muh2/Y1j+qDADFc+e/Ggy/Hvj3dYU3zQsvuSpViOsNY/nkNCDZQ==}
+
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3389,11 +3387,11 @@ packages:
       '@types/react':
         optional: true
 
-  react-hook-form@7.42.1:
-    resolution: {integrity: sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==}
-    engines: {node: '>=12.22.0'}
+  react-hook-form@7.77.0:
+    resolution: {integrity: sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-icons@4.3.1:
     resolution: {integrity: sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==}
@@ -3955,8 +3953,14 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  vest@3.2.8:
-    resolution: {integrity: sha512-O+GLawwfIO7ESODaJMevsI+LL959dZzjwK6oUYzMTxog+6fZ8U/NPR/ITX6tmECb8EEUVuLkNJ1lGOkoor35SA==}
+  vest-utils@2.0.17:
+    resolution: {integrity: sha512-12gNz4I3oXKO12sp4B0UBgY1b/m4Zmd7e7x1EDQkIDf/N+DHCOk1h16YGM6g/zZS1ZoJMvL35SADcEsZ+YMN3g==}
+
+  vest@6.3.2:
+    resolution: {integrity: sha512-gpXsKohvbntw2Z4VKNw04tax3EG4Av7z/8JyAe5qmpRUn2mxzPUh2OhmEf485i8v+oiCH49R+R6owVHYYlreGw==}
+
+  vestjs-runtime@2.0.17:
+    resolution: {integrity: sha512-6U2jLwvqtVSOE/kS0YFDZFLBT6a5TJEod787MVE4w691M32bW0y8uWZWquIJ7a96929/p/afH5lcVt4XGef1YQ==}
 
   vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
@@ -5314,10 +5318,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@hookform/resolvers@2.9.11(react-hook-form@7.42.1(react@18.2.0))':
-    dependencies:
-      react-hook-form: 7.42.1(react@18.2.0)
-
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
@@ -6271,6 +6271,10 @@ snapshots:
   compute-scroll-into-view@3.0.3: {}
 
   concat-map@0.0.1: {}
+
+  context@4.0.17:
+    dependencies:
+      vest-utils: 2.0.17
 
   convert-source-map@1.8.0:
     dependencies:
@@ -7600,6 +7604,11 @@ snapshots:
 
   ms@2.1.3: {}
 
+  n4s@6.2.1:
+    dependencies:
+      context: 4.0.17
+      vest-utils: 2.0.17
+
   nanoid@3.3.7: {}
 
   natural-compare@1.4.0: {}
@@ -7903,7 +7912,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.2.60
 
-  react-hook-form@7.42.1(react@18.2.0):
+  react-hook-form@7.77.0(react@18.2.0):
     dependencies:
       react: 18.2.0
 
@@ -8503,7 +8512,19 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vest@3.2.8: {}
+  vest-utils@2.0.17: {}
+
+  vest@6.3.2:
+    dependencies:
+      context: 4.0.17
+      n4s: 6.2.1
+      vest-utils: 2.0.17
+      vestjs-runtime: 2.0.17
+
+  vestjs-runtime@2.0.17:
+    dependencies:
+      context: 4.0.17
+      vest-utils: 2.0.17
 
   vfile-message@2.0.4:
     dependencies:

--- a/hyperglass/ui/util/index.ts
+++ b/hyperglass/ui/util/index.ts
@@ -3,3 +3,4 @@ export * from './config';
 export * from './history-id';
 export * from './state';
 export * from './theme';
+export * from './vest-resolver';

--- a/hyperglass/ui/util/vest-resolver.test.ts
+++ b/hyperglass/ui/util/vest-resolver.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { create, enforce, test as vestTest } from 'vest';
+import { vestResolver } from './vest-resolver';
+
+import type { ResolverOptions } from 'react-hook-form';
+
+interface Data {
+  queryTarget: string[];
+  queryType: string;
+}
+
+// Vest suites are stateful (results persist between runs), so each test gets
+// a fresh suite instance.
+const makeSuite = () =>
+  create((data: Data) => {
+    vestTest('queryTarget', 'Query Target is required.', () => {
+      enforce(data.queryTarget).isArrayOf(enforce.isString()).isNotEmpty();
+    });
+    vestTest('queryType', 'Query Type is required.', () => {
+      enforce(data.queryType).isNotEmpty();
+    });
+  });
+
+const options = {} as ResolverOptions<Data>;
+
+describe('vestResolver - bridge vest suites to react-hook-form', () => {
+  it('returns values and no errors for valid data', async () => {
+    const resolver = vestResolver<Data>(makeSuite());
+    const values: Data = { queryTarget: ['192.0.2.0/24'], queryType: 'bgp_route' };
+    const result = await resolver(values, undefined, options);
+    expect(result.errors).toEqual({});
+    expect(result.values).toEqual(values);
+  });
+
+  it('returns the first error message per failing field and empty values', async () => {
+    const resolver = vestResolver<Data>(makeSuite());
+    const result = await resolver({ queryTarget: [], queryType: '' }, undefined, options);
+    expect(result.values).toEqual({});
+    expect(result.errors.queryTarget?.message).toBe('Query Target is required.');
+    expect(result.errors.queryType?.message).toBe('Query Type is required.');
+  });
+
+  it('only reports errors for failing fields', async () => {
+    const resolver = vestResolver<Data>(makeSuite());
+    const result = await resolver(
+      { queryTarget: ['192.0.2.0/24'], queryType: '' },
+      undefined,
+      options,
+    );
+    expect(result.errors.queryTarget).toBeUndefined();
+    expect(result.errors.queryType?.message).toBe('Query Type is required.');
+  });
+
+  it('waits for async tests via the suite result done() callback', async () => {
+    const suite = create((data: Data) => {
+      vestTest('queryTarget', 'Async validation failed.', async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        enforce(data.queryTarget).isNotEmpty();
+      });
+    });
+    const resolver = vestResolver<Data>(suite);
+    const result = await resolver({ queryTarget: [], queryType: '' }, undefined, options);
+    expect(result.errors.queryTarget?.message).toBe('Async validation failed.');
+  });
+});

--- a/hyperglass/ui/util/vest-resolver.ts
+++ b/hyperglass/ui/util/vest-resolver.ts
@@ -1,0 +1,54 @@
+import type { FieldErrors, FieldValues, Resolver } from 'react-hook-form';
+import type { SuiteResult } from 'vest';
+
+/**
+ * Structural subset of a vest suite — only what the resolver calls. Typing
+ * against vest's full `Suite` generics couples this to the suite callback's
+ * exact signature (e.g. optional `data` params break inference).
+ */
+interface RunnableSuite<T> {
+  runStatic(data: T): SuiteResult<string, string>;
+}
+
+/**
+ * Bridge a vest suite into a react-hook-form resolver.
+ *
+ * Replaces `vestResolver` from `@hookform/resolvers/vest`. Every released
+ * version of @hookform/resolvers (≤5.4.0 as of 2026-06) statically imports
+ * the `vest/promisify` subpath, which vest removed in v6.0.0 — so bundling
+ * or testing with vest 6 fails module resolution outright, and no upstream
+ * fix or tracking issue exists. Since that resolver was this app's only use
+ * of @hookform/resolvers, it was replaced with this implementation and the
+ * dependency removed.
+ *
+ * Why not @hookform/resolvers' `standardSchemaResolver` with vest 6's
+ * Standard Schema support (`suite['~standard']`): vest's Standard Schema
+ * adapter snapshots the result synchronously, so a suite containing async
+ * tests reports no issues while still pending — invalid data would pass
+ * validation silently. `runStatic()` returns a thenable that settles after
+ * async tests finish (vest 6's replacement for `promisify`/`done()`), and is
+ * stateless, which is exactly the contract a resolver wants.
+ *
+ * Scope: exactly what the looking-glass form needs — flat field names and
+ * the first error message per failing field. The upstream resolver
+ * additionally nests dotted field paths (`toNestErrors`), populates
+ * `FieldError.types` under `criteriaMode: 'all'`, and supports
+ * `shouldUseNativeValidation`; none of those are used here.
+ */
+export function vestResolver<T extends FieldValues>(suite: RunnableSuite<T>): Resolver<T> {
+  return async values => {
+    const result = await suite.runStatic(values);
+
+    if (!result.hasErrors()) {
+      return { values, errors: {} };
+    }
+
+    const errors: Record<string, { type: string; message: string }> = {};
+    for (const [field, messages] of Object.entries(result.getErrors())) {
+      if (messages.length > 0) {
+        errors[field] = { type: 'validation', message: messages[0] };
+      }
+    }
+    return { values: {}, errors: errors as FieldErrors<T> };
+  };
+}


### PR DESCRIPTION
Closes #110

## Summary

vest **3 → 6.3.2**, react-hook-form **7.42 → 7.77**, and `@hookform/resolvers` **removed** in favor of a small in-repo resolver.

## Why the plan changed from #110

The issue's premise — "resolvers v5 is the first version compatible with vest 5+" — turned out to be false. **No released @hookform/resolvers works with vest 6**: every version through latest (5.4.0) and `master` statically `import promisify from 'vest/promisify'`, a subpath vest deleted in 6.0.0. Module resolution fails at build/test time (`ERR_MODULE_NOT_FOUND`), regardless of the resolver's `mode: 'sync'` option. Upstream CI pins `vest: ^5.4.6`, so the regression is invisible there, and no tracking issue exists. (Renovate #89 was green only because resolvers v5 + vest *3* still resolved the subpath.)

`vestResolver` was the codebase's **only** import from `@hookform/resolvers`, and for this form's shapes (three flat fields, sync suite, no `criteriaMode: 'all'`, no native validation) its effective logic is ~15 lines. So: hand-rolled `util/vest-resolver.ts`, dependency dropped.

## Design notes (also recorded in the resolver's docstring)

- Built on vest 6's `suite.runStatic()` — stateless and awaitable (settles after async tests finish), the successor to `promisify`/`done()`.
- **Rejected alternative**: vest 6 implements Standard Schema (`suite['~standard']`), which would pair with resolvers' `standardSchemaResolver` — but vest's adapter snapshots the result synchronously, so a suite with pending async tests reports **no issues**, silently passing invalid data. Verified empirically.
- Scope is intentionally minimal; the docstring records exactly what the upstream resolver did beyond this (nested paths via `toNestErrors`, `FieldError.types`, `shouldUseNativeValidation`) for whoever needs it later.
- vest 6 API changes in `looking-glass-form.tsx`: `create` is a named export now, and returns a suite object instead of a callable.
- react-hook-form bump rides along (resolvers v5 would have required `^7.55`; current is 7.77 and the bump stands on its own).

## Testing (the affected path)

New coverage, written **before** the migration as a green safety net on vest 3, passing identically after:

- `components/looking-glass-form.validation.test.tsx` — integration through react-hook-form: missing `queryTarget` blocks submission + shows the configured message (`messages.noInput` interpolated), fully empty form blocks + shows location message, valid data submits (submissionId stamped) with no errors shown.
- `util/vest-resolver.test.ts` — unit: valid passthrough, first-message-per-field mapping, per-field error isolation, and async suites awaited via `runStatic`.

## Verification

- Full vitest suite: **127/127** locally
- `tsc --noEmit`, `biome lint`, `biome format` clean
- `pnpm exec next build` exit 0

## Follow-ups

- Renovate #100 (vest) and #89 (resolvers) should be closed once this merges — both superseded.
- Filing the `vest/promisify` bug upstream at react-hook-form/resolvers is worth doing as a courtesy (not done yet).
