### PR TITLE
chore(cli): modernize for current typer, lift typer/click caps

### DIFF
--- a/.tests/ga-backend-app.sh
+++ b/.tests/ga-backend-app.sh
@@ -6,7 +6,17 @@ touch /tmp/hyperglass.log
 . .venv/bin/activate
 
 echo "[INFO] Starting setup..."
-python3 -m hyperglass.console setup -d &>$LOG_FILE
+# Scaffold only — config files aren't in place yet and the UI is built
+# explicitly below. (Historical note: this used to pass an invalid '-d'
+# flag and fail silently; the scaffold step now actually runs and is
+# checked.)
+python3 -m hyperglass.console setup --no-ui &>$LOG_FILE
+
+if [[ ! $? == 0 ]]; then
+    echo "[ERROR] Setup failed."
+    cat $LOG_FILE
+    exit 1
+fi
 echo "[SUCCESS] Setup completed."
 sleep 2
 

--- a/hyperglass/cli/installer.py
+++ b/hyperglass/cli/installer.py
@@ -33,13 +33,15 @@ class Installer:
     progress: Progress
     user: str
     assets: int
+    build_ui: bool
 
-    def __init__(self):
+    def __init__(self, build_ui: bool = True):
         """Start hyperglass installer."""
         self.app_path = Settings.app_path
         self.progress: Progress = Progress(console=echo._console)
         self.user = getpass.getuser()
         self.assets = len([p for p in ASSET_DIR.iterdir() if p.name not in IGNORED_FILES])
+        self.build_ui = build_ui
 
     def install(self) -> None:
         """Initialize tasks and start installer."""
@@ -50,14 +52,17 @@ class Installer:
         asset_task = self.progress.add_task(
             "[bright cyan]Migrating Static Assets", total=self.assets
         )
-        ui_task = self.progress.add_task("[bright teal]Initialzing UI", total=1, start=False)
+        ui_task = None
+        if self.build_ui:
+            ui_task = self.progress.add_task("[bright teal]Initializing UI", total=1, start=False)
 
         self.progress.start()
 
         self.check_permissions(task_id=permissions_task)
         self.scaffold(task_id=scaffold_task)
         self.migrate_static_assets(task_id=asset_task)
-        self.init_ui(task_id=ui_task)
+        if ui_task is not None:
+            self.init_ui(task_id=ui_task)
 
     def __enter__(self) -> t.Callable[[], None]:
         """Initialize tasks."""

--- a/hyperglass/cli/main.py
+++ b/hyperglass/cli/main.py
@@ -11,8 +11,15 @@ import typer
 # Local
 from .echo import echo
 
+cli = typer.Typer(name="hyperglass", help="hyperglass Command Line Interface", no_args_is_help=True)
 
-def _version(value: bool) -> None:
+
+def run():
+    """Run the hyperglass CLI."""
+    return cli()
+
+
+def _print_version(value: bool) -> None:
     # Project
     from hyperglass import __version__
 
@@ -21,36 +28,32 @@ def _version(value: bool) -> None:
         raise typer.Exit()
 
 
-cli = typer.Typer(name="hyperglass", help="hyperglass Command Line Interface", no_args_is_help=True)
-
-
-def run():
-    """Run the hyperglass CLI."""
-    return typer.run(cli())
-
-
-@cli.callback(name="version")
-def _version(
-    version: t.Optional[bool] = typer.Option(
-        None, "--version", help="hyperglass version", callback=_version
-    ),
+@cli.callback()
+def _main(
+    version: t.Annotated[
+        t.Optional[bool],
+        typer.Option(
+            "--version",
+            help="Show hyperglass version and exit",
+            callback=_print_version,
+            is_eager=True,
+        ),
+    ] = None,
 ) -> None:
-    """hyperglass"""
-    pass
+    """hyperglass Command Line Interface."""
 
 
 @cli.command(name="start")
-def _start(build: bool = False, workers: t.Optional[int] = None) -> None:
+def _start(
+    build: t.Annotated[bool, typer.Option("--build", help="Build the UI before starting")] = False,
+    workers: t.Annotated[t.Optional[int], typer.Option(help="Number of server processes")] = None,
+) -> None:
     """Start hyperglass"""
     # Project
     from hyperglass.main import run
 
     # Local
     from .util import build_ui
-
-    kwargs = {}
-    if workers != 0:
-        kwargs["workers"] = workers
 
     try:
         if build:
@@ -69,7 +72,9 @@ def _start(build: bool = False, workers: t.Optional[int] = None) -> None:
 
 
 @cli.command(name="build-ui")
-def _build_ui(timeout: int = typer.Option(180, help="Timeout in seconds")) -> None:
+def _build_ui(
+    timeout: t.Annotated[int, typer.Option(help="Timeout in seconds")] = 180,
+) -> None:
     """Create a new UI build."""
     # Local
     from .util import build_ui as _build_ui
@@ -77,7 +82,7 @@ def _build_ui(timeout: int = typer.Option(180, help="Timeout in seconds")) -> No
     with echo._console.status(
         f"Starting new UI build with a {timeout} second timeout...", spinner="aesthetic"
     ):
-        _build_ui(timeout=120)
+        _build_ui(timeout=timeout)
 
 
 @cli.command(name="system-info")
@@ -139,7 +144,9 @@ def _clear_cache():
 
 @cli.command(name="devices")
 def _devices(
-    search: t.Optional[str] = typer.Argument(None, help="Device ID or Name Search Pattern"),
+    search: t.Annotated[
+        t.Optional[str], typer.Argument(help="Device ID or Name Search Pattern")
+    ] = None,
 ):
     """Show all configured devices"""
     # Third Party
@@ -188,9 +195,11 @@ def _devices(
 
 @cli.command(name="directives")
 def _directives(
-    search: t.Optional[str] = typer.Argument(None, help="Directive ID or Name Search Pattern"),
+    search: t.Annotated[
+        t.Optional[str], typer.Argument(help="Directive ID or Name Search Pattern")
+    ] = None,
 ):
-    """Show all configured devices"""
+    """Show all configured directives"""
     # Third Party
     from rich.columns import Columns
     from rich._inspect import Inspect
@@ -237,15 +246,17 @@ def _directives(
 
 @cli.command(name="plugins")
 def _plugins(
-    search: t.Optional[str] = typer.Argument(None, help="Plugin ID or Name Search Pattern"),
-    _input: bool = typer.Option(
-        False, "--input", show_default=False, is_flag=True, help="Show Input Plugins"
-    ),
-    output: bool = typer.Option(
-        False, "--output", show_default=False, is_flag=True, help="Show Output Plugins"
-    ),
+    search: t.Annotated[
+        t.Optional[str], typer.Argument(help="Plugin ID or Name Search Pattern")
+    ] = None,
+    _input: t.Annotated[
+        bool, typer.Option("--input", show_default=False, help="Show Input Plugins")
+    ] = False,
+    output: t.Annotated[
+        bool, typer.Option("--output", show_default=False, help="Show Output Plugins")
+    ] = False,
 ):
-    """Show all configured devices"""
+    """Show all configured plugins"""
     # Third Party
     from rich.columns import Columns
 
@@ -277,9 +288,10 @@ def _plugins(
 
 @cli.command(name="params")
 def _params(
-    path: t.Optional[str] = typer.Argument(
-        None, help="Parameter Object Path, for example 'messages.no_input'"
-    ),
+    path: t.Annotated[
+        t.Optional[str],
+        typer.Argument(help="Parameter Object Path, for example 'messages.no_input'"),
+    ] = None,
 ):
     """Show configuration parameters"""
     # Standard Library
@@ -329,12 +341,20 @@ def _params(
 
 
 @cli.command(name="setup")
-def _setup():
+def _setup(
+    ui: t.Annotated[
+        bool,
+        typer.Option(
+            "--ui/--no-ui",
+            help="Build the UI after scaffolding (requires config, Redis, and Node)",
+        ),
+    ] = True,
+):
     """Initialize hyperglass setup."""
     # Local
     from .installer import Installer
 
-    with Installer() as start:
+    with Installer(build_ui=ui) as start:
         start()
 
 

--- a/hyperglass/cli/tests/test_cli.py
+++ b/hyperglass/cli/tests/test_cli.py
@@ -1,0 +1,55 @@
+"""CLI smoke tests.
+
+The unit suite otherwise never imports `hyperglass.cli`, so CLI breakage from
+dependency updates (e.g. typer API changes) only surfaced when a fresh
+install actually ran the entrypoint. These tests import the app and exercise
+argument parsing for every command — they intentionally avoid running
+commands that require Redis, config files, or Node.
+"""
+
+# Third Party
+import pytest
+from typer.testing import CliRunner
+
+# Project
+from hyperglass.cli.main import cli
+from hyperglass.constants import __version__
+
+runner = CliRunner()
+
+ALL_COMMANDS = (
+    "start",
+    "build-ui",
+    "system-info",
+    "clear-cache",
+    "devices",
+    "directives",
+    "plugins",
+    "params",
+    "setup",
+    "settings",
+)
+
+
+def test_cli_help():
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    for command in ALL_COMMANDS:
+        assert command in result.output
+
+
+def test_cli_version():
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+@pytest.mark.parametrize("command", ALL_COMMANDS)
+def test_command_help(command: str):
+    result = runner.invoke(cli, [command, "--help"])
+    assert result.exit_code == 0
+
+
+def test_no_args_shows_help():
+    result = runner.invoke(cli, [])
+    assert "Usage" in result.output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,7 @@ dependencies = [
     "pydantic>=2.6.3",
     "redis==4.5.4",
     "rich>=13.7.0",
-    # The CLI uses typer 0.9 APIs (e.g. Typer.callback(name=...)); the cap was
-    # previously implicit via the removed favicons package. click<8.2 pairs
-    # with typer 0.9 (click 8.2+ crashes it at startup). Modernizing the CLI
-    # to lift both caps is tracked as a follow-up.
-    "typer>=0.9.0,<0.10",
-    "click>=8.1,<8.2",
+    "typer>=0.12",
     "uvicorn==0.21.1",
     "uvloop>=0.17.0",
     "xmltodict==0.13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -302,14 +311,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -538,7 +547,6 @@ version = "2.1.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
-    { name = "click" },
     { name = "distro" },
     { name = "h11" },
     { name = "httpx" },
@@ -582,7 +590,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=23.2.1" },
-    { name = "click", specifier = ">=8.1,<8.2" },
     { name = "distro", specifier = "==1.8.0" },
     { name = "h11", specifier = ">=0.16.0" },
     { name = "httpx", specifier = ">=0.27.0,<0.28" },
@@ -602,7 +609,7 @@ requires-dist = [
     { name = "resvg-py", specifier = ">=0.3.2" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "toml", specifier = ">=0.10.2" },
-    { name = "typer", specifier = ">=0.9.0,<0.10" },
+    { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = "==0.21.1" },
     { name = "uvloop", specifier = ">=0.17.0" },
     { name = "xmltodict", specifier = "==0.13.0" },
@@ -1794,6 +1801,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1931,15 +1947,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.9.4"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "typing-extensions" },
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/7d/b1e0399aa5e27071f0042784681d28417f3e526c61f62c8e3635ee5ad334/typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f", size = 276061, upload-time = "2024-03-23T17:07:55.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/39/82c9d3e10979851847361d922a373bdfef4091020da7f893acfaf07c0225/typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb", size = 45973, upload-time = "2024-03-23T17:07:53.985Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #105

## Summary

`hyperglass/cli/` modernized for current typer; both caps lifted: `typer>=0.9,<0.10` → `typer>=0.12` (lock resolves **0.26.7**), explicit `click>=8.1,<8.2` pin dropped (typer constrains it; lock resolves **click 8.4.1**).

## What changed

- **`@cli.callback(name="version")` crash** (the issue's trigger): replaced with the modern pattern — eager `--version` option with callback on the app callback.
- **Annotated-style** `Option`/`Argument` declarations throughout; `is_flag=True` click-ism removed from `plugins` (the family behind the click 8.2 "Secondary flag" crash).
- **`setup --ui/--no-ui`** (default `--ui`, behavior unchanged): the installer's final step builds the UI, which needs config + Redis + Node — scaffold-only contexts (CI, container builds) now have a first-class path.

## Pre-existing bugs fixed along the way

1. `run()` was `typer.run(cli())` — `cli()` parses argv and exits itself, so the wrapper only worked by accident. Now just `cli()`.
2. `build-ui --timeout` was accepted and *displayed*, then ignored — the build always ran with a hard-coded `timeout=120`.
3. The eager-version callback and the app callback both named `_version` — worked only via decoration-time binding order.
4. `directives` and `plugins` help text both read "Show all configured **devices**".
5. `.tests/ga-backend-app.sh` ran `setup -d` — an invalid flag since the typer-0.9 era — and ignored the failure. It now runs `setup --no-ui` and checks the exit code, so the installer scaffold path is actually exercised by CI again.

## Tests

New `hyperglass/cli/tests/test_cli.py` (13 cases, CliRunner): top-level `--help` lists every command, `--version` prints the version, per-command `--help` parses, bare invocation shows usage. Committed first and verified green on typer **0.9**, then re-verified on **0.26.7** — the suite now imports the CLI, so the next typer API break fails CI instead of a fresh install.

## Verification

- Full pytest suite: 117 passed, 1 skipped (pre-existing skip); ruff clean; black/isort applied
- CLI smoke from the venv: `--version`, `--help`, `setup --no-ui` scaffolds a clean app dir without Redis/Node
- **Fresh-resolution gate** (how the original crash manifested): clean venv + `pip install -e .` resolves typer 0.26.7/click 8.4.1 and the CLI entrypoint boots (exit 0)

## Unblocks

- Renovate #57 (`click >=8.4,<8.5`) — resolves naturally now
- The Renovate typer-update PR on the dashboard

## Not in scope

The Dockerfile installing from pyproject ranges instead of `uv.lock` (`pip install -e .`) — reproducibility concern noted in #105's "Related" section; worth its own issue.
