### PR TITLE
fix(ui): replace removed framer-motion CustomDomComponent type (unblocks #33/#90)

### DIFF
--- a/hyperglass/ui/components/header/title.tsx
+++ b/hyperglass/ui/components/header/title.tsx
@@ -1,8 +1,8 @@
 import { Button, Flex, VStack } from '@chakra-ui/react';
-import { motion } from 'framer-motion';
 import { isSafari } from 'react-device-detect';
 import { Case, Switch } from 'react-if';
 import { useConfig } from '~/context';
+import { motionChakra } from '~/elements';
 import { useFormInteractive, useFormState, useMobile } from '~/hooks';
 import { Logo } from './logo';
 import { SubtitleOnly } from './subtitle-only';
@@ -15,8 +15,10 @@ type DWrapperProps = Omit<StackProps, 'transition'> & MotionProps;
 type MWrapperProps = Omit<StackProps, 'transition'> & MotionProps;
 type WrapperProps = Partial<MotionProps & Omit<StackProps, 'transition'>>;
 
-const AnimatedVStack = motion(VStack);
-const AnimatedFlex = motion(Flex);
+// motionChakra (rather than raw `motion(...)`) reconciles the conflicting
+// chakra/framer `transition` prop types — see elements/animated.ts.
+const AnimatedVStack = motionChakra<StackProps>(VStack);
+const AnimatedFlex = motionChakra<FlexProps>(Flex);
 
 /**
  * Title wrapper for mobile devices, breakpoints sm & md.
@@ -115,7 +117,10 @@ const All = (props: WrapperProps): JSX.Element => (
  * Title component which renders sub-components based on the `title_mode` configuration variable.
  */
 export const Title = (props: FlexProps): JSX.Element => {
-  const { fontSize, ...rest } = props;
+  // framer-motion and chakra/DOM declare incompatible types for these props;
+  // AnimatedFlex expects framer's versions, so exclude the DOM ones from the
+  // spread (they are never passed — <Title /> takes no props at its call site).
+  const { fontSize, transition, onAnimationStart, onDragStart, onDragEnd, onDrag, ...rest } = props;
   const { web } = useConfig();
   const { titleMode } = web.text;
 

--- a/hyperglass/ui/elements/animated.ts
+++ b/hyperglass/ui/elements/animated.ts
@@ -2,7 +2,7 @@ import { chakra } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 
 import type { BoxProps } from '@chakra-ui/react';
-import type { CustomDomComponent, Transition, MotionProps } from 'framer-motion';
+import type { MotionProps, Transition } from 'framer-motion';
 
 type MCComponent = Parameters<typeof chakra>[0];
 type MCOptions = Parameters<typeof chakra>[1];
@@ -11,7 +11,21 @@ type MakeMotionProps<P extends BoxProps> = React.PropsWithChildren<
 >;
 
 /**
+ * Return type of `motionChakra`. Self-defined replacement for framer-motion's
+ * `CustomDomComponent` (removed from the public types in v11.x), mirroring its
+ * shape so the signature survives framer-motion type churn.
+ */
+type MotionChakraComponent<P extends BoxProps> = React.ForwardRefExoticComponent<
+  MakeMotionProps<P> & React.RefAttributes<HTMLElement>
+>;
+
+/**
  * Combine `chakra` and `motion` factories.
+ *
+ * Chakra and framer-motion both declare a `transition` prop (CSS string vs.
+ * animation config), so the combined component's props are re-declared with
+ * chakra's omitted — the cast below is deliberate and is what makes the
+ * merged component usable without per-call-site suppressions.
  *
  * @param component Component or string
  * @param options `chakra` options
@@ -20,9 +34,8 @@ type MakeMotionProps<P extends BoxProps> = React.PropsWithChildren<
 export function motionChakra<P extends BoxProps = BoxProps>(
   component: MCComponent,
   options?: MCOptions,
-): CustomDomComponent<MakeMotionProps<P>> {
-  // @ts-expect-error I don't know how to fix this.
-  return motion<P>(chakra<MCComponent, P>(component, options));
+): MotionChakraComponent<P> {
+  return motion(chakra(component, options)) as unknown as MotionChakraComponent<P>;
 }
 
 export const AnimatedDiv = motionChakra('div');


### PR DESCRIPTION
Closes #108

## Summary

Replaces the removed `CustomDomComponent` type so the codebase typechecks on current framer-motion, unblocking Renovate #33 (11.18.2, minor → automerges once green) and clearing the type-level path for #90 (v12 major). **No dependency bump in this PR** — the lockfile stays on 11.2.10; Renovate lands the bumps.

## Changes

- **`elements/animated.ts`** — `MotionChakraComponent<P>` defined locally (same shape `CustomDomComponent` had: `ForwardRefExoticComponent` over the merged chakra+motion props), so the signature no longer depends on framer-motion's type exports. The old `// @ts-expect-error I don't know how to fix this` on the merge expression is replaced with a deliberate, documented cast — also version-proof, since an expect-error that *stops* erroring on a newer dependency fails the build by itself.
- **`components/header/title.tsx`** — `AnimatedFlex`/`AnimatedVStack` now go through `motionChakra` instead of raw `motion(Flex)`/`motion(VStack)`. Newer framer-motion rejects raw `motion(...)` over chakra components: chakra and framer declare incompatible types for `transition` and the animation/drag event handlers (`onAnimationStart` et al. — DOM event handler vs framer callback). `motionChakra`'s `MakeMotionProps` exists precisely to reconcile this; `title.tsx` had bypassed it. The conflicting `FlexProps` handlers are excluded from the `Title` spread (type-level only — `<Title />` takes no props at its single call site).

## Verification matrix

Each of typecheck (`tsc --noEmit`), vitest (127/127), and `next build` run against:

| framer-motion | Result |
|---|---|
| 11.2.10 (locked, shipping state) | ✅ |
| 11.18.2 (Renovate #33 target) | ✅ |
| 12.40.0 (Renovate #90 target) | ✅ |

Biome lint/format clean.
