### PR TITLE
fix(ui): replace react-icons template-literal import with a family map (unblocks #97)

### DIFF
--- a/hyperglass/ui/elements/dynamic-icon.tsx
+++ b/hyperglass/ui/elements/dynamic-icon.tsx
@@ -6,6 +6,31 @@ import { chakra, Icon as ChakraIcon } from '@chakra-ui/react';
 import isEqual from 'react-fast-compare';
 
 import type { IconProps as ChakraIconProps, TooltipProps } from '@chakra-ui/react';
+import type { IconType } from 'react-icons';
+
+/**
+ * Lazy importers for every react-icons family used in the app, keyed by the
+ * family's lowercase prefix.
+ *
+ * These are static `import()` specifiers rather than a `react-icons/${family}`
+ * template literal on purpose: react-icons v5 ships an `exports` map that
+ * forbids arbitrary subpath enumeration, so a template literal makes webpack
+ * build a context module over `react-icons/*` and fail to compile. An explicit
+ * map keeps the families tree-shakeable to the ones we actually use and is the
+ * full set DynamicIcon accepts — add an entry here to support a new family.
+ */
+const ICON_FAMILIES: Record<string, () => Promise<Record<string, unknown>>> = {
+  bi: () => import('react-icons/bi'),
+  bs: () => import('react-icons/bs'),
+  cg: () => import('react-icons/cg'),
+  fa: () => import('react-icons/fa'),
+  fi: () => import('react-icons/fi'),
+  go: () => import('react-icons/go'),
+  hi: () => import('react-icons/hi'),
+  io: () => import('react-icons/io'),
+  md: () => import('react-icons/md'),
+  ri: () => import('react-icons/ri'),
+};
 
 interface IconMap {
   [library: string]: string;
@@ -131,23 +156,28 @@ const _DynamicIcon = (props: DynamicIconProps): JSX.Element => {
 
     const Component = useMemo(
       () =>
-        dynamic(() =>
-          import(`react-icons/${library}/index.js`)
+        dynamic(() => {
+          const importFamily = ICON_FAMILIES[library];
+          if (importFamily === undefined) {
+            // Unknown family — not in the supported map.
+            throw new IconError({ original: iconObj, iconName, library });
+          }
+          return importFamily()
             .then(i => {
               if (!(iconName in i)) {
                 // If the icon name doesn't exist in the module, error out.
                 throw new IconError({ original: iconObj, iconName, library });
               }
               // Otherwise, return the imported icon.
-              return i[iconName as keyof typeof i];
+              return i[iconName] as IconType;
             })
             .catch(error => {
               // Handle any error that occurs during dynamic import.
               console.error(error);
               const CaughtError = (): JSX.Element => <ErrorIcon message={String(error)} />;
               return CaughtError;
-            }),
-        ),
+            });
+        }),
       [library, iconName],
     );
 


### PR DESCRIPTION
Closes #114

## Summary

`DynamicIcon` imported icon families via `` import(`react-icons/${library}/index.js`) ``, which makes webpack build a **context module** over `react-icons/*`. react-icons v5 ships an `exports` map that forbids arbitrary subpath enumeration, so the context can't compile (`Module not found: react-icons`) — the break Renovate #97 hit.

Replaced the template literal with an explicit `ICON_FAMILIES` map of **static** `import()` specifiers for the 10 families actually used (`bi bs cg fa fi go hi io md ri`).

## Correcting the issue's premise

#114 assumed icon families are "operator-configurable at runtime." They aren't — I checked: every one of the ~20 call sites passes a literal (`{ fa: 'FaPlus' }`), and no backend config (`web.links` `showIcon` just toggles a hardcoded `GoLinkExternal`) feeds an arbitrary family/name into `DynamicIcon`. So enumerating the families loses **no** runtime configurability, and the static-map fix is behavior-preserving rather than a feature regression.

## What's preserved vs. changed

- **Unchanged:** the `DynamicIcon` API, all ~20 call sites, and the `iconPath` name normalization (`{fa:'plus'}`, `{fa:'faplus'}`, `{fa:'FaPlus'}` all still resolve).
- **Changed:** an unknown family now routes through the existing `ErrorIcon` path; the bundle no longer pulls every react-icons family (only the 10 mapped ones are chunked).

## Verification

typecheck, vitest (129/129), and `next build`, each on:

| react-icons | Result |
|---|---|
| 4.3.1 (locked, shipping state) | ✅ |
| 5.6.0 (Renovate #97 target) | ✅ build compiles — the original failure is gone |

**The `next build` step is the real gate here.** The original break was a webpack compile failure, which vitest's module resolver can't reproduce — so a unit test wouldn't have caught it or guarded the fix. The build step (added in #115) is the correct guard and runs in CI.

## Unblocks

Renovate #97 (react-icons v5).
