### PR TITLE
chore(api,models): fix Litestar v3 and Pydantic v3 deprecations

### DIFF
--- a/hyperglass/api/__init__.py
+++ b/hyperglass/api/__init__.py
@@ -6,8 +6,10 @@ import logging
 
 # Third Party
 from litestar import Litestar, get
+from litestar.params import FromPath
 from litestar.openapi import OpenAPIConfig
 from litestar.response import File
+from litestar.openapi.plugins import StoplightRenderPlugin
 from litestar.exceptions import HTTPException, NotFoundException, ValidationException
 from litestar.static_files import create_static_files_router
 
@@ -37,12 +39,14 @@ OPEN_API = OpenAPIConfig(
     version=__version__,
     description=STATE.params.docs.description,
     path=STATE.params.docs.path,
-    root_schema_site="elements",
+    # Stoplight Elements served at the OpenAPI root path (the first/only
+    # render plugin), replacing the deprecated root_schema_site="elements".
+    render_plugins=[StoplightRenderPlugin()],
 )
 
 
 @get("/result/{share_id:str}", include_in_schema=False)
-async def share_view_html(share_id: str) -> File:
+async def share_view_html(share_id: FromPath[str]) -> File:
     """Serve the SPA shell (index.html) for share result URLs.
 
     Litestar's static-files html_mode serves 404.html (the Next.js error

--- a/hyperglass/api/routes.py
+++ b/hyperglass/api/routes.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime, timedelta
 # Third Party
 from litestar import Request, Response, get, post
 from litestar.di import Provide
+from litestar.params import FromPath
 from litestar.exceptions import HTTPException, NotFoundException
 from litestar.background_tasks import BackgroundTask
 
@@ -74,7 +75,7 @@ def _build_share_url(params, request, share_id: str) -> str:
 
 
 @get("/api/devices/{id:str}", dependencies={"devices": Provide(get_devices)})
-async def device(devices: Devices, id: str) -> APIDevice:
+async def device(devices: Devices, id: FromPath[str]) -> APIDevice:
     """Retrieve a device by ID."""
     return devices[id].export_api()
 
@@ -222,7 +223,7 @@ async def query(_state: HyperglassState, request: Request, data: Query) -> Query
 async def share_create(
     _state: HyperglassState,
     request: Request,
-    cache_id: str,
+    cache_id: FromPath[str],
 ) -> Response:
     """Promote a cached query result to a long-lived shareable snapshot."""
     # TODO: make configurable via params.messages (no existing precedent for
@@ -273,7 +274,7 @@ async def share_create(
 
 
 @get("/api/query/share/{share_id:str}", dependencies={"_state": Provide(get_state)})
-async def share_get(_state: HyperglassState, share_id: str) -> Response:
+async def share_get(_state: HyperglassState, share_id: FromPath[str]) -> Response:
     """Read a shared snapshot."""
     if not _state.params.cache.share_enabled:
         raise NotFoundException()

--- a/hyperglass/api/state.py
+++ b/hyperglass/api/state.py
@@ -1,15 +1,15 @@
 """hyperglass state dependencies."""
 
-# Standard Library
-import typing as t
-
 # Project
 from hyperglass.state import use_state
 
 
-async def get_state(attr: t.Optional[str] = None):
-    """Get hyperglass state as a FastAPI dependency."""
-    return use_state(attr)
+async def get_state():
+    """Get hyperglass state as a dependency."""
+    # No parameters: a parameter here would be inferred as a request query
+    # parameter by Litestar (the deprecated inferred style), exposing an
+    # unintended `?attr=` surface that could coerce a state subset.
+    return use_state()
 
 
 async def get_params():

--- a/hyperglass/api/tests/test_no_deprecations.py
+++ b/hyperglass/api/tests/test_no_deprecations.py
@@ -1,0 +1,50 @@
+"""Regression gate for framework deprecations in hyperglass code.
+
+These deprecations are removed in Litestar v3 / Pydantic v3, so catching their
+reintroduction here keeps the path to those majors clear. Each test rebuilds
+the relevant object under an error filter — re-running signature parsing /
+schema generation so a reintroduced deprecation is re-emitted (and raised)
+rather than silently deduplicated after first import.
+
+Third-party deprecations (netmiko telnetlib, paramiko TripleDES) are out of
+scope and tracked separately.
+"""
+
+# Standard Library
+import warnings
+
+# Third Party
+import pytest
+from litestar import Litestar
+from litestar.exceptions import LitestarDeprecationWarning
+from pydantic.warnings import PydanticDeprecatedSince20, PydanticDeprecatedSince212
+
+
+def test_route_handlers_use_no_deprecated_parameter_style(state):
+    """Building the app must not emit Litestar inferred-parameter warnings.
+
+    `state` seeds Redis: hyperglass.api reads state at import (module-level
+    `STATE = use_state()` and the OpenAPI config).
+    """
+    # Project
+    from hyperglass.api import HANDLERS, OPEN_API
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LitestarDeprecationWarning)
+        Litestar(route_handlers=HANDLERS, openapi_config=OPEN_API)
+
+
+@pytest.mark.parametrize("category", [PydanticDeprecatedSince20, PydanticDeprecatedSince212])
+def test_models_emit_no_pydantic_deprecations(category):
+    """Rebuilding a HyperglassModel schema must not emit Pydantic deprecations.
+
+    Credential extends HyperglassModel, so a force rebuild re-runs both the
+    base-model schema generation (catching a reintroduced `json_encoders`) and
+    the validator wiring (catching a `mode='after'` classmethod validator).
+    """
+    # Project
+    from hyperglass.models.config.credential import Credential
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", category)
+        Credential.model_rebuild(force=True)

--- a/hyperglass/models/config/credential.py
+++ b/hyperglass/models/config/credential.py
@@ -21,15 +21,15 @@ class Credential(HyperglassModel, extra="allow"):
     _method: t.Optional[AuthMethod] = None
 
     @model_validator(mode="after")
-    def validate_credential(cls, data: "Credential"):
+    def validate_credential(self) -> "Credential":
         """Ensure either a password or an SSH key is set."""
-        if data.key is None and data.password is None:
+        if self.key is None and self.password is None:
             raise ValueError(
                 "Either a password or an SSH key must be specified for user '{}'".format(
-                    data.username
+                    self.username
                 )
             )
-        return data
+        return self
 
     def __init__(self, **kwargs):
         """Set private attribute _method based on validated model."""

--- a/hyperglass/models/main.py
+++ b/hyperglass/models/main.py
@@ -9,7 +9,7 @@ import typing as t
 from pathlib import Path
 
 # Third Party
-from pydantic import HttpUrl, BaseModel, RootModel, ConfigDict, PrivateAttr
+from pydantic import BaseModel, RootModel, ConfigDict, PrivateAttr
 
 # Project
 from hyperglass.log import log
@@ -37,9 +37,11 @@ def alias_generator(field: str) -> str:
 class HyperglassModel(BaseModel):
     """Base model for all hyperglass configuration models."""
 
+    # Pydantic v2 natively serializes HttpUrl and Path to strings in JSON mode
+    # (model_dump_json / export_json), so the deprecated json_encoders config
+    # for those types is redundant and has been removed.
     model_config = ConfigDict(
         extra="forbid",
-        json_encoders={HttpUrl: lambda v: str(v), Path: str},
         populate_by_name=True,
         validate_assignment=True,
         validate_default=True,


### PR DESCRIPTION
Closes #126

## Summary

Clears every hyperglass-originated deprecation from the pytest warnings summary — the count drops from ~30 to **3**, and those 3 are all third-party (netmiko `telnetlib`, paramiko `TripleDES`), tracked separately in #127. These deprecations are removed in Litestar v3 / Pydantic v3, so this keeps the path to those majors open.

## Litestar (inferred parameter style → removed in v3)

- **`routes.py`** — path params `id` / `cache_id` / `share_id` annotated with `FromPath[str]` (`device`, `share_create`, `share_get`).
- **`__init__.py`** — `share_view_html`'s `share_id` annotated `FromPath[str]`; `root_schema_site="elements"` replaced with `render_plugins=[StoplightRenderPlugin()]` (first plugin → served at the OpenAPI root path). Verified `/api/docs` still returns 200 and renders Stoplight Elements.
- **`state.py`** — dropped the vestigial `attr` parameter from `get_state`. It was never supplied through DI, but Litestar inferred it as a **query parameter**, which both triggered the deprecation on every handler using the dependency *and* exposed an unintended `?attr=` surface that could coerce a state subset on `/api/query`. Removing it closes that surface.

## Pydantic (→ removed in v3)

- **`models/main.py`** — dropped `json_encoders={HttpUrl, Path}` from `HyperglassModel`. Pydantic v2 serializes both to strings natively in JSON mode, so `export_json` output is **byte-identical** — verified by regenerating the `ui_params` export that `.tests/hyperglass.json` is built from and `cmp`-ing against the pre-change output.
- **`credential.py`** — converted the `mode="after"` validator from a classmethod `(cls, data)` to an instance method `(self)`.

## Regression gate (`test_no_deprecations.py`)

Three tests rebuild the app / a model schema under a `simplefilter("error", ...)` filter, so a reintroduced deprecation is re-emitted and raised rather than silently deduplicated after first import. **Each was confirmed to fail on the pre-fix code** (e.g. reverting the `FromPath` annotation makes the Litestar test raise).

## Verification

- Full suite: **120 passed, 1 skipped** (117 prior + 3 new), `ruff` and `black` clean.
- Warnings summary: only the 3 third-party warnings remain.
- `/api/docs` + `/api/docs/openapi.json` both 200 with Stoplight Elements rendered.

## Out of scope

netmiko/paramiko third-party deprecations (#127); no dependency changes here.
