### PR TITLE
chore(release): rename to hyperglass-ng and cut 2.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.yaml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: Version
       description: What version of hyperglass are you currently running?
-      placeholder: v2.0.4
+      placeholder: v2.1.0
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/2-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yaml
@@ -20,7 +20,7 @@ body:
     attributes:
       label: Version
       description: What version of hyperglass are you currently running?
-      placeholder: v2.0.4
+      placeholder: v2.1.0
     validations:
       required: true
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-06-08
+
+First release under the **hyperglass-ng** name — a maintained fork of
+[thatmattlove/hyperglass](https://github.com/thatmattlove/hyperglass) that
+carries production-oriented fixes and dependency modernization that had not
+landed upstream as of v2.0.4.
+
+This rename is **branding and distribution only**: the Python import package
+(`hyperglass`), the `hyperglass` CLI command, the `HYPERGLASS_` environment
+prefix, and the `/etc/hyperglass` configuration layout are all unchanged, so
+existing deployments upgrade in place. Only the distribution name has changed —
+`hyperglass-ng` on PyPI and `ghcr.io/<owner>/hyperglass-ng` on GHCR.
+
 ### Added
 
+- Renamed the project to **hyperglass-ng** and cut the first release under that name.
 - [#304](https://github.com/thatmattlove/hyperglass/pull/304): Add FRR structured output for BGP Routes - @chriswiggins
 - Sharable result snapshots: clicking the new Share button on a result mints a `/result/<id>` URL (default 7-day TTL, operator-tunable via `cache.share_timeout`).
 - `params.public_url` (optional): when set, share URLs use this base; otherwise derived from request headers.
@@ -18,6 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - [#245](https://github.com/thatmattlove/hyperglass/issues/245): v2.0.0 Vyos version platforms - Moved to latest LTS command set. - @ServerForge
 - [#292](https://github.com/thatmattlove/hyperglass/pull/292): Updates Mikrotik BGP route command so supernets are selected as well as exact matches. - @GrandArcher
 - `cache.timeout` default raised from 120s → 600s. End-user refresh behavior is preserved by `cache.refresh_min_interval` (UI cooldown, default 120s) and the new query `force` flag. Operators relying on 2-minute cache staleness should set `cache.timeout: 120` explicitly.
+- Dependency and toolchain modernization to unblock automated updates and clear the path to Python 3.12+ / Litestar v3 / Pydantic v3:
+  - [#115](https://github.com/jsenecal/hyperglass/issues/115): Frontend CI now runs a production `next build` and tests across Node 20/22/24.
+  - [#110](https://github.com/jsenecal/hyperglass/issues/110): Migrated form validation to vest 6, dropping the incompatible `@hookform/resolvers` dependency in favor of a small in-tree resolver.
+  - [#105](https://github.com/jsenecal/hyperglass/issues/105): Modernized the CLI for typer 0.26 / click 8.4 and added a non-interactive `setup --ui/--no-ui` flag.
+  - [#108](https://github.com/jsenecal/hyperglass/issues/108) / [#90](https://github.com/jsenecal/hyperglass/issues/90) / [#109](https://github.com/jsenecal/hyperglass/issues/109): Restored compatibility with framer-motion v12 and Chakra UI 2.9.
+  - [#114](https://github.com/jsenecal/hyperglass/issues/114): Replaced the react-icons template-literal import with an explicit family map for react-icons v5.
+  - [#126](https://github.com/jsenecal/hyperglass/issues/126): Cleared Litestar v3 / Pydantic v3 deprecations in first-party code and added a regression gate.
 
 ### Fixed
 - [#280](https://github.com/thatmattlove/hyperglass/issues/280): Fix: `condition: None` caused error in directive @Jimmy01240397
@@ -618,4 +639,5 @@ Version comparison links. Only the fork-era tags exist in this repository
 (v2.0.4-jsenecal.*); historical upstream versions below were never tagged
 here, so they are intentionally left unlinked.
 -->
-[Unreleased]: https://github.com/jsenecal/hyperglass/compare/v2.0.4-jsenecal.2...HEAD
+[Unreleased]: https://github.com/jsenecal/hyperglass/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/jsenecal/hyperglass/compare/v2.0.4-jsenecal.2...v2.1.0

--- a/README.md
+++ b/README.md
@@ -9,18 +9,20 @@
 
 <hr/>
 
-> ### Fork notice
+> ### About this fork — hyperglass-ng
 >
-> This repository is a maintained fork of [**thatmattlove/hyperglass**](https://github.com/thatmattlove/hyperglass). The upstream project has been quiet for an extended period, so this fork carries production-oriented fixes that hadn't landed upstream as of v2.0.4.
+> **hyperglass-ng** is a maintained fork of [**thatmattlove/hyperglass**](https://github.com/thatmattlove/hyperglass). The upstream project has been quiet for an extended period, so this fork carries production-oriented fixes and dependency modernization that hadn't landed upstream as of v2.0.4.
+>
+> The rename is **branding and distribution only**: the `hyperglass` import package, the `hyperglass` CLI command, the `HYPERGLASS_` environment prefix, and the `/etc/hyperglass` config layout are unchanged, so existing deployments upgrade in place. The distribution is published as `hyperglass-ng` on PyPI and `ghcr.io/<owner>/hyperglass-ng` on GHCR.
 >
 > **Container images** are published to GHCR on every push to `main` and on tag pushes:
 >
 > | Tag | Updated by | Use case |
 > | --- | --- | --- |
-> | `ghcr.io/jsenecal/hyperglass:2.0.4-jsenecal.2` | tag push | immutable, recommended for production |
-> | `ghcr.io/jsenecal/hyperglass:sha-<short>` | every build | per-commit immutable |
-> | `ghcr.io/jsenecal/hyperglass:main` | every push to `main` | rolling HEAD |
-> | `ghcr.io/jsenecal/hyperglass:latest` | every build | rolling whatever's freshest |
+> | `ghcr.io/jsenecal/hyperglass-ng:2.1.0` | tag push | immutable, recommended for production |
+> | `ghcr.io/jsenecal/hyperglass-ng:sha-<short>` | every build | per-commit immutable |
+> | `ghcr.io/jsenecal/hyperglass-ng:main` | every push to `main` | rolling HEAD |
+> | `ghcr.io/jsenecal/hyperglass-ng:latest` | every build | rolling whatever's freshest |
 >
 > **Maintained by** Jonathan Senecal &lt;jonathan.senecal@metrooptic.com&gt;. **Issues** belong in the [fork's tracker](https://github.com/jsenecal/hyperglass/issues), not upstream's.
 

--- a/docs/pages/installation/upgrading.mdx
+++ b/docs/pages/installation/upgrading.mdx
@@ -5,7 +5,7 @@ cd /opt/hyperglass
 docker compose down
 docker compose rm -f
 git fetch
-git checkout v2.0.4
+git checkout v2.1.0
 docker compose build
 docker compose up
 ```

--- a/hyperglass/__init__.py
+++ b/hyperglass/__init__.py
@@ -1,6 +1,7 @@
 """hyperglass is a modern, customizable network looking glass.
 
-https://github.com/thatmattlove/hyperglass
+hyperglass-ng (maintained fork): https://github.com/jsenecal/hyperglass
+Upstream: https://github.com/thatmattlove/hyperglass
 
 The Clear BSD License
 

--- a/hyperglass/constants.py
+++ b/hyperglass/constants.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 
 __name__ = "hyperglass"
-__version__ = "2.1.0.dev0"
+__version__ = "2.1.0"
 __author__ = "Matt Love"
 __copyright__ = f"Copyright {datetime.now().year} Matthew Love"
 __license__ = "BSD 3-Clause Clear License"

--- a/hyperglass/ui/package.json
+++ b/hyperglass/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0-dev.0",
+  "version": "2.1.0",
   "name": "ui",
   "description": "UI for hyperglass, the modern network looking glass",
   "author": "Matt Love",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "hyperglass-ng"
-version = "2.1.0.dev0"
-description = "hyperglass is the modern network looking glass that tries to make the internet better."
+version = "2.1.0"
+description = "hyperglass-ng is a maintained fork of hyperglass, the modern network looking glass that tries to make the internet better."
 authors = [
     { name = "thatmattlove", email = "matt@hyperglass.dev" },
     { name = "Jonathan Senecal", email = "jonathan.senecal@metrooptic.com" }

--- a/uv.lock
+++ b/uv.lock
@@ -543,7 +543,7 @@ wheels = [
 
 [[package]]
 name = "hyperglass-ng"
-version = "2.1.0.dev0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
First release under the **hyperglass-ng** name.

## What this is
A **branding + distribution** rename only. The `hyperglass` import package, the `hyperglass` CLI command, the `HYPERGLASS_` env prefix, and the `/etc/hyperglass` config layout are all unchanged — existing deployments upgrade in place. The distribution is published as `hyperglass-ng` on PyPI and `ghcr.io/<owner>/hyperglass-ng` on GHCR.

## Changes
- **Version** `2.1.0.dev0` → `2.1.0` across `pyproject.toml`, `hyperglass/constants.py`, `hyperglass/ui/package.json`, `docs/.../upgrading.mdx`, and the issue templates (via `version.py`).
- **pyproject** description now reflects the hyperglass-ng fork.
- **README** fork notice rewritten for hyperglass-ng; GHCR image table corrected to `ghcr.io/jsenecal/hyperglass-ng:2.1.0` (the Docker workflow already publishes under that name).
- **Package docstring** points at the fork repo (upstream link retained).
- **CHANGELOG** `[Unreleased]` cut to `[2.1.0] - 2026-06-08`, documenting the rename plus the dependency/toolchain modernization landed this cycle (#115, #110, #105, #108, #90, #109, #114, #126). Comparison links updated.

## After merge
Tag `v2.1.0` on `main` and publish the GitHub release — that tag push triggers the Docker workflow to build and push `ghcr.io/jsenecal/hyperglass-ng:2.1.0`.

Note: LICENSE and `__copyright__` retain the original BSD copyright (Matthew Love) as required for the fork.