### PR TITLE
fix: correct MIN_PYTHON_VERSION to 3.11

### DIFF
--- a/hyperglass/constants.py
+++ b/hyperglass/constants.py
@@ -11,7 +11,7 @@ __license__ = "BSD 3-Clause Clear License"
 
 METADATA = (__name__, __version__, __author__, __copyright__, __license__)
 
-MIN_PYTHON_VERSION = (3, 8)
+MIN_PYTHON_VERSION = (3, 11)
 
 MIN_NODE_VERSION = 18
 


### PR DESCRIPTION
`constants.py` still declared `MIN_PYTHON_VERSION = (3, 8)`, but `pyproject.toml` requires `>=3.11` and CI tests 3.11/3.12. That constant is the runtime guard compared against `sys.version_info` in `hyperglass/main.py` and `hyperglass/util/system_info.py`, so the stale floor would let an unsupported interpreter start instead of erroring early.

Bumps it to `(3, 11)` to match the declared support window. Surfaced during the 2.1.0 release pass.