### PR TITLE
fix(ui): repair the share/result/form-prefill flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-running a query from history or a shared result now populates the form correctly (location, query type, and target) and the form can be submitted; previously the query type was blank and a prefilled "new target" form could not be submitted.
+- The opened-history "view result" and shared-result pages now use the same green bottom-left back control as live results, replacing the inconsistent text button. The shared page keeps its snapshot/expiry banner.
+- Shared results now offer Re-run and "new target" actions; "Run a fresh query" no longer lands on an empty form.
+
+### Added
+
+- Opening a stored result reflects it in the address bar (a `/result/<id>` link when the result has been shared, otherwise a bookmarkable deep link).
+
 ## [2.1.3] - 2026-06-09
 
 ### Fixed

--- a/docs/superpowers/plans/2026-06-09-share-result-form-flow.md
+++ b/docs/superpowers/plans/2026-06-09-share-result-form-flow.md
@@ -1,0 +1,1034 @@
+# Share / result / form-prefill flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the broken result-share / form-prefill flow — prefilled forms actually populate and submit, back controls are consistent, shared results offer re-run, and opened results are reflected in the URL.
+
+**Architecture:** Collapse the three drifting form-state representations (react-hook-form values, Zustand `form`, Zustand `selections`) behind a single `prefillForm` entry point plus a Zustand→RHF mirror effect. Generalize the green floating back control. Add deep-link navigation (with optional auto-run) for re-running shared snapshots. Reflect opened results in the address bar.
+
+**Tech Stack:** Next.js 13 (pages router, static export), React, Zustand, react-hook-form + vest, Chakra UI, Vitest + jsdom, Playwright (headless e2e gate).
+
+**Working directory:** `hyperglass/ui/`. All paths below are relative to it unless noted. Run UI commands with `task pnpm <args>` from repo root, or `pnpm <args>` inside `hyperglass/ui/`. Lint: `npx biome lint .`; typecheck: `npx tsc --noEmit`; tests: `npx vitest --run <path>`.
+
+**Scope:** UI only. No backend changes. All user-visible strings already exist as config keys in `hyperglass/models/config/web.py` (`historyRerun`, `historyNewTarget`, `historyBack`, `shareRunFreshQuery`); do not hard-code strings.
+
+**Confirmed during planning (do not re-investigate):**
+- `LocationCard` already syncs `isChecked` from `defaultChecked` via a `useEffect` — no change needed; cards reflect prefill once `form.queryLocation` updates.
+- `useQueryHistory` already excludes `openId` from `persist` (partialize keeps only `entries`) — no change needed for that.
+- `ResultSnapshot` has no `query`; only `ShareResponse` (the `/result/<id>` payload) does. Shared re-run actions live on the result page where `ShareResponse` is available.
+
+---
+
+## File structure
+
+- `hooks/use-form-state.ts` — `prefillForm` becomes full source of truth (adds `selections.queryType`).
+- `components/looking-glass-form.tsx` — Zustand→RHF mirror; URL effect delegates to `prefillForm`; consumes `?run=1` auto-run.
+- `elements/floating-back-button.tsx` (new) — presentational floating green back control `{ isVisible, onClick, label }`.
+- `elements/index.ts` — export the new element.
+- `components/reset-button.tsx` — re-implemented on top of `FloatingBackButton` (live-results reset).
+- `pages/index.tsx` — opened-history view uses the floating back control instead of the text button.
+- `hooks/use-prefill-navigate.ts` (new) — builds the deep-link and navigates home (optionally with `run`).
+- `components/results/snapshot-actions.tsx` (new) — Re-run / New-target icon buttons for snapshots.
+- `pages/result/[id].tsx` — floating back arrow → `/`; replace the fresh-query link with `SnapshotActions`.
+- `hooks/use-query-history.ts` — `shareId` field + `setShareId` action + URL side effects in `open`/`close`.
+- `components/results/share-button.tsx` — optional `onShared(shareId)` callback.
+- `components/history/history-entry-row.tsx` — wire `onShared` → `setShareId`.
+
+---
+
+## Phase 1 — prefill correctness
+
+### Task 1: `prefillForm` populates `selections.queryType`
+
+**Files:**
+- Modify: `hooks/use-form-state.ts` (the `prefillForm` method, ~lines 204-239)
+- Test: `hooks/use-form-state.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `hooks/use-form-state.test.tsx` (follow the existing `getDevice` mock pattern already in that file; if a device/directive fixture helper exists, reuse it). The fixture device must expose a directive with `id: 'juniper_bgp_route'`, `name: 'BGP Route'`, `groups: []`.
+
+```tsx
+it('prefillForm sets selections.queryType from the matching directive', () => {
+  const getDevice = makeGetDevice(); // existing helper returning a device w/ the directive
+  useFormState.getState().prefillForm(
+    { queryLocation: ['test1'], queryType: 'juniper_bgp_route', queryTarget: ['192.0.2.0/24'] },
+    getDevice,
+  );
+  const { selections, form } = useFormState.getState();
+  expect(form.queryType).toBe('juniper_bgp_route');
+  expect(selections.queryType).toEqual({ value: 'juniper_bgp_route', label: 'BGP Route' });
+});
+
+it('prefillForm leaves selections.queryType null for an empty type (new target)', () => {
+  const getDevice = makeGetDevice();
+  useFormState.getState().prefillForm(
+    { queryLocation: ['test1'], queryType: '', queryTarget: [] },
+    getDevice,
+  );
+  expect(useFormState.getState().selections.queryType).toBeNull();
+});
+```
+
+If `makeGetDevice` does not already exist in the test file, define a local helper that returns a device matching `~/types` `Device` with one directive as above, and `null` for unknown ids.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest --run hooks/use-form-state.test.tsx -t "selections.queryType"`
+Expected: FAIL — `selections.queryType` is `null` for the first test (current code hardcodes `null`).
+
+- [ ] **Step 3: Implement**
+
+In `hooks/use-form-state.ts`, replace the `set({...})` block inside `prefillForm` so `selections.queryType` is derived from the computed `directives`:
+
+```ts
+    const directives = dedupObjectArray(intersectingDirectives, 'id');
+
+    const matchingType = directives.find(d => d.id === query.queryType) ?? null;
+    const queryTypeSelection = matchingType
+      ? { value: matchingType.id, label: matchingType.name }
+      : null;
+
+    set({
+      form: {
+        queryLocation: validLocations,
+        queryType: query.queryType,
+        queryTarget: query.queryTarget,
+      },
+      selections: {
+        queryLocation: validDevices.map(d => ({ value: d.id, label: d.name })),
+        queryType: queryTypeSelection,
+      },
+      filtered: { groups: intersecting, types: directives },
+      target: { display: query.queryTarget.join(' ') },
+    });
+
+    return validLocations;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest --run hooks/use-form-state.test.tsx`
+Expected: PASS (all tests in file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hooks/use-form-state.ts hooks/use-form-state.test.tsx
+git commit -m "fix(ui): prefillForm populates the query-type selection"
+```
+
+---
+
+### Task 2: Zustand→RHF mirror + URL prefill via `prefillForm` + auto-run
+
+**Files:**
+- Modify: `components/looking-glass-form.tsx`
+- Test: `components/looking-glass-form.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `components/looking-glass-form.test.tsx` (it already has a `?location=` prefill test and `next/router` mock; follow that mock style — set `router.query` and `isReady: true`).
+
+```tsx
+it('prefills type + target from URL and mirrors them into react-hook-form', async () => {
+  // Arrange router.query = { location: 'test1', type: 'juniper_bgp_route', target: '192.0.2.0/24' }
+  // (use the file's existing router-mock helper)
+  renderForm();
+  // selections.queryType drives the visible type value:
+  await waitFor(() =>
+    expect(useFormState.getState().selections.queryType).toEqual({
+      value: 'juniper_bgp_route',
+      label: 'BGP Route',
+    }),
+  );
+  // RHF mirror: the submit button is gated on a valid form; target present => SubmitButton visible.
+  await waitFor(() => expect(screen.getByLabelText(/submit/i)).toBeInTheDocument());
+});
+
+it('auto-runs when ?run=1 is present', async () => {
+  // router.query = { location: 'test1', type: 'juniper_bgp_route', target: '192.0.2.0/24', run: '1' }
+  renderForm();
+  await waitFor(() => expect(useFormState.getState().status).toBe('results'));
+  expect(useFormState.getState().submissionId).not.toBeNull();
+});
+```
+
+Match the file's existing render/mocks (`renderForm`, `screen`, `waitFor`). The submit-button accessible name comes from `web.text` in the test config; adjust the matcher to the file's existing convention if it differs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest --run components/looking-glass-form.test.tsx -t "mirrors them into react-hook-form"`
+Expected: FAIL — `selections.queryType` stays `null` (URL path never set it) and/or auto-run test fails (no `run` handling).
+
+- [ ] **Step 3: Implement**
+
+In `components/looking-glass-form.tsx`:
+
+(a) Replace the URL-param prefill `useEffect` (currently ~lines 141-172) with one that delegates to `prefillForm` and handles `run`:
+
+```tsx
+  const prefillForm = useFormState(s => s.prefillForm);
+
+  // Pre-fill from URL query params (?location=&target=&type=[&run=1]). Applied
+  // once on mount when router.isReady; the ref guard prevents re-applying after
+  // the user edits the form. Delegates to prefillForm (single source of truth);
+  // the Zustand→RHF mirror below keeps react-hook-form in sync for validation.
+  const prefillApplied = useRef(false);
+  useEffect(() => {
+    if (!router.isReady || prefillApplied.current) return;
+    const { location, target, type, run } = router.query;
+    if (typeof location !== 'string') {
+      prefillApplied.current = true;
+      return;
+    }
+    prefillApplied.current = true;
+
+    const valid = prefillForm(
+      {
+        queryLocation: [location],
+        queryType: typeof type === 'string' ? type : '',
+        queryTarget: typeof target === 'string' ? [target] : [],
+      },
+      getDevice,
+    );
+
+    const canRun =
+      run === '1' &&
+      valid.length > 0 &&
+      typeof type === 'string' &&
+      type.length > 0 &&
+      typeof target === 'string' &&
+      target.length > 0;
+    if (canRun) {
+      setSubmissionId(makeSubmissionId());
+      setStatus('results');
+    }
+  }, [router.isReady, router.query]); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+(b) Add the Zustand→RHF mirror effect (anywhere after `formInstance` is created):
+
+```tsx
+  // Mirror Zustand form values into react-hook-form. Prefill paths write to
+  // Zustand (form/selections) but not RHF; without this, RHF's validation still
+  // sees empty values and a prefilled form cannot be submitted.
+  useEffect(() => {
+    setValue('queryLocation', form.queryLocation);
+    setValue('queryType', form.queryType);
+    setValue('queryTarget', form.queryTarget);
+  }, [form.queryLocation, form.queryType, form.queryTarget, setValue]);
+```
+
+`setSubmissionId`, `setStatus`, `getDevice`, `makeSubmissionId`, and `form` are already in scope in this component. Remove now-unused `setSelection`/`setTarget`/`setFormValue`/`locationChange` references **only if** they become unused after the rewrite (they are still used by `handleChange`; keep those).
+
+- [ ] **Step 4: Run tests + lint + typecheck**
+
+Run:
+```
+npx vitest --run components/looking-glass-form.test.tsx
+npx biome lint components/looking-glass-form.tsx
+npx tsc --noEmit
+```
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/looking-glass-form.tsx components/looking-glass-form.test.tsx
+git commit -m "fix(ui): sync prefilled form into react-hook-form and support URL auto-run"
+```
+
+---
+
+### Task 3: History Re-run / New-target populate correctly (regression test)
+
+**Files:**
+- Test: `components/history/history-entry-row.test.tsx`
+
+This behavior is fixed by Tasks 1–2; add explicit assertions so it can't regress.
+
+- [ ] **Step 1: Write the test**
+
+Extend the existing Re-run / New-target tests (the file already renders a row and triggers these). Assert the type selection is populated:
+
+```tsx
+it('Re-run prefills location, type selection, and target', () => {
+  // render row for an entry with query { queryLocation:['test1'], queryType:'juniper_bgp_route', queryTarget:['192.0.2.0/24'] }
+  fireEvent.click(screen.getByLabelText(web.text.historyRerun));
+  const st = useFormState.getState();
+  expect(st.form.queryType).toBe('juniper_bgp_route');
+  expect(st.selections.queryType).toEqual({ value: 'juniper_bgp_route', label: 'BGP Route' });
+  expect(st.form.queryTarget).toEqual(['192.0.2.0/24']);
+});
+
+it('New target prefills type selection but clears target', () => {
+  fireEvent.click(screen.getByLabelText(web.text.historyNewTarget));
+  const st = useFormState.getState();
+  expect(st.selections.queryType).toEqual({ value: 'juniper_bgp_route', label: 'BGP Route' });
+  expect(st.form.queryTarget).toEqual([]);
+});
+```
+
+Reuse the file's existing config/`web.text` access and entry fixtures. (Note: New-target passes `queryType` through, so the type selection is preserved — only target is cleared.)
+
+- [ ] **Step 2: Run**
+
+Run: `npx vitest --run components/history/history-entry-row.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/history/history-entry-row.test.tsx
+git commit -m "test(ui): assert history re-run/new-target populate the type selection"
+```
+
+---
+
+## Phase 2 — consistent back control + shared re-run
+
+### Task 4: `FloatingBackButton` element + reuse in `ResetButton`
+
+**Files:**
+- Create: `elements/floating-back-button.tsx`
+- Modify: `elements/index.ts`, `components/reset-button.tsx`
+- Test: `elements/floating-back-button.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { ChakraProvider } from '@chakra-ui/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FloatingBackButton } from './floating-back-button';
+
+const renderEl = (props: Partial<React.ComponentProps<typeof FloatingBackButton>>) =>
+  render(
+    <ChakraProvider>
+      <FloatingBackButton isVisible onClick={() => {}} label="Back" {...props} />
+    </ChakraProvider>,
+  );
+
+describe('FloatingBackButton', () => {
+  it('renders when visible and fires onClick', () => {
+    const onClick = vi.fn();
+    renderEl({ onClick });
+    fireEvent.click(screen.getByLabelText('Back'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the button when not visible', () => {
+    renderEl({ isVisible: false });
+    expect(screen.queryByLabelText('Back')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest --run elements/floating-back-button.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the element**
+
+Create `elements/floating-back-button.tsx` (extracted from the existing `ResetButton` styling):
+
+```tsx
+import { Flex, IconButton } from '@chakra-ui/react';
+import { AnimatePresence } from 'framer-motion';
+import { AnimatedDiv, DynamicIcon } from '~/elements';
+import { useColorValue, useOpposingColor } from '~/hooks';
+
+import type { FlexProps } from '@chakra-ui/react';
+
+interface FloatingBackButtonProps extends FlexProps {
+  isVisible: boolean;
+  onClick(): void;
+  label: string;
+  /** Extra bottom offset (e.g. developer-mode bar). */
+  raised?: boolean;
+}
+
+export const FloatingBackButton = (props: FloatingBackButtonProps): JSX.Element => {
+  const { isVisible, onClick, label, raised = false, ...rest } = props;
+  const bg = useColorValue('primary.500', 'primary.300');
+  const color = useOpposingColor(bg);
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <AnimatedDiv
+          bg={bg}
+          left={0}
+          zIndex={4}
+          bottom={24}
+          boxSize={12}
+          color={color}
+          position="fixed"
+          animate={{ x: 0 }}
+          exit={{ x: '-100%' }}
+          borderRightRadius="md"
+          initial={{ x: '-100%' }}
+          mb={raised ? { base: 0, lg: 14 } : undefined}
+          transition={{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }}
+        >
+          <Flex boxSize="100%" justifyContent="center" alignItems="center" {...rest}>
+            <IconButton
+              lineHeight={0}
+              color="current"
+              variant="unstyled"
+              aria-label={label}
+              onClick={onClick}
+              icon={<DynamicIcon icon={{ fa: 'FaAngleLeft' }} boxSize={8} />}
+            />
+          </Flex>
+        </AnimatedDiv>
+      )}
+    </AnimatePresence>
+  );
+};
+```
+
+Add to `elements/index.ts`:
+
+```ts
+export * from './floating-back-button';
+```
+
+- [ ] **Step 4: Re-implement `ResetButton` on top of it**
+
+Replace `components/reset-button.tsx` body with:
+
+```tsx
+import { useConfig } from '~/context';
+import { FloatingBackButton } from '~/elements';
+import { useFormState } from '~/hooks';
+
+interface ResetButtonProps {
+  developerMode: boolean;
+  resetForm(): void;
+}
+
+export const ResetButton = (props: ResetButtonProps): JSX.Element => {
+  const { developerMode, resetForm } = props;
+  const status = useFormState(s => s.status);
+  const { web } = useConfig();
+  return (
+    <FloatingBackButton
+      isVisible={status === 'results'}
+      onClick={resetForm}
+      label={web.text.historyBack}
+      raised={developerMode}
+    />
+  );
+};
+```
+
+If `ResetButton`'s call site passed `FlexProps` spread (`...rest`), check `components/layout.tsx` for how it's rendered and drop any now-unsupported props. Run typecheck to catch this.
+
+- [ ] **Step 5: Run tests + typecheck + lint**
+
+Run:
+```
+npx vitest --run elements/floating-back-button.test.tsx
+npx tsc --noEmit
+npx biome lint elements/floating-back-button.tsx components/reset-button.tsx
+```
+Expected: PASS / clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add elements/floating-back-button.tsx elements/floating-back-button.test.tsx elements/index.ts components/reset-button.tsx
+git commit -m "refactor(ui): extract FloatingBackButton and build ResetButton on it"
+```
+
+---
+
+### Task 5: Opened-history view uses the floating back control
+
+**Files:**
+- Modify: `pages/index.tsx`
+
+- [ ] **Step 1: Implement**
+
+In `pages/index.tsx`, replace the opened-entry `<Flex>…<Button>{web.text.historyBack}</Button></Flex>` block with the floating control, and drop the now-unused `Button`/`Flex` import if unused:
+
+```tsx
+  if (openEntry) {
+    const items: SnapshotResultsItem[] = Object.entries(openEntry.results).map(
+      ([queryLocation, snapshot]) => ({ queryLocation, snapshot }),
+    );
+    return (
+      <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
+        <FloatingBackButton isVisible onClick={close} label={web.text.historyBack} />
+        <SnapshotResults items={items} showShare />
+      </Box>
+    );
+  }
+```
+
+Add `import { FloatingBackButton } from '~/elements';` and remove `Button`/`Flex` from the chakra import if they are no longer referenced elsewhere in the file (`Box` is still used).
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `npx tsc --noEmit && npx biome lint pages/index.tsx`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pages/index.tsx
+git commit -m "fix(ui): use the floating back control in the opened-history view"
+```
+
+---
+
+### Task 6: `usePrefillNavigate` hook + `SnapshotActions` component
+
+**Files:**
+- Create: `hooks/use-prefill-navigate.ts`, `components/results/snapshot-actions.tsx`
+- Modify: `hooks/index.ts` (if hooks are re-exported there — check; otherwise import directly)
+- Test: `components/results/snapshot-actions.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { ChakraProvider } from '@chakra-ui/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const push = vi.fn();
+vi.mock('next/router', () => ({ useRouter: () => ({ push }) }));
+vi.mock('~/context', () => ({
+  useConfig: () => ({ web: { text: { historyRerun: 'Run again', historyNewTarget: 'Run with a new target' } } }),
+}));
+
+import { SnapshotActions } from './snapshot-actions';
+
+const q = { queryLocation: 'test1', queryType: 'juniper_bgp_route', queryTarget: '192.0.2.0/24' };
+
+describe('SnapshotActions', () => {
+  it('Re-run navigates home with prefill + run flag', () => {
+    render(
+      <ChakraProvider>
+        <SnapshotActions query={q} />
+      </ChakraProvider>,
+    );
+    fireEvent.click(screen.getByLabelText('Run again'));
+    expect(push).toHaveBeenCalledWith(
+      '/?location=test1&type=juniper_bgp_route&target=192.0.2.0%2F24&run=1',
+    );
+  });
+
+  it('New target navigates home with prefill, no run flag and no target', () => {
+    render(
+      <ChakraProvider>
+        <SnapshotActions query={q} />
+      </ChakraProvider>,
+    );
+    fireEvent.click(screen.getByLabelText('Run with a new target'));
+    expect(push).toHaveBeenCalledWith('/?location=test1&type=juniper_bgp_route');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest --run components/results/snapshot-actions.test.tsx`
+Expected: FAIL — modules do not exist.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `hooks/use-prefill-navigate.ts`:
+
+```ts
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+
+export interface PrefillQuery {
+  queryLocation: string;
+  queryType: string;
+  /** Single target value; omitted/empty means "new target". */
+  queryTarget?: string;
+}
+
+/**
+ * Navigate to the looking-glass home with the form pre-filled from a snapshot's
+ * query. When `run` is true, append `run=1` so the form auto-submits a fresh
+ * live query on arrival (consumed by LookingGlassForm's URL prefill effect).
+ */
+export function usePrefillNavigate(): (q: PrefillQuery, opts?: { run?: boolean }) => void {
+  const router = useRouter();
+  return useCallback(
+    (q: PrefillQuery, opts?: { run?: boolean }) => {
+      const params = new URLSearchParams();
+      params.set('location', q.queryLocation);
+      params.set('type', q.queryType);
+      if (q.queryTarget) params.set('target', q.queryTarget);
+      if (opts?.run && q.queryTarget) params.set('run', '1');
+      router.push(`/?${params.toString()}`);
+    },
+    [router],
+  );
+}
+```
+
+If `hooks/index.ts` re-exports hooks, add `export * from './use-prefill-navigate';` there.
+
+- [ ] **Step 4: Implement the component**
+
+Create `components/results/snapshot-actions.tsx`:
+
+```tsx
+import { Button, HStack, Tooltip } from '@chakra-ui/react';
+import { useConfig } from '~/context';
+import { DynamicIcon } from '~/elements';
+import { usePrefillNavigate } from '~/hooks/use-prefill-navigate';
+
+export interface SnapshotActionsProps {
+  query: { queryLocation: string; queryType: string; queryTarget: string };
+}
+
+const iconBtn = {
+  mx: 1,
+  size: 'sm' as const,
+  variant: 'ghost' as const,
+  colorScheme: 'secondary' as const,
+};
+
+export const SnapshotActions = (props: SnapshotActionsProps): JSX.Element => {
+  const { query } = props;
+  const { web } = useConfig();
+  const navigate = usePrefillNavigate();
+
+  return (
+    <HStack spacing={0} flex="0 0 auto">
+      <Tooltip hasArrow label={web.text.historyRerun} placement="top">
+        <Button
+          {...iconBtn}
+          aria-label={web.text.historyRerun}
+          onClick={() =>
+            navigate(
+              { queryLocation: query.queryLocation, queryType: query.queryType, queryTarget: query.queryTarget },
+              { run: true },
+            )
+          }
+        >
+          <DynamicIcon icon={{ fi: 'FiRepeat' }} boxSize="16px" />
+        </Button>
+      </Tooltip>
+      <Tooltip hasArrow label={web.text.historyNewTarget} placement="top">
+        <Button
+          {...iconBtn}
+          aria-label={web.text.historyNewTarget}
+          onClick={() => navigate({ queryLocation: query.queryLocation, queryType: query.queryType })}
+        >
+          <DynamicIcon icon={{ fi: 'FiEdit' }} boxSize="16px" />
+        </Button>
+      </Tooltip>
+    </HStack>
+  );
+};
+```
+
+- [ ] **Step 5: Run tests + typecheck + lint**
+
+Run:
+```
+npx vitest --run components/results/snapshot-actions.test.tsx
+npx tsc --noEmit
+npx biome lint hooks/use-prefill-navigate.ts components/results/snapshot-actions.tsx
+```
+Expected: PASS / clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hooks/use-prefill-navigate.ts components/results/snapshot-actions.tsx components/results/snapshot-actions.test.tsx hooks/index.ts
+git commit -m "feat(ui): add snapshot re-run/new-target actions with prefill navigation"
+```
+
+---
+
+### Task 7: Wire the shared result page (back arrow + SnapshotActions)
+
+**Files:**
+- Modify: `pages/result/[id].tsx`
+- Test: `__tests__/pages/result/[id].test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `__tests__/pages/result/[id].test.tsx` (it already mocks `~/context` and sets `window.location`; reuse `SHARE_ID` and the fake snapshot). The snapshot fake's `query` uses snake_case keys.
+
+```tsx
+it('renders re-run action that navigates home with prefill + run flag', async () => {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse({}));
+  render(<ResultPage />, { wrapper });
+  const rerun = await screen.findByLabelText('Run again'); // web.text.historyRerun from test config
+  fireEvent.click(rerun);
+  expect(push).toHaveBeenCalledWith(
+    expect.stringContaining('/?location=test1&type=juniper_bgp_route&target=192.0.2.0%2F24&run=1'),
+  );
+});
+```
+
+Add `historyRerun`/`historyNewTarget` to the test's `~/context` `web.text` mock, add a `next/router` mock exposing a `push` spy (the page currently doesn't import the router — add the mock at top of file), and import `fireEvent`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest --run "__tests__/pages/result/[id].test.tsx" -t "re-run action"`
+Expected: FAIL — no such control yet.
+
+- [ ] **Step 3: Implement**
+
+In `pages/result/[id].tsx`:
+
+- Add `import { FloatingBackButton } from '~/elements';`, `import { useRouter } from 'next/router';`, and `import { SnapshotActions } from '~/components/results/snapshot-actions';`.
+- Normalize the snapshot query (target may be string or string[]):
+
+```tsx
+  const router = useRouter();
+  const rawTarget = snapshot.query.query_target;
+  const queryTarget = typeof rawTarget === 'string' ? rawTarget : rawTarget[0];
+  const actionsQuery = {
+    queryLocation: snapshot.query.query_location,
+    queryType: snapshot.query.query_type,
+    queryTarget,
+  };
+```
+
+- Replace the existing `freshUrl`/`<Link>` block with `<SnapshotActions query={actionsQuery} />`, and add the floating back arrow at the top of the returned `<Box>`:
+
+```tsx
+  return (
+    <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
+      <FloatingBackButton isVisible onClick={() => router.push('/')} label={web.text.historyBack} />
+      <Flex /* existing banner row: keep "Snapshot taken at…" + "Expires…" */ >
+        <Text>{banner}</Text>
+        <Text>{expires}</Text>
+      </Flex>
+      <SnapshotResults items={[{ queryLocation: snapshot.query.query_location, snapshot }]} />
+      <Flex justifyContent="center" mt={4}>
+        <SnapshotActions query={actionsQuery} />
+      </Flex>
+    </Box>
+  );
+```
+
+Remove the now-unused `Link` import and the `freshUrl`/`strF(web.text.shareRunFreshQuery…)` usage if no longer referenced.
+
+- [ ] **Step 4: Run tests + typecheck + lint**
+
+Run:
+```
+npx vitest --run "__tests__/pages/result/[id].test.tsx"
+npx tsc --noEmit
+npx biome lint "pages/result/[id].tsx"
+```
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "pages/result/[id].tsx" "__tests__/pages/result/[id].test.tsx"
+git commit -m "feat(ui): shared result page gets a back arrow and re-run actions"
+```
+
+---
+
+### Task 8: End-to-end browser gate for Phases 1–2
+
+**Files:**
+- Create (temporary, deleted at end): `verify-flow.mjs`
+
+This is the real-browser gate. It mirrors the harness used for the share-download fix.
+
+- [ ] **Step 1: Build the export**
+
+```bash
+cp ../../.tests/hyperglass.json ./hyperglass.json
+export NODE_OPTIONS=--openssl-legacy-provider
+NODE_ENV=production npx next build
+```
+Expected: build succeeds; `out/result/shared.html` and `out/index.html` exist.
+
+- [ ] **Step 2: Write the verification script**
+
+Create `hyperglass/ui/verify-flow.mjs` — a static server that (a) serves `out/`, (b) serves `out/result/shared.html` for `/result/<id>`, (c) fakes `GET /api/query/share/<id>` with a full `ShareResponse` (use the `.tests/hyperglass.json` device id `example_device` for `query_location`), and (d) fakes `POST /api/query` so an auto-run resolves. Drive it with Playwright (resolve the package from the npx cache as before: `import pw from '<npx-cache>/playwright/index.js'`).
+
+Assertions:
+1. Load `/result/<id>` → the snapshot output renders and a "Run again" control is present.
+2. Click "Run again" → URL becomes `/?location=example_device&type=…&target=…&run=1`, the form is populated, and the app transitions to the results view (auto-run fired — assert a `POST /api/query` was received, or the results view rendered).
+3. The floating back arrow (aria-label "Back") is present on `/result/<id>` and navigates to `/`.
+
+- [ ] **Step 3: Run the verification**
+
+```bash
+node hyperglass/ui/verify-flow.mjs
+```
+Expected: prints `PASS` and exits 0. If it fails, return to systematic-debugging — do NOT proceed.
+
+- [ ] **Step 4: Clean up build artifacts**
+
+```bash
+rm -f hyperglass/ui/verify-flow.mjs hyperglass/ui/hyperglass.json
+rm -rf hyperglass/ui/out
+```
+
+- [ ] **Step 5: Commit (only if a real source fix was needed)**
+
+If Steps 1–3 surfaced a bug requiring a source change, commit it with a `fix(ui):` message. Otherwise no commit (artifacts were removed).
+
+---
+
+## Phase 3 — URL reflects opened results
+
+### Task 9: `shareId` on history entries + capture on share
+
+**Files:**
+- Modify: `hooks/use-query-history.ts`, `components/results/share-button.tsx`, `components/history/history-entry-row.tsx`
+- Test: `hooks/use-query-history.test.tsx`, `components/results/share-button.test.tsx`
+
+- [ ] **Step 1: Write the failing test (store)**
+
+In `hooks/use-query-history.test.tsx`:
+
+```tsx
+it('setShareId stores a share id on the matching entry', () => {
+  const store = useQueryHistory.getState();
+  // seed one entry via record(...) using the file's existing helper/fixture, capture its id
+  const id = useQueryHistory.getState().entries[0].id;
+  useQueryHistory.getState().setShareId(id, 'ABCDEFGHIJK');
+  expect(useQueryHistory.getState().entries[0].shareId).toBe('ABCDEFGHIJK');
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest --run hooks/use-query-history.test.tsx -t "setShareId"`
+Expected: FAIL — no `setShareId`.
+
+- [ ] **Step 3: Implement store changes**
+
+In `hooks/use-query-history.ts`:
+- Add `shareId?: string;` to the `HistoryEntry` interface.
+- Add to the state interface: `setShareId(id: string, shareId: string): void;`
+- Implement:
+
+```ts
+        setShareId(id: string, shareId: string): void {
+          set(state => ({
+            entries: state.entries.map(e => (e.id === id ? { ...e, shareId } : e)),
+          }));
+        },
+```
+
+- [ ] **Step 4: Write the failing test (ShareButton callback)**
+
+In `components/results/share-button.test.tsx`, add a test that when the mutation succeeds, `onShared` is called with the minted id. Follow the file's existing `useShareCreate` mock pattern (it mocks the hook / fetch). Assert:
+
+```tsx
+it('calls onShared with the minted id on success', async () => {
+  const onShared = vi.fn();
+  // render <ShareButton cacheId="cache1" onShared={onShared} /> with a mocked success returning { id: 'ABCDEFGHIJK', url, expiresAt }
+  // trigger the share click
+  await waitFor(() => expect(onShared).toHaveBeenCalledWith('ABCDEFGHIJK'));
+});
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run: `npx vitest --run components/results/share-button.test.tsx -t "onShared"`
+Expected: FAIL — no `onShared` prop.
+
+- [ ] **Step 6: Implement ShareButton callback**
+
+In `components/results/share-button.tsx`:
+- Extend props: `export interface ShareButtonProps { cacheId: string; onShared?: (shareId: string) => void; }`
+- Fire it once when the mutation succeeds:
+
+```tsx
+  useEffect(() => {
+    if (isSuccess && data?.id) onShared?.(data.id);
+  }, [isSuccess, data?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+(`onShared` destructured from props.)
+
+- [ ] **Step 7: Wire history-entry-row**
+
+In `components/history/history-entry-row.tsx`, pass the callback:
+
+```tsx
+  const setShareId = useQueryHistory(s => s.setShareId);
+  // …
+  {isSingleDevice && (
+    <ShareButton
+      cacheId={entry.results[deviceIds[0]].id}
+      onShared={shareId => setShareId(entry.id, shareId)}
+    />
+  )}
+```
+
+- [ ] **Step 8: Run all affected tests + typecheck + lint**
+
+Run:
+```
+npx vitest --run hooks/use-query-history.test.tsx components/results/share-button.test.tsx components/history/history-entry-row.test.tsx
+npx tsc --noEmit
+npx biome lint hooks/use-query-history.ts components/results/share-button.tsx components/history/history-entry-row.tsx
+```
+Expected: PASS / clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add hooks/use-query-history.ts hooks/use-query-history.test.tsx components/results/share-button.tsx components/results/share-button.test.tsx components/history/history-entry-row.tsx
+git commit -m "feat(ui): remember a history entry's share id when shared"
+```
+
+---
+
+### Task 10: Reflect opened results in the URL
+
+**Files:**
+- Modify: `hooks/use-query-history.ts` (open/close) and/or `pages/index.tsx`
+- Test: `pages/index.test.tsx` (create if absent) or extend an existing index/history test
+
+The router is not available inside a Zustand store, so perform the URL side effect in `pages/index.tsx` via an effect keyed on `openId`, not inside `open()`/`close()`.
+
+- [ ] **Step 1: Write the failing test**
+
+In a test for `pages/index.tsx` (mock `next/router` with `push` spy and a `query` object; mock `useQueryHistory` and `useConfig`):
+
+```tsx
+it('opening an un-shared entry shallow-pushes the deep-link', async () => {
+  // useQueryHistory returns openId='e1', entries=[{ id:'e1', query:{queryLocation:['test1'],queryType:'juniper_bgp_route',queryTarget:['192.0.2.0/24']}, results:{...}, labels:{...} }]
+  render(<Index />);
+  await waitFor(() =>
+    expect(push).toHaveBeenCalledWith(
+      '/?location=test1&type=juniper_bgp_route&target=192.0.2.0%2F24',
+      undefined,
+      { shallow: true },
+    ),
+  );
+});
+
+it('opening a shared entry navigates to /result/<shareId>', async () => {
+  // same entry but with shareId:'ABCDEFGHIJK'
+  render(<Index />);
+  await waitFor(() => expect(push).toHaveBeenCalledWith('/result/ABCDEFGHIJK'));
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest --run pages/index.test.tsx`
+Expected: FAIL — no URL push on open.
+
+- [ ] **Step 3: Implement**
+
+In `pages/index.tsx`, add an effect that runs when `openEntry` changes:
+
+```tsx
+  const router = useRouter();
+  useEffect(() => {
+    if (!openEntry) return;
+    if (openEntry.shareId) {
+      router.push(`/result/${openEntry.shareId}`);
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set('location', openEntry.query.queryLocation[0]);
+    params.set('type', openEntry.query.queryType);
+    if (openEntry.query.queryTarget[0]) params.set('target', openEntry.query.queryTarget[0]);
+    router.push(`/?${params.toString()}`, undefined, { shallow: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openEntry?.id]);
+```
+
+And in `close`'s handler path, restore `/`: change the `close` button/back control to also shallow-reset the URL. Since `close` lives in the store, do it in the same component — wrap the back control's `onClick`:
+
+```tsx
+  const close = useQueryHistory(s => s.close);
+  const handleClose = () => {
+    close();
+    router.push('/', undefined, { shallow: true });
+  };
+  // …in the openEntry return: onClick={handleClose}
+```
+
+`useRouter` and `useEffect` must be imported in `pages/index.tsx`.
+
+- [ ] **Step 4: Run tests + typecheck + lint**
+
+Run:
+```
+npx vitest --run pages/index.test.tsx
+npx tsc --noEmit
+npx biome lint pages/index.tsx
+```
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pages/index.tsx pages/index.test.tsx
+git commit -m "feat(ui): reflect an opened history result in the address bar"
+```
+
+---
+
+### Task 11: Final full verification + changelog
+
+**Files:**
+- Modify: `CHANGELOG.md` (repo root)
+
+- [ ] **Step 1: Full UI suite + lint + typecheck**
+
+Run (from repo root):
+```
+task pnpm test
+npx --prefix hyperglass/ui biome lint hyperglass/ui     # or: cd hyperglass/ui && npx biome lint .
+cd hyperglass/ui && npx tsc --noEmit
+```
+Expected: all tests pass; Biome clean; tsc clean.
+
+- [ ] **Step 2: Re-run the end-to-end browser gate (Task 8 script) including the Phase-3 URL behavior**
+
+Rebuild the export and re-run the verification (add an assertion that opening a shared entry lands on `/result/<id>`). Expected: PASS. Clean up artifacts afterward.
+
+- [ ] **Step 3: Changelog**
+
+Add an Unreleased entry to `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Fixed
+
+- Re-running a query from history or a shared result now populates the form correctly (location, query type, and target) and the form can be submitted; previously the query type was blank and a prefilled "new target" form could not be submitted.
+- The "view result" and shared-result pages now use the same green bottom-left back control as live results, replacing the inconsistent text button. The shared page keeps its snapshot/expiry banner.
+- Shared results now offer Re-run and "new target" actions; "Run a fresh query" no longer lands on an empty form.
+
+### Added
+
+- Opening a stored result reflects it in the address bar (a `/result/<id>` link when the result has been shared, otherwise a bookmarkable deep link).
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): record share/result/form-prefill fixes"
+```
+
+---
+
+## Self-review notes (addressed)
+
+- **Spec coverage:** item 1 → Tasks 1–3; item 2 → Tasks 4,5,7; item 3 → Tasks 9,10; item 4 → Tasks 1–2 (prefill), 6,7 (actions); testing/e2e gate → Tasks 8,11.
+- **Dropped from spec (correctly):** LocationCard change (already self-syncs) and `openId` persist exclusion (already partialized) — confirmed during planning; no tasks needed.
+- **Type consistency:** `FloatingBackButton` props `{ isVisible, onClick, label, raised }` used identically in Tasks 4,5,7. `PrefillQuery`/`SnapshotActions` query shape `{ queryLocation, queryType, queryTarget? }` consistent across Tasks 6,7. `setShareId(id, shareId)` consistent across Tasks 9,10.
+- **No backend changes:** all strings reuse existing `web.text` keys.

--- a/docs/superpowers/specs/2026-06-09-share-result-form-flow-design.md
+++ b/docs/superpowers/specs/2026-06-09-share-result-form-flow-design.md
@@ -1,0 +1,167 @@
+# Share / result / form-prefill flow — design
+
+Date: 2026-06-09
+Status: Approved (pending spec review)
+Scope: hyperglass UI (`hyperglass/ui/`) only. No backend changes.
+
+## Problem
+
+Four user-reported defects in the result-viewing / sharing / history flow:
+
+1. **"Run with a new target" (history) doesn't populate the form.** Location
+   appears selected but is inert, Query Type is blank, Target is blank.
+2. **Inconsistent back controls.** Live query results use a green bottom-left
+   arrow (`ResetButton`, `FaAngleLeft`); the opened-history "view result" uses a
+   plain text "Back" button; the shared `/result/<id>` page has no back control
+   (but does show a "Snapshot taken at…/Expires…" banner the user wants kept).
+3. **URL does not reflect the result being viewed.** Opening a stored result
+   leaves the address bar unchanged, so it is not linkable / back-navigable.
+4. **Shared results lack re-run actions, and "Run a fresh query" is broken** —
+   it navigates to `/?…` but the form does not populate.
+
+## Root causes
+
+The form has **three** representations of its state that must stay in sync:
+
+- **react-hook-form (RHF) values** — drive validation and gate submit (the vest
+  resolver validates RHF values; `handleSubmit` won't call `submitHandler` if
+  RHF says the form is invalid).
+- **Zustand `form`** — drives `submitHandler`, `useView`, the gallery
+  `LocationCard` `defaultChecked`, and directive filtering.
+- **Zustand `selections`** — drive the *displayed* value of the Location and
+  Query Type dropdowns (`<Select value={selections.queryType} />`).
+
+The two prefill paths each sync a different subset:
+
+- `prefillForm` (`hooks/use-form-state.ts`, used by history Re-run / New-target)
+  sets Zustand `form` + `selections.queryLocation`, but hardcodes
+  `selections.queryType: null` and **never touches RHF**. Result: Query Type
+  shows blank, and a prefilled "New target" form cannot be submitted because RHF
+  still believes `queryLocation` is empty.
+- The URL-param effect (`looking-glass-form.tsx`, used by "Run a fresh query")
+  sets RHF + Zustand `form` but **also never sets `selections.queryType`**.
+
+So both items 1 and 4 share a root cause: prefill never populates
+`selections.queryType`, and the two paths sync different subsets of the three
+state representations (they have drifted twice now).
+
+For item 2, the green back control is `components/reset-button.tsx`, hardwired
+to `status === 'results'` and `resetForm`. For item 4's missing actions,
+`components/results/individual.tsx` hides `RequeryButton`/`ShareButton` whenever
+`readOnly` (the share and snapshot views).
+
+## Approved product decisions
+
+- **Item 3 — URL on results:** *Only for opened results.* Live query results
+  keep the bare URL (`/`). Opening a stored result reflects in the URL:
+  `/result/<id>` when a share id is known, otherwise a deep-link
+  `/?location=…&target=…&type=…`. The shared view stays `/result/<id>`.
+- **Item 2 — back control:** Use the green bottom-left arrow on **both** the
+  opened-history view and the shared `/result/<id>` page, replacing the plain
+  text "Back". Keep the snapshot/expires banner on the shared page.
+- **Item 4 — shared re-run:** Re-running from a shared result navigates to the
+  looking glass home, populates the form, and **auto-runs** a fresh live query.
+
+## Design
+
+Chosen approach for prefill (vs. patching each path separately): **one prefill
+entry point + a Zustand→RHF mirror.** This collapses the duplication that caused
+the drift.
+
+### Phase 1 — prefill correctness (fixes item 1 + populate-half of item 4)
+
+- `prefillForm(query, getDevice)` becomes the single source of truth. In
+  addition to today's behavior it sets `selections.queryType` by finding the
+  directive in the computed `filtered.types` whose `id === query.queryType` and
+  building `{ value: id, label: name }` (or `null` when the type is empty/
+  unknown, e.g. New-target which clears only the target).
+- Add an effect in `looking-glass-form.tsx` that mirrors Zustand `form` into RHF
+  (`setValue`) whenever they diverge, guarded against update loops. This makes a
+  prefilled form (including history "New target") actually submittable.
+- Rewrite the URL-param prefill effect to call `prefillForm` (passing
+  `getDevice`) instead of duplicating the location/type/target wiring. The
+  mirror effect then pushes values into RHF.
+- Make the gallery `LocationCard` reflect the prefilled selection via a
+  controlled checked state derived from `form.queryLocation`, not a one-shot
+  `defaultChecked`, so cards-mode prefill is visible and active.
+
+### Phase 2 — consistent back control + shared actions
+
+- Generalize `ResetButton` into a reusable floating back control
+  (`FloatingBackButton`) with props `{ isVisible, onClick, label }`, and migrate
+  the single live-results call site to it (no compatibility wrapper).
+  - Live results → resets the form (unchanged behavior).
+  - Opened-history view (`pages/index.tsx`) → green arrow, `onClick = close()`;
+    remove the text `historyBack` button.
+  - Shared `/result/[id]` → green arrow returning to `/`; keep the banner.
+- In `individual.tsx`, replace the blanket `readOnly` action-hiding with
+  snapshot-aware actions: add **Re-run** (`FiRepeat`) and **New target**
+  (`FiEdit`) to snapshot results (shared page + opened history), mirroring the
+  history row. They build the deep-link and navigate to `/`; Re-run includes an
+  auto-run flag. Remove the broken "Run a fresh query" text link from
+  `pages/result/[id].tsx` in favor of these icons.
+
+### Phase 3 — URL reflects opened results (item 3)
+
+- Add `shareId?: string` to `HistoryEntry` (`hooks/use-query-history.ts`).
+  Persist it when a user shares from within an opened entry (capture the id
+  minted by `ShareButton` / `useShareCreate`).
+- `open(id)` updates the address bar. When the entry has a `shareId`, navigate
+  to `/result/<shareId>` (a normal client navigation to the canonical share
+  page — not shallow, since it's a different route). Otherwise stay on the index
+  page and shallow-push the deep-link `/?location=…&target=…&type=…` so the
+  opened-entry view remains mounted and is bookmarkable. `close()` shallow-pushes
+  back to `/`. (Only the deep-link case is shallow; the `/result/<id>` case is a
+  real route change handled by the share page.)
+- Exclude `openId` from the history `persist` partialize so reloading `/` shows
+  the form rather than a stale opened entry.
+- This phase is the most intricate (shallow routing + browser-back interplay)
+  and is kept isolated so it cannot destabilize Phases 1–2.
+
+### Auto-run mechanism (shared/deep-link)
+
+The deep-link prefill already keys off URL query params. Add an opt-in `run`
+flag (e.g. `?…&run=1`) that, after a successful prefill where the form is valid,
+stamps a `submissionId` and sets status to `results` (the same path
+`submitHandler` takes for a non-FQDN query). Without the flag, prefill only
+populates (used by New-target). The flag is consumed once (the existing
+`prefillApplied` ref guard prevents re-runs on re-render).
+
+## Components and boundaries
+
+- `hooks/use-form-state.ts` — `prefillForm` owns full form/selection/filtered/
+  target population. Pure state transition; testable in isolation.
+- `components/looking-glass-form.tsx` — owns RHF mirroring and URL→prefill +
+  optional auto-run. Thin orchestration over `prefillForm`.
+- `components/<floating-back-button>` — presentational; `{ isVisible, onClick,
+  label }`. No knowledge of form/history/share.
+- `components/results/individual.tsx` — snapshot-aware action row.
+- `hooks/use-query-history.ts` — `shareId` field + open/close URL side-effects.
+
+## Testing
+
+- **Unit (Vitest):**
+  - `prefillForm` populates `selections.queryType` from a matching directive and
+    leaves it `null` for empty/unknown types.
+  - The RHF mirror makes a prefilled form pass validation / be submittable.
+  - History Re-run and New-target populate Location + Type (and Target for
+    Re-run; cleared for New-target).
+  - Shared-page Re-run/New-target render and build the correct deep-link, with
+    Re-run carrying the auto-run flag.
+  - Floating back control: visible per state, fires the right callback.
+- **End-to-end headless-browser check** (the Playwright harness used for the
+  share-download fix): build the export, load `/result/<id>`, click Re-run →
+  assert it lands on `/`, the form is populated, and the query auto-runs;
+  assert the green back arrow returns to `/`. Completion is gated on this real
+  pass, not unit tests alone.
+
+## Out of scope
+
+- Backend changes (the share API and `/result/<id>` handler are unchanged).
+- Auto-minting shares for live results (explicitly rejected in item 3).
+- Any unrelated refactor of the results group or query hooks.
+
+## Implementation order
+
+Phase 1 → Phase 2 → Phase 3. Each phase ends green (lint + unit). The end-to-end
+browser check runs after Phase 2 (covers items 1, 2, 4) and again after Phase 3.

--- a/hyperglass/ui/__tests__/pages/index.test.tsx
+++ b/hyperglass/ui/__tests__/pages/index.test.tsx
@@ -18,12 +18,16 @@ vi.mock('~/hooks', () => ({
 }));
 vi.mock('~/context', () => ({ useConfig: () => ({ web: { text: { historyBack: 'Back' } } }) }));
 
-import Index from './index';
+import Index from '../../pages/index';
 
 const entry = {
   id: 'e1',
   savedAt: 0,
-  query: { queryLocation: ['test1'], queryType: 'juniper_bgp_route', queryTarget: ['192.0.2.0/24'] },
+  query: {
+    queryLocation: ['test1'],
+    queryType: 'juniper_bgp_route',
+    queryTarget: ['192.0.2.0/24'],
+  },
   labels: { locations: ['Test1'], type: 'BGP Route', target: '192.0.2.0/24' },
   results: { test1: { id: 'c1' } },
 };

--- a/hyperglass/ui/__tests__/pages/result/[id].test.tsx
+++ b/hyperglass/ui/__tests__/pages/result/[id].test.tsx
@@ -1,8 +1,11 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const push = vi.fn();
+vi.mock('next/router', () => ({ useRouter: () => ({ push }) }));
 
 // jsdom does not implement window.matchMedia; Chakra UI's useBreakpointValue requires it.
 Object.defineProperty(window, 'matchMedia', {
@@ -52,6 +55,9 @@ vi.mock('~/context', () => ({
         shareLinkCopied: 'Copied!',
         shareCreateError: 'Could not create share link.',
         shareCreateExpired: 'Result expired. Refresh and try again.',
+        historyBack: 'Back',
+        historyRerun: 'Run again',
+        historyNewTarget: 'Run with a new target',
       },
       highlight: [],
     },
@@ -107,6 +113,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
 
 beforeEach(() => {
   global.fetch = vi.fn();
+  push.mockClear();
   // Simulate the browser loading /result/<id>; the page reads the ID from here.
   window.history.pushState({}, '', `/result/${SHARE_ID}`);
 });
@@ -145,17 +152,14 @@ describe('ResultPage', () => {
     );
   });
 
-  it('exposes a "Run a fresh query" link with prefilled query string', async () => {
+  it('renders a re-run action that navigates home with prefill + run flag', async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse({}));
-
     render(<ResultPage />, { wrapper });
-
-    const link = await screen.findByRole('link', { name: /Run a fresh query/i });
-    expect(link).toBeInTheDocument();
-
-    const href = link.getAttribute('href') ?? '';
-    expect(href).toMatch(/location=test1/);
-    expect(href).toMatch(/target=192\.0\.2\.0%2F24/);
-    expect(href).toMatch(/type=juniper_bgp_route/);
+    const rerun = await screen.findByLabelText('Run again');
+    fireEvent.click(rerun);
+    expect(push).toHaveBeenCalledWith(
+      expect.stringContaining('/?location='),
+    );
+    expect(push).toHaveBeenCalledWith(expect.stringContaining('run=1'));
   });
 });

--- a/hyperglass/ui/__tests__/pages/result/[id].test.tsx
+++ b/hyperglass/ui/__tests__/pages/result/[id].test.tsx
@@ -157,9 +157,7 @@ describe('ResultPage', () => {
     render(<ResultPage />, { wrapper });
     const rerun = await screen.findByLabelText('Run again');
     fireEvent.click(rerun);
-    expect(push).toHaveBeenCalledWith(
-      expect.stringContaining('/?location='),
-    );
+    expect(push).toHaveBeenCalledWith(expect.stringContaining('/?location='));
     expect(push).toHaveBeenCalledWith(expect.stringContaining('run=1'));
   });
 });

--- a/hyperglass/ui/components/history/history-entry-row.test.tsx
+++ b/hyperglass/ui/components/history/history-entry-row.test.tsx
@@ -155,6 +155,7 @@ describe('HistoryEntryRow', () => {
     expect(state.form.queryLocation).toEqual(['core1']);
     expect(state.form.queryType).toBe('bgp_route');
     expect(state.form.queryTarget).toEqual(['192.0.2.1']);
+    expect(state.selections.queryType).toEqual({ value: 'bgp_route', label: 'BGP Route' });
     expect(state.submissionId).not.toBeNull();
     expect(state.submissionId).not.toBe('previous-submission');
     expect(state.status).toBe('results');
@@ -168,6 +169,7 @@ describe('HistoryEntryRow', () => {
     expect(state.form.queryLocation).toEqual(['core1']);
     expect(state.form.queryType).toBe('bgp_route');
     expect(state.form.queryTarget).toEqual([]);
+    expect(state.selections.queryType).toEqual({ value: 'bgp_route', label: 'BGP Route' });
     expect(state.status).toBe('form');
     expect(state.submissionId).toBeNull();
   });

--- a/hyperglass/ui/components/history/history-entry-row.tsx
+++ b/hyperglass/ui/components/history/history-entry-row.tsx
@@ -31,6 +31,7 @@ export const HistoryEntryRow = (props: HistoryEntryRowProps): JSX.Element => {
 
   const open = useQueryHistory(s => s.open);
   const remove = useQueryHistory(s => s.remove);
+  const setShareId = useQueryHistory(s => s.setShareId);
   const prefillForm = useFormState(s => s.prefillForm);
   const setStatus = useFormState(s => s.setStatus);
   const setSubmissionId = useFormState(s => s.setSubmissionId);
@@ -81,7 +82,12 @@ export const HistoryEntryRow = (props: HistoryEntryRowProps): JSX.Element => {
             </Button>
           </Tooltip>
         )}
-        {isSingleDevice && <ShareButton cacheId={entry.results[deviceIds[0]].id} />}
+        {isSingleDevice && (
+          <ShareButton
+            cacheId={entry.results[deviceIds[0]].id}
+            onShared={shareId => setShareId(entry.id, shareId)}
+          />
+        )}
         <Tooltip hasArrow label={web.text.historyRerun} placement="top">
           <Button {...iconBtn} aria-label={web.text.historyRerun} onClick={handleRerun}>
             <DynamicIcon icon={{ fi: 'FiRepeat' }} boxSize="16px" />

--- a/hyperglass/ui/components/looking-glass-form.test.tsx
+++ b/hyperglass/ui/components/looking-glass-form.test.tsx
@@ -1,7 +1,7 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // jsdom does not implement window.matchMedia; Chakra UI requires it.
@@ -23,15 +23,18 @@ import type { Config } from '~/types';
 import { LookingGlassForm } from './looking-glass-form';
 
 // ---------------------------------------------------------------------------
-// next/router mock — query params that should pre-fill the form
+// next/router mock — mutable so each test can control which query params are
+// present without conflicting vi.mock hoisting across describe blocks.
 // ---------------------------------------------------------------------------
+let mockRouterQuery: Record<string, string> = {
+  location: 'test1',
+  target: '192.0.2.0/24',
+  type: 'juniper_bgp_route',
+};
+
 vi.mock('next/router', () => ({
   useRouter: () => ({
-    query: {
-      location: 'test1',
-      target: '192.0.2.0/24',
-      type: 'juniper_bgp_route',
-    },
+    query: mockRouterQuery,
     isReady: true,
     push: vi.fn(),
     replace: vi.fn(),
@@ -175,8 +178,14 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-// Reset Zustand form state between tests so pre-fill useEffect fires cleanly
+// Reset Zustand form state and router query between tests so pre-fill useEffect
+// fires cleanly and tests do not bleed state into each other.
 beforeEach(async () => {
+  mockRouterQuery = {
+    location: 'test1',
+    target: '192.0.2.0/24',
+    type: 'juniper_bgp_route',
+  };
   const { useFormState } = await import('~/hooks');
   await useFormState.getState().reset();
 });
@@ -218,5 +227,32 @@ describe('LookingGlassForm — query-string pre-fill', () => {
     expect(checkedCard).toBeInTheDocument();
     // Confirm it is the card for the correct location by checking it contains the device name.
     expect(checkedCard?.textContent).toContain('Test Router 1');
+  });
+
+  it('prefills type + target from URL and mirrors them into react-hook-form', async () => {
+    const { useFormState } = await import('~/hooks');
+    // Default mockRouterQuery already has location, type, and target set.
+    render(<LookingGlassForm />, { wrapper });
+    await waitFor(() =>
+      expect(useFormState.getState().selections.queryType).toEqual({
+        value: 'juniper_bgp_route',
+        label: 'BGP Route',
+      }),
+    );
+    await waitFor(() => expect(useFormState.getState().form.queryTarget).toEqual(['192.0.2.0/24']));
+  });
+
+  it('auto-runs when ?run=1 is present', async () => {
+    const { useFormState } = await import('~/hooks');
+    // Override query to include run=1.
+    mockRouterQuery = {
+      location: 'test1',
+      type: 'juniper_bgp_route',
+      target: '192.0.2.0/24',
+      run: '1',
+    };
+    render(<LookingGlassForm />, { wrapper });
+    await waitFor(() => expect(useFormState.getState().status).toBe('results'));
+    expect(useFormState.getState().submissionId).not.toBeNull();
   });
 });

--- a/hyperglass/ui/components/looking-glass-form.tsx
+++ b/hyperglass/ui/components/looking-glass-form.tsx
@@ -32,9 +32,9 @@ export const LookingGlassForm = (): JSX.Element => {
   const setLoading = useFormState(s => s.setLoading);
   const setStatus = useFormState(s => s.setStatus);
   const locationChange = useFormState(s => s.locationChange);
-  const setSelection = useFormState(s => s.setSelection);
   const setTarget = useFormState(s => s.setTarget);
   const setFormValue = useFormState(s => s.setFormValue);
+  const prefillForm = useFormState(s => s.prefillForm);
   const { form, filtered, selections } = useFormState(
     useShallow(({ form, filtered, selections }) => ({ form, filtered, selections })),
   );
@@ -72,6 +72,15 @@ export const LookingGlassForm = (): JSX.Element => {
   });
 
   const { handleSubmit, register, setValue, setError, clearErrors } = formInstance;
+
+  // Mirror Zustand form values into react-hook-form. Prefill paths write to
+  // Zustand (form/selections) but not RHF; without this, RHF's validation still
+  // sees empty values and a prefilled form cannot be submitted.
+  useEffect(() => {
+    setValue('queryLocation', form.queryLocation);
+    setValue('queryType', form.queryType);
+    setValue('queryTarget', form.queryTarget);
+  }, [form.queryLocation, form.queryType, form.queryTarget, setValue]);
 
   const isFqdnQuery = useCallback(
     (target: string | string[], fieldType: Directive['fieldType'] | null): boolean =>
@@ -138,38 +147,41 @@ export const LookingGlassForm = (): JSX.Element => {
   const handleLocChange = (locations: string[]) =>
     locationChange(locations, { setError, clearErrors, getDevice, text: web.text });
 
-  // Pre-fill form from URL query params (?location=&target=&type=).
-  // Applied once on mount when router.isReady — a ref guard prevents re-applying
-  // if the component re-renders after the user has edited the form.
+  // Pre-fill from URL query params (?location=&target=&type=[&run=1]). Applied
+  // once on mount when router.isReady; the ref guard prevents re-applying after
+  // the user edits the form. Delegates to prefillForm (single source of truth);
+  // the Zustand→RHF mirror above keeps react-hook-form in sync for validation.
   const prefillApplied = useRef(false);
   useEffect(() => {
     if (!router.isReady || prefillApplied.current) return;
+    const { location, target, type, run } = router.query;
+    if (typeof location !== 'string') {
+      prefillApplied.current = true;
+      return;
+    }
     prefillApplied.current = true;
 
-    const { location, target, type } = router.query;
+    const valid = prefillForm(
+      {
+        queryLocation: [location],
+        queryType: typeof type === 'string' ? type : '',
+        queryTarget: typeof target === 'string' ? [target] : [],
+      },
+      getDevice,
+    );
 
-    if (typeof location === 'string') {
-      setValue('queryLocation', [location]);
-      // Drive Zustand state through locationChange so filtered.types is populated.
-      locationChange([location], { setError, clearErrors, getDevice, text: web.text });
-      // Also populate selections.queryLocation so the dropdown <Select value=...> and
-      // the gallery <LocationCard defaultChecked=...> both reflect the pre-filled value.
-      // Guard for unknown location IDs: skip selection rather than inserting a null/bad option.
-      const device = getDevice(location);
-      if (device !== null) {
-        setSelection('queryLocation', [{ value: device.id, label: device.name }]);
-      }
+    const canRun =
+      run === '1' &&
+      valid.length > 0 &&
+      typeof type === 'string' &&
+      type.length > 0 &&
+      typeof target === 'string' &&
+      target.length > 0;
+    if (canRun) {
+      setSubmissionId(makeSubmissionId());
+      setStatus('results');
     }
-    if (typeof type === 'string') {
-      setValue('queryType', type);
-      setFormValue('queryType', type);
-    }
-    if (typeof target === 'string') {
-      setValue('queryTarget', [target]);
-      setFormValue('queryTarget', [target]);
-      setTarget({ display: target });
-    }
-  }, [router.isReady, router.query]);
+  }, [router.isReady, router.query]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleChange(e: OnChangeArgs): void {
     // Signal the field & value to react-hook-form.

--- a/hyperglass/ui/components/looking-glass-form.tsx
+++ b/hyperglass/ui/components/looking-glass-form.tsx
@@ -73,9 +73,13 @@ export const LookingGlassForm = (): JSX.Element => {
 
   const { handleSubmit, register, setValue, setError, clearErrors } = formInstance;
 
-  // Mirror Zustand form values into react-hook-form. Prefill paths write to
-  // Zustand (form/selections) but not RHF; without this, RHF's validation still
-  // sees empty values and a prefilled form cannot be submitted.
+  // Mirror Zustand form values into react-hook-form. Prefill paths (URL params,
+  // store prefillForm) write to Zustand (form/selections) but not RHF; without
+  // this, RHF validation still sees empty values and a prefilled form cannot be
+  // submitted. NOTE: handleChange already calls setValue on user input, so this
+  // effect is load-bearing specifically for the prefill paths — do not remove it.
+  // Keep these setValue calls option-less (no shouldValidate) to avoid running
+  // the vest resolver on every Zustand mutation.
   useEffect(() => {
     setValue('queryLocation', form.queryLocation);
     setValue('queryType', form.queryType);
@@ -177,6 +181,8 @@ export const LookingGlassForm = (): JSX.Element => {
       type.length > 0 &&
       typeof target === 'string' &&
       target.length > 0;
+    // Auto-run skips submitHandler's FQDN-resolution modal: deep links carry a
+    // concrete target from a prior query, so go straight to the results view.
     if (canRun) {
       setSubmissionId(makeSubmissionId());
       setStatus('results');

--- a/hyperglass/ui/components/reset-button.tsx
+++ b/hyperglass/ui/components/reset-button.tsx
@@ -1,50 +1,22 @@
-import { Flex, IconButton } from '@chakra-ui/react';
-import { AnimatePresence } from 'framer-motion';
-import { AnimatedDiv, DynamicIcon } from '~/elements';
-import { useColorValue, useOpposingColor, useFormState } from '~/hooks';
+import { useConfig } from '~/context';
+import { FloatingBackButton } from '~/elements';
+import { useFormState } from '~/hooks';
 
-import type { FlexProps } from '@chakra-ui/react';
-
-interface ResetButtonProps extends FlexProps {
+interface ResetButtonProps {
   developerMode: boolean;
   resetForm(): void;
 }
 
 export const ResetButton = (props: ResetButtonProps): JSX.Element => {
-  const { developerMode, resetForm, ...rest } = props;
+  const { developerMode, resetForm } = props;
   const status = useFormState(s => s.status);
-  const bg = useColorValue('primary.500', 'primary.300');
-  const color = useOpposingColor(bg);
+  const { web } = useConfig();
   return (
-    <AnimatePresence>
-      {status === 'results' && (
-        <AnimatedDiv
-          bg={bg}
-          left={0}
-          zIndex={4}
-          bottom={24}
-          boxSize={12}
-          color={color}
-          position="fixed"
-          animate={{ x: 0 }}
-          exit={{ x: '-100%' }}
-          borderRightRadius="md"
-          initial={{ x: '-100%' }}
-          mb={developerMode ? { base: 0, lg: 14 } : undefined}
-          transition={{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }}
-        >
-          <Flex boxSize="100%" justifyContent="center" alignItems="center" {...rest}>
-            <IconButton
-              lineHeight={0}
-              color="current"
-              variant="unstyled"
-              aria-label="Reset"
-              onClick={resetForm}
-              icon={<DynamicIcon icon={{ fa: 'FaAngleLeft' }} boxSize={8} />}
-            />
-          </Flex>
-        </AnimatedDiv>
-      )}
-    </AnimatePresence>
+    <FloatingBackButton
+      isVisible={status === 'results'}
+      onClick={resetForm}
+      label={web.text.historyBack}
+      raised={developerMode}
+    />
   );
 };

--- a/hyperglass/ui/components/results/individual.tsx
+++ b/hyperglass/ui/components/results/individual.tsx
@@ -51,6 +51,8 @@ interface ResultProps {
   readOnly?: boolean;
   /** Controls ShareButton visibility; defaults to !readOnly. */
   showShare?: boolean;
+  /** Called with the minted share id after a successful share; only passed for single-device history entries. */
+  onShared?: (shareId: string) => void;
 }
 
 const AnimatedAccordionItem = motion(AccordionItem);
@@ -68,7 +70,14 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
   props: ResultProps,
   ref,
 ) => {
-  const { index, queryLocation, snapshot, readOnly = false, showShare = !readOnly } = props;
+  const {
+    index,
+    queryLocation,
+    snapshot,
+    readOnly = false,
+    showShare = !readOnly,
+    onShared,
+  } = props;
   const toast = useToast();
   const { web, cache, messages } = useConfig();
   const { index: indices, setIndex } = useAccordionContext();
@@ -321,7 +330,7 @@ const _Result: React.ForwardRefRenderFunction<HTMLDivElement, ResultProps> = (
           {!snapshot && isStructuredOutput(data) && data.level === 'success' && tableComponent && (
             <Path device={deviceId} />
           )}
-          {showShare && data?.id && <ShareButton cacheId={data.id} />}
+          {showShare && data?.id && <ShareButton cacheId={data.id} onShared={onShared} />}
           {!snapshot && <HistoryDisabledHint directiveHistory={getDirective()?.history ?? true} />}
           <CopyButton copyValue={copyValue} isDisabled={!snapshot && isLoading} />
           {!readOnly && (

--- a/hyperglass/ui/components/results/share-button.test.tsx
+++ b/hyperglass/ui/components/results/share-button.test.tsx
@@ -138,6 +138,25 @@ describe('ShareButton', () => {
     );
   });
 
+  it('calls onShared with the minted id on success', async () => {
+    const onShared = vi.fn();
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({
+        json: async () => ({
+          id: 'ABCDEFGHIJK',
+          url: 'http://x/result/ABCDEFGHIJK',
+          expiresAt: '2026-05-08T00:00:00Z',
+        }),
+      }),
+    );
+
+    render(<ShareButton cacheId="cache1" onShared={onShared} />, { wrapper });
+    fireEvent.click(screen.getByRole('button', { name: /Share/i }));
+
+    await waitFor(() => expect(onShared).toHaveBeenCalledWith('ABCDEFGHIJK'));
+  });
+
   it('does not POST again when popover is closed and reopened', async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
       mockResponse({

--- a/hyperglass/ui/components/results/share-button.tsx
+++ b/hyperglass/ui/components/results/share-button.tsx
@@ -21,10 +21,11 @@ import { ShareError } from '~/hooks/use-share';
 
 export interface ShareButtonProps {
   cacheId: string;
+  onShared?: (shareId: string) => void;
 }
 
 export const ShareButton = (props: ShareButtonProps): JSX.Element | null => {
-  const { cacheId } = props;
+  const { cacheId, onShared } = props;
 
   const { cache, web } = useConfig();
   const strF = useStrf();
@@ -44,6 +45,10 @@ export const ShareButton = (props: ShareButtonProps): JSX.Element | null => {
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (isSuccess && data?.id) onShared?.(data.id);
+  }, [isSuccess, data?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!cacheId || !cache.shareEnabled) {
     return null;

--- a/hyperglass/ui/components/results/snapshot-actions.test.tsx
+++ b/hyperglass/ui/components/results/snapshot-actions.test.tsx
@@ -1,0 +1,39 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+const push = vi.fn();
+vi.mock('next/router', () => ({ useRouter: () => ({ push }) }));
+vi.mock('~/context', () => ({
+  useConfig: () => ({
+    web: { text: { historyRerun: 'Run again', historyNewTarget: 'Run with a new target' } },
+  }),
+}));
+
+import { SnapshotActions } from './snapshot-actions';
+
+const q = { queryLocation: 'test1', queryType: 'juniper_bgp_route', queryTarget: '192.0.2.0/24' };
+
+const renderActions = () =>
+  render(
+    <ChakraProvider>
+      <SnapshotActions query={q} />
+    </ChakraProvider>,
+  );
+
+describe('SnapshotActions', () => {
+  it('Re-run navigates home with prefill + run flag', () => {
+    renderActions();
+    fireEvent.click(screen.getByLabelText('Run again'));
+    expect(push).toHaveBeenCalledWith(
+      '/?location=test1&type=juniper_bgp_route&target=192.0.2.0%2F24&run=1',
+    );
+  });
+
+  it('New target navigates home with prefill, no run flag and no target', () => {
+    renderActions();
+    fireEvent.click(screen.getByLabelText('Run with a new target'));
+    expect(push).toHaveBeenCalledWith('/?location=test1&type=juniper_bgp_route');
+  });
+});

--- a/hyperglass/ui/components/results/snapshot-actions.tsx
+++ b/hyperglass/ui/components/results/snapshot-actions.tsx
@@ -1,0 +1,55 @@
+import { Button, HStack, Tooltip } from '@chakra-ui/react';
+import { useConfig } from '~/context';
+import { DynamicIcon } from '~/elements';
+import { usePrefillNavigate } from '~/hooks';
+
+export interface SnapshotActionsProps {
+  query: { queryLocation: string; queryType: string; queryTarget: string };
+}
+
+const iconBtn = {
+  mx: 1,
+  size: 'sm' as const,
+  variant: 'ghost' as const,
+  colorScheme: 'secondary' as const,
+};
+
+export const SnapshotActions = (props: SnapshotActionsProps): JSX.Element => {
+  const { query } = props;
+  const { web } = useConfig();
+  const navigate = usePrefillNavigate();
+
+  return (
+    <HStack spacing={0} flex="0 0 auto">
+      <Tooltip hasArrow label={web.text.historyRerun} placement="top">
+        <Button
+          {...iconBtn}
+          aria-label={web.text.historyRerun}
+          onClick={() =>
+            navigate(
+              {
+                queryLocation: query.queryLocation,
+                queryType: query.queryType,
+                queryTarget: query.queryTarget,
+              },
+              { run: true },
+            )
+          }
+        >
+          <DynamicIcon icon={{ fi: 'FiRepeat' }} boxSize="16px" />
+        </Button>
+      </Tooltip>
+      <Tooltip hasArrow label={web.text.historyNewTarget} placement="top">
+        <Button
+          {...iconBtn}
+          aria-label={web.text.historyNewTarget}
+          onClick={() =>
+            navigate({ queryLocation: query.queryLocation, queryType: query.queryType })
+          }
+        >
+          <DynamicIcon icon={{ fi: 'FiEdit' }} boxSize="16px" />
+        </Button>
+      </Tooltip>
+    </HStack>
+  );
+};

--- a/hyperglass/ui/components/results/snapshot-results.test.tsx
+++ b/hyperglass/ui/components/results/snapshot-results.test.tsx
@@ -1,7 +1,7 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { expect, it, vi } from 'vitest';
 
 // jsdom does not implement window.matchMedia; Chakra UI requires it.
@@ -20,7 +20,9 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 vi.mock('./share-button', () => ({
-  ShareButton: () => <div data-testid="share-button" />,
+  ShareButton: ({ onShared }: { cacheId: string; onShared?: (shareId: string) => void }) => (
+    <button type="button" data-testid="share-button" onClick={() => onShared?.('test-share-id')} />
+  ),
 }));
 
 vi.mock('~/context', () => ({
@@ -99,4 +101,22 @@ it('renders one result per item', () => {
   );
   expect(screen.getByText('Core 1')).toBeInTheDocument();
   expect(screen.getByText('Edge 2')).toBeInTheDocument();
+});
+
+it('forwards onShared to ShareButton and fires callback on share', () => {
+  const handleShared = vi.fn();
+  render(
+    <Providers>
+      <SnapshotResults
+        items={[{ queryLocation: 'core1', snapshot: snap('Core 1', 'A') }]}
+        showShare
+        onShared={handleShared}
+      />
+    </Providers>,
+  );
+  const shareBtn = screen.getByTestId('share-button');
+  expect(shareBtn).toBeInTheDocument();
+  fireEvent.click(shareBtn);
+  expect(handleShared).toHaveBeenCalledOnce();
+  expect(handleShared).toHaveBeenCalledWith('test-share-id');
 });

--- a/hyperglass/ui/components/results/snapshot-results.tsx
+++ b/hyperglass/ui/components/results/snapshot-results.tsx
@@ -11,10 +11,12 @@ interface SnapshotResultsProps {
   items: SnapshotResultsItem[];
   /** Show each result's ShareButton (history-open); default false (share page). */
   showShare?: boolean;
+  /** Called with the minted share id after a successful share; only meaningful for single-device entries. */
+  onShared?: (shareId: string) => void;
 }
 
 export const SnapshotResults = (props: SnapshotResultsProps): JSX.Element => {
-  const { items, showShare = false } = props;
+  const { items, showShare = false, onShared } = props;
   return (
     <AnimatedDiv
       p={0}
@@ -39,6 +41,7 @@ export const SnapshotResults = (props: SnapshotResultsProps): JSX.Element => {
             snapshot={item.snapshot}
             readOnly
             showShare={showShare}
+            onShared={onShared}
           />
         ))}
       </Accordion>

--- a/hyperglass/ui/elements/floating-back-button.test.tsx
+++ b/hyperglass/ui/elements/floating-back-button.test.tsx
@@ -1,0 +1,26 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FloatingBackButton } from './floating-back-button';
+
+const renderEl = (props: Partial<React.ComponentProps<typeof FloatingBackButton>>) =>
+  render(
+    <ChakraProvider>
+      <FloatingBackButton isVisible onClick={() => {}} label="Back" {...props} />
+    </ChakraProvider>,
+  );
+
+describe('FloatingBackButton', () => {
+  it('renders when visible and fires onClick', () => {
+    const onClick = vi.fn();
+    renderEl({ onClick });
+    fireEvent.click(screen.getByLabelText('Back'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the button when not visible', () => {
+    renderEl({ isVisible: false });
+    expect(screen.queryByLabelText('Back')).not.toBeInTheDocument();
+  });
+});

--- a/hyperglass/ui/elements/floating-back-button.tsx
+++ b/hyperglass/ui/elements/floating-back-button.tsx
@@ -1,0 +1,53 @@
+import { Flex, IconButton } from '@chakra-ui/react';
+import { AnimatePresence } from 'framer-motion';
+import { AnimatedDiv } from '~/elements/animated';
+import { DynamicIcon } from '~/elements/dynamic-icon';
+import { useColorValue, useOpposingColor } from '~/hooks';
+
+import type { FlexProps } from '@chakra-ui/react';
+
+interface FloatingBackButtonProps extends FlexProps {
+  isVisible: boolean;
+  onClick(): void;
+  label: string;
+  /** Extra bottom offset (e.g. developer-mode bar). */
+  raised?: boolean;
+}
+
+export const FloatingBackButton = (props: FloatingBackButtonProps): JSX.Element => {
+  const { isVisible, onClick, label, raised = false, ...rest } = props;
+  const bg = useColorValue('primary.500', 'primary.300');
+  const color = useOpposingColor(bg);
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <AnimatedDiv
+          bg={bg}
+          left={0}
+          zIndex={4}
+          bottom={24}
+          boxSize={12}
+          color={color}
+          position="fixed"
+          animate={{ x: 0 }}
+          exit={{ x: '-100%' }}
+          borderRightRadius="md"
+          initial={{ x: '-100%' }}
+          mb={raised ? { base: 0, lg: 14 } : undefined}
+          transition={{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }}
+        >
+          <Flex boxSize="100%" justifyContent="center" alignItems="center" {...rest}>
+            <IconButton
+              lineHeight={0}
+              color="current"
+              variant="unstyled"
+              aria-label={label}
+              onClick={onClick}
+              icon={<DynamicIcon icon={{ fa: 'FaAngleLeft' }} boxSize={8} />}
+            />
+          </Flex>
+        </AnimatedDiv>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/hyperglass/ui/elements/index.ts
+++ b/hyperglass/ui/elements/index.ts
@@ -13,6 +13,7 @@ export * from './countdown';
 export * from './custom';
 export * from './dynamic-icon';
 export * from './favicon';
+export * from './floating-back-button';
 export * from './form-row';
 export * from './label';
 export * from './load-error';

--- a/hyperglass/ui/hooks/index.ts
+++ b/hyperglass/ui/hooks/index.ts
@@ -15,3 +15,4 @@ export * from './use-table-to-string';
 export * from './use-wtf';
 export * from './use-query-history';
 export * from './use-record-history';
+export * from './use-prefill-navigate';

--- a/hyperglass/ui/hooks/use-form-state.test.tsx
+++ b/hyperglass/ui/hooks/use-form-state.test.tsx
@@ -123,3 +123,38 @@ describe('useFormState.prefillForm', () => {
     expect(useFormState.getState().form.queryLocation).toEqual(['core1']);
   });
 });
+
+describe('useFormState.prefillForm selections.queryType', () => {
+  beforeEach(async () => {
+    await useFormState.getState().reset();
+  });
+
+  const makeGetDevice = () => {
+    const testDevice = {
+      id: 'test1',
+      name: 'Test Router 1',
+      directives: [{ id: 'juniper_bgp_route', name: 'BGP Route', groups: [] }],
+    } as never;
+    return (id: string) => (id === 'test1' ? testDevice : null);
+  };
+
+  it('prefillForm sets selections.queryType from the matching directive', () => {
+    const getDevice = makeGetDevice();
+    useFormState.getState().prefillForm(
+      { queryLocation: ['test1'], queryType: 'juniper_bgp_route', queryTarget: ['192.0.2.0/24'] },
+      getDevice as never,
+    );
+    const { selections, form } = useFormState.getState();
+    expect(form.queryType).toBe('juniper_bgp_route');
+    expect(selections.queryType).toEqual({ value: 'juniper_bgp_route', label: 'BGP Route' });
+  });
+
+  it('prefillForm leaves selections.queryType null for an empty type (new target)', () => {
+    const getDevice = makeGetDevice();
+    useFormState.getState().prefillForm(
+      { queryLocation: ['test1'], queryType: '', queryTarget: [] },
+      getDevice as never,
+    );
+    expect(useFormState.getState().selections.queryType).toBeNull();
+  });
+});

--- a/hyperglass/ui/hooks/use-form-state.test.tsx
+++ b/hyperglass/ui/hooks/use-form-state.test.tsx
@@ -133,20 +133,24 @@ describe('useFormState.prefillForm selections.queryType', () => {
   const getDevice = (id: string) => (id === 'test1' ? testDevice : null);
 
   it('sets the query-type selection from the matching directive', () => {
-    useFormState.getState().prefillForm(
-      { queryLocation: ['test1'], queryType: 'juniper_bgp_route', queryTarget: ['192.0.2.0/24'] },
-      getDevice as never,
-    );
+    useFormState
+      .getState()
+      .prefillForm(
+        { queryLocation: ['test1'], queryType: 'juniper_bgp_route', queryTarget: ['192.0.2.0/24'] },
+        getDevice as never,
+      );
     const { selections, form } = useFormState.getState();
     expect(form.queryType).toBe('juniper_bgp_route');
     expect(selections.queryType).toEqual({ value: 'juniper_bgp_route', label: 'BGP Route' });
   });
 
   it('leaves the query-type selection null for an empty type', () => {
-    useFormState.getState().prefillForm(
-      { queryLocation: ['test1'], queryType: '', queryTarget: [] },
-      getDevice as never,
-    );
+    useFormState
+      .getState()
+      .prefillForm(
+        { queryLocation: ['test1'], queryType: '', queryTarget: [] },
+        getDevice as never,
+      );
     expect(useFormState.getState().selections.queryType).toBeNull();
   });
 });

--- a/hyperglass/ui/hooks/use-form-state.test.tsx
+++ b/hyperglass/ui/hooks/use-form-state.test.tsx
@@ -125,21 +125,14 @@ describe('useFormState.prefillForm', () => {
 });
 
 describe('useFormState.prefillForm selections.queryType', () => {
-  beforeEach(async () => {
-    await useFormState.getState().reset();
-  });
+  const testDevice = {
+    id: 'test1',
+    name: 'Test Router 1',
+    directives: [{ id: 'juniper_bgp_route', name: 'BGP Route', groups: [] }],
+  } as never;
+  const getDevice = (id: string) => (id === 'test1' ? testDevice : null);
 
-  const makeGetDevice = () => {
-    const testDevice = {
-      id: 'test1',
-      name: 'Test Router 1',
-      directives: [{ id: 'juniper_bgp_route', name: 'BGP Route', groups: [] }],
-    } as never;
-    return (id: string) => (id === 'test1' ? testDevice : null);
-  };
-
-  it('prefillForm sets selections.queryType from the matching directive', () => {
-    const getDevice = makeGetDevice();
+  it('sets the query-type selection from the matching directive', () => {
     useFormState.getState().prefillForm(
       { queryLocation: ['test1'], queryType: 'juniper_bgp_route', queryTarget: ['192.0.2.0/24'] },
       getDevice as never,
@@ -149,8 +142,7 @@ describe('useFormState.prefillForm selections.queryType', () => {
     expect(selections.queryType).toEqual({ value: 'juniper_bgp_route', label: 'BGP Route' });
   });
 
-  it('prefillForm leaves selections.queryType null for an empty type (new target)', () => {
-    const getDevice = makeGetDevice();
+  it('leaves the query-type selection null for an empty type', () => {
     useFormState.getState().prefillForm(
       { queryLocation: ['test1'], queryType: '', queryTarget: [] },
       getDevice as never,

--- a/hyperglass/ui/hooks/use-form-state.ts
+++ b/hyperglass/ui/hooks/use-form-state.ts
@@ -223,7 +223,7 @@ const formState: StateCreator<FormStateType> = (set, get) => ({
 
     const matchingType = directives.find(d => d.id === query.queryType) ?? null;
     const queryTypeSelection = matchingType
-      ? { value: matchingType.id, label: matchingType.name ?? matchingType.id }
+      ? { value: matchingType.id, label: matchingType.name }
       : null;
 
     set({

--- a/hyperglass/ui/hooks/use-form-state.ts
+++ b/hyperglass/ui/hooks/use-form-state.ts
@@ -221,6 +221,11 @@ const formState: StateCreator<FormStateType> = (set, get) => ({
       : [];
     const directives = dedupObjectArray(intersectingDirectives, 'id');
 
+    const matchingType = directives.find(d => d.id === query.queryType) ?? null;
+    const queryTypeSelection = matchingType
+      ? { value: matchingType.id, label: matchingType.name ?? matchingType.id }
+      : null;
+
     set({
       form: {
         queryLocation: validLocations,
@@ -229,7 +234,7 @@ const formState: StateCreator<FormStateType> = (set, get) => ({
       },
       selections: {
         queryLocation: validDevices.map(d => ({ value: d.id, label: d.name })),
-        queryType: null,
+        queryType: queryTypeSelection,
       },
       filtered: { groups: intersecting, types: directives },
       target: { display: query.queryTarget.join(' ') },

--- a/hyperglass/ui/hooks/use-prefill-navigate.ts
+++ b/hyperglass/ui/hooks/use-prefill-navigate.ts
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+
+export interface PrefillQuery {
+  queryLocation: string;
+  queryType: string;
+  /** Single target value; omitted/empty means "new target". */
+  queryTarget?: string;
+}
+
+/**
+ * Navigate to the looking-glass home with the form pre-filled from a snapshot's
+ * query. When `run` is true, append `run=1` so the form auto-submits a fresh
+ * live query on arrival (consumed by LookingGlassForm's URL prefill effect).
+ */
+export function usePrefillNavigate(): (q: PrefillQuery, opts?: { run?: boolean }) => void {
+  const router = useRouter();
+  return useCallback(
+    (q: PrefillQuery, opts?: { run?: boolean }) => {
+      const params = new URLSearchParams();
+      params.set('location', q.queryLocation);
+      params.set('type', q.queryType);
+      if (q.queryTarget) params.set('target', q.queryTarget);
+      if (opts?.run && q.queryTarget) params.set('run', '1');
+      router.push(`/?${params.toString()}`);
+    },
+    [router],
+  );
+}

--- a/hyperglass/ui/hooks/use-query-history.test.ts
+++ b/hyperglass/ui/hooks/use-query-history.test.ts
@@ -69,6 +69,15 @@ describe('useQueryHistory.record', () => {
   });
 });
 
+describe('useQueryHistory setShareId', () => {
+  it('setShareId stores a share id on the matching entry', () => {
+    useQueryHistory.getState().record(input());
+    const id = useQueryHistory.getState().entries[0].id;
+    useQueryHistory.getState().setShareId(id, 'ABCDEFGHIJK');
+    expect(useQueryHistory.getState().entries[0].shareId).toBe('ABCDEFGHIJK');
+  });
+});
+
 describe('useQueryHistory remove/clear/open/close', () => {
   it('remove deletes by id', () => {
     useQueryHistory.getState().record(input({ submissionId: 's1' }));

--- a/hyperglass/ui/hooks/use-query-history.ts
+++ b/hyperglass/ui/hooks/use-query-history.ts
@@ -6,6 +6,7 @@ import { historyStorage } from '~/util/history-storage';
 export interface HistoryEntry {
   id: string;
   savedAt: number;
+  shareId?: string;
   query: { queryLocation: string[]; queryType: string; queryTarget: string[] };
   labels: { locations: string[]; type: string; target: string };
   results: Record<string, ResultSnapshot>;
@@ -29,6 +30,7 @@ interface QueryHistoryState {
   clear(): void;
   open(id: string): void;
   close(): void;
+  setShareId(id: string, shareId: string): void;
 }
 
 const uniq = (values: string[]): string[] => Array.from(new Set(values));
@@ -87,6 +89,12 @@ export const useQueryHistory = create<QueryHistoryState>()(
 
         close(): void {
           set({ openId: null });
+        },
+
+        setShareId(id: string, shareId: string): void {
+          set(state => ({
+            entries: state.entries.map(e => (e.id === id ? { ...e, shareId } : e)),
+          }));
         },
       }),
       'useQueryHistory',

--- a/hyperglass/ui/pages/index.test.tsx
+++ b/hyperglass/ui/pages/index.test.tsx
@@ -1,0 +1,53 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const push = vi.fn();
+vi.mock('next/router', () => ({ useRouter: () => ({ push }) }));
+
+// Stub heavy/dynamic children so the test isolates URL behavior.
+vi.mock('~/components/results/snapshot-results', () => ({ SnapshotResults: () => null }));
+vi.mock('~/elements', () => ({ FloatingBackButton: () => null, Loading: () => null }));
+vi.mock('next/dynamic', () => ({ default: () => () => null }));
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock state, type is intentionally loose
+let mockState: any;
+vi.mock('~/hooks', () => ({
+  useView: () => 'form',
+  // biome-ignore lint/suspicious/noExplicitAny: test mock selector, mirrors Zustand selector signature
+  useQueryHistory: (sel: any) => sel(mockState),
+}));
+vi.mock('~/context', () => ({ useConfig: () => ({ web: { text: { historyBack: 'Back' } } }) }));
+
+import Index from './index';
+
+const entry = {
+  id: 'e1',
+  savedAt: 0,
+  query: { queryLocation: ['test1'], queryType: 'juniper_bgp_route', queryTarget: ['192.0.2.0/24'] },
+  labels: { locations: ['Test1'], type: 'BGP Route', target: '192.0.2.0/24' },
+  results: { test1: { id: 'c1' } },
+};
+
+beforeEach(() => {
+  push.mockClear();
+  mockState = { openId: 'e1', close: vi.fn(), entries: [entry] };
+});
+
+describe('Index opened-entry URL sync', () => {
+  it('opening an un-shared entry shallow-pushes the deep-link', async () => {
+    render(<Index />);
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith(
+        '/?location=test1&type=juniper_bgp_route&target=192.0.2.0%2F24',
+        undefined,
+        { shallow: true },
+      ),
+    );
+  });
+
+  it('opening a shared entry navigates to /result/<shareId>', async () => {
+    mockState = { openId: 'e1', close: vi.fn(), entries: [{ ...entry, shareId: 'ABCDEFGHIJK' }] };
+    render(<Index />);
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/result/ABCDEFGHIJK'));
+  });
+});

--- a/hyperglass/ui/pages/index.tsx
+++ b/hyperglass/ui/pages/index.tsx
@@ -1,6 +1,8 @@
 import { Box } from '@chakra-ui/react';
 import { AnimatePresence } from 'framer-motion';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { Else, If, Then } from 'react-if';
 import { SnapshotResults } from '~/components/results/snapshot-results';
 import { useConfig } from '~/context';
@@ -32,8 +34,28 @@ const Index: NextPage = () => {
   const openId = useQueryHistory(s => s.openId);
   const close = useQueryHistory(s => s.close);
   const entries = useQueryHistory(s => s.entries);
+  const router = useRouter();
 
   const openEntry = openId ? entries.find(e => e.id === openId) : undefined;
+
+  useEffect(() => {
+    if (!openEntry) return;
+    if (openEntry.shareId) {
+      router.push(`/result/${openEntry.shareId}`);
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set('location', openEntry.query.queryLocation[0]);
+    params.set('type', openEntry.query.queryType);
+    if (openEntry.query.queryTarget[0]) params.set('target', openEntry.query.queryTarget[0]);
+    router.push(`/?${params.toString()}`, undefined, { shallow: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openEntry?.id]);
+
+  const handleClose = () => {
+    close();
+    router.push('/', undefined, { shallow: true });
+  };
 
   if (openEntry) {
     const items: SnapshotResultsItem[] = Object.entries(openEntry.results).map(
@@ -41,7 +63,7 @@ const Index: NextPage = () => {
     );
     return (
       <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
-        <FloatingBackButton isVisible onClick={close} label={web.text.historyBack} />
+        <FloatingBackButton isVisible onClick={handleClose} label={web.text.historyBack} />
         <SnapshotResults items={items} showShare />
       </Box>
     );

--- a/hyperglass/ui/pages/index.tsx
+++ b/hyperglass/ui/pages/index.tsx
@@ -34,6 +34,7 @@ const Index: NextPage = () => {
   const openId = useQueryHistory(s => s.openId);
   const close = useQueryHistory(s => s.close);
   const entries = useQueryHistory(s => s.entries);
+  const setShareId = useQueryHistory(s => s.setShareId);
   const router = useRouter();
 
   const openEntry = openId ? entries.find(e => e.id === openId) : undefined;
@@ -61,10 +62,15 @@ const Index: NextPage = () => {
     const items: SnapshotResultsItem[] = Object.entries(openEntry.results).map(
       ([queryLocation, snapshot]) => ({ queryLocation, snapshot }),
     );
+    const isSingleDevice = Object.keys(openEntry.results).length === 1;
     return (
       <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
         <FloatingBackButton isVisible onClick={handleClose} label={web.text.historyBack} />
-        <SnapshotResults items={items} showShare />
+        <SnapshotResults
+          items={items}
+          showShare
+          onShared={isSingleDevice ? shareId => setShareId(openEntry.id, shareId) : undefined}
+        />
       </Box>
     );
   }

--- a/hyperglass/ui/pages/index.tsx
+++ b/hyperglass/ui/pages/index.tsx
@@ -1,10 +1,10 @@
-import { Box, Button, Flex } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { AnimatePresence } from 'framer-motion';
 import dynamic from 'next/dynamic';
 import { Else, If, Then } from 'react-if';
 import { SnapshotResults } from '~/components/results/snapshot-results';
 import { useConfig } from '~/context';
-import { Loading } from '~/elements';
+import { FloatingBackButton, Loading } from '~/elements';
 import { useQueryHistory, useView } from '~/hooks';
 
 import type { NextPage } from 'next';
@@ -41,11 +41,7 @@ const Index: NextPage = () => {
     );
     return (
       <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
-        <Flex justify="flex-start" mb={2}>
-          <Button size="sm" variant="ghost" onClick={close}>
-            {web.text.historyBack}
-          </Button>
-        </Flex>
+        <FloatingBackButton isVisible onClick={close} label={web.text.historyBack} />
         <SnapshotResults items={items} showShare />
       </Box>
     );

--- a/hyperglass/ui/pages/result/[id].tsx
+++ b/hyperglass/ui/pages/result/[id].tsx
@@ -1,8 +1,10 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
-import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { SnapshotActions } from '~/components/results/snapshot-actions';
 import { SnapshotResults } from '~/components/results/snapshot-results';
 import { useConfig } from '~/context';
+import { FloatingBackButton } from '~/elements';
 import { useShareGet, useStrf } from '~/hooks';
 
 import type { NextPage } from 'next';
@@ -10,6 +12,7 @@ import type { NextPage } from 'next';
 const ResultPage: NextPage = () => {
   const { web } = useConfig();
   const strF = useStrf();
+  const router = useRouter();
 
   // This page ships as a single static placeholder export (result/shared.html)
   // that the backend serves for every /result/<id> URL. Because it's a
@@ -52,19 +55,17 @@ const ResultPage: NextPage = () => {
   const expiresDisplay = new Date(snapshot.expiresAt).toLocaleString();
   const expires = strF(web.text.shareExpiresAt, { expires: expiresDisplay });
 
-  const queryTarget =
-    typeof snapshot.query.query_target === 'string'
-      ? snapshot.query.query_target
-      : snapshot.query.query_target[0];
-
-  const freshUrl = `/?location=${encodeURIComponent(
-    snapshot.query.query_location,
-  )}&target=${encodeURIComponent(queryTarget)}&type=${encodeURIComponent(
-    snapshot.query.query_type,
-  )}`;
+  const rawTarget = snapshot.query.query_target;
+  const queryTarget = typeof rawTarget === 'string' ? rawTarget : rawTarget[0];
+  const actionsQuery = {
+    queryLocation: snapshot.query.query_location,
+    queryType: snapshot.query.query_type,
+    queryTarget,
+  };
 
   return (
     <Box w="100%" maxW={{ base: '100%', md: '75%' }} mx="auto">
+      <FloatingBackButton isVisible onClick={() => router.push('/')} label={web.text.historyBack} />
       <Flex
         mb={3}
         gap={2}
@@ -81,7 +82,7 @@ const ResultPage: NextPage = () => {
       </Flex>
       <SnapshotResults items={[{ queryLocation: snapshot.query.query_location, snapshot }]} />
       <Flex justifyContent="center" mt={4}>
-        <Link href={freshUrl}>{web.text.shareRunFreshQuery}</Link>
+        <SnapshotActions query={actionsQuery} />
       </Flex>
     </Box>
   );


### PR DESCRIPTION
## Summary

Fixes four reported defects in the result-viewing / sharing / history flow. Root cause for the form bugs: the form had **three** drifting state representations (react-hook-form values, Zustand `form`, Zustand `selections`) and the two prefill paths each synced a different subset. This collapses prefill behind a single `prefillForm` entry point plus a Zustand→RHF mirror.

- **Form prefill (items 1 & 4):** `prefillForm` now also sets `selections.queryType` (was hardcoded `null` → blank Query Type), and a mirror effect syncs Zustand `form` into react-hook-form so a prefilled form — including history "Run with a new target" — is actually submittable. The URL-param path now delegates to `prefillForm` instead of duplicating the wiring.
- **Consistent back control (item 2):** extracted the green bottom-left `FloatingBackButton`; the opened-history "view result" and the shared `/result/<id>` page now use it instead of a plain text button. The shared page keeps its "Snapshot taken at…/Expires…" banner.
- **Shared re-run (item 4):** shared results gain Re-run (auto-runs a fresh live query via `?run=1`) and "new target" actions; the broken "Run a fresh query" link is replaced.
- **URL reflects opened results (item 3):** opening a stored result updates the address bar — `/result/<id>` when the entry has been shared (single-device), otherwise a bookmarkable deep link; closing restores `/`.

Design spec and implementation plan are included under `docs/superpowers/`. UI-only; no backend changes (all user-visible strings reuse existing `web.text` config keys). `CHANGELOG.md` has an `[Unreleased]` entry; no version cut here.

## Test Plan
- [x] Full UI suite green: 143 Vitest tests across 35 files
- [x] Biome lint + format clean (177 files); `tsc --noEmit` clean
- [x] `next build` (static export) succeeds — caught/fixed a build break from a test file under `pages/`
- [x] **Headless-browser e2e gate:** loading `/result/<id>` renders the snapshot + actions + back arrow; clicking Re-run navigates to `/?location=…&type=…&target=…&run=1`, the form auto-populates, and a fresh `POST /api/query` fires with the correct body; the back arrow returns to `/`
- [ ] Manual smoke on a deployed build (history re-run / new-target, opened-result URL, shared re-run)