### PR TITLE
test(ssh): Tier-1 SSH transport integration test + CI job

### DIFF
--- a/.github/workflows/ssh-integration.yml
+++ b/.github/workflows/ssh-integration.yml
@@ -1,0 +1,88 @@
+name: SSH Integration
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - hyperglass/**
+            - .github/**
+    pull_request:
+
+# One run per branch; a re-push (e.g. a Renovate rebase) cancels the superseded run.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    ssh-integration:
+        name: SSH Integration Test
+        runs-on: ubuntu-latest
+
+        # Real OpenSSH server for the netmiko/paramiko transport test. `frr`
+        # maps to Netmiko's linux_ssh, so a plain sshd is a representative target.
+        services:
+            sshd:
+                image: lscr.io/linuxserver/openssh-server:latest
+                env:
+                    PUID: "1000"
+                    PGID: "1000"
+                    PASSWORD_ACCESS: "true"
+                    USER_NAME: hyperglass
+                    USER_PASSWORD: hyperglass
+                    SUDO_ACCESS: "false"
+                ports:
+                    - 2222:2222
+
+        steps:
+            - name: Git Checkout
+              uses: actions/checkout@v3
+
+            - name: Install system packages
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y python3-dev
+
+            - name: Install Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+
+            - name: Setup uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  enable-cache: true
+
+            - name: Start Redis
+              uses: supercharge/redis-github-action@1.7.0
+              with:
+                  redis-version: latest
+
+            - name: Prepare
+              run: |
+                  mkdir -p "$HOME/hyperglass"
+                  echo "HYPERGLASS_APP_PATH=$HOME/hyperglass" >> $GITHUB_ENV
+                  echo "HYPERGLASS_HOST=127.0.0.1" >> $GITHUB_ENV
+                  echo "HYPERGLASS_PORT=8001" >> $GITHUB_ENV
+                  echo "HYPERGLASS_TEST_SSH_HOST=127.0.0.1" >> $GITHUB_ENV
+                  echo "HYPERGLASS_TEST_SSH_PORT=2222" >> $GITHUB_ENV
+                  echo "HYPERGLASS_TEST_SSH_USERNAME=hyperglass" >> $GITHUB_ENV
+                  echo "HYPERGLASS_TEST_SSH_PASSWORD=hyperglass" >> $GITHUB_ENV
+
+            - name: Install
+              run: uv sync --python 3.12
+
+            - name: Wait for SSH to accept connections
+              run: |
+                  for i in $(seq 1 30); do
+                      if ssh-keyscan -p 2222 -T 3 127.0.0.1 2>/dev/null | grep -q .; then
+                          echo "sshd is up after ${i}s"; exit 0
+                      fi
+                      sleep 1
+                  done
+                  echo "sshd did not become reachable in time" >&2
+                  exit 1
+
+            - name: SSH integration tests (PyTest)
+              run: |
+                  . .venv/bin/activate
+                  pytest hyperglass/execution/drivers/tests/test_ssh_integration.py -v

--- a/hyperglass/execution/drivers/tests/test_ssh_integration.py
+++ b/hyperglass/execution/drivers/tests/test_ssh_integration.py
@@ -1,0 +1,120 @@
+"""SSH transport integration test (Tier 1).
+
+Exercises the real `NetmikoConnection` driver — and therefore the live
+netmiko/paramiko transport stack — against an actual OpenSSH server, instead
+of mocking it. This is the layer that dependency bumps (netmiko, paramiko)
+most affect (auth, prompt detection, channel read/write, timeouts), which the
+rest of the suite never touches because it relies on ``fake_output``.
+
+`frr` maps to Netmiko's ``linux_ssh`` device type (see
+``Device.get_device_type``), so a plain OpenSSH server is a representative
+target for the linux-based platforms hyperglass actually supports (FRR / BIRD /
+OpenBGPD), not a synthetic stand-in.
+
+The test is skipped unless an SSH server is advertised via environment
+variables. CI starts an ``openssh-server`` service container and sets them; to
+run locally, point these at any reachable SSH server with a POSIX shell::
+
+    docker run -d --name hg-ssh -e PASSWORD_ACCESS=true \
+        -e USER_NAME=hyperglass -e USER_PASSWORD=hyperglass -e SUDO_ACCESS=false \
+        -p 2222:2222 lscr.io/linuxserver/openssh-server
+    HYPERGLASS_TEST_SSH_HOST=127.0.0.1 HYPERGLASS_TEST_SSH_PORT=2222 \
+        pytest hyperglass/execution/drivers/tests/test_ssh_integration.py
+"""
+
+# Standard Library
+import os
+import typing as t
+
+# Third Party
+import pytest
+
+# Project
+from hyperglass.models.api import Query
+from hyperglass.exceptions.public import AuthError
+from hyperglass.execution.drivers import NetmikoConnection
+
+SSH_HOST = os.getenv("HYPERGLASS_TEST_SSH_HOST")
+SSH_PORT = os.getenv("HYPERGLASS_TEST_SSH_PORT")
+SSH_USER = os.getenv("HYPERGLASS_TEST_SSH_USERNAME", "hyperglass")
+SSH_PASS = os.getenv("HYPERGLASS_TEST_SSH_PASSWORD", "hyperglass")
+
+# Skip the whole module (before any fixture runs) unless a server is advertised.
+pytestmark = pytest.mark.skipif(
+    not (SSH_HOST and SSH_PORT),
+    reason="No SSH server advertised; set HYPERGLASS_TEST_SSH_HOST/_PORT to run.",
+)
+
+# A unique marker echoed back over the channel proves end-to-end command flow.
+MARKER = "HG_SSH_OK"
+
+
+@pytest.fixture
+def directives() -> t.Sequence[t.Dict[str, t.Any]]:
+    """Provide a linux directive whose command is a plain shell echo.
+
+    `echo {target}` runs on any POSIX shell, so the round-trip validates the
+    transport without needing a real routing daemon.
+    """
+    return [
+        {
+            "echo_ssh": {
+                "name": "Echo SSH",
+                "rules": [
+                    {
+                        "condition": "0.0.0.0/0",
+                        "action": "permit",
+                        "command": f"echo {MARKER}_{{target}}",
+                    },
+                    {
+                        "condition": "::/0",
+                        "action": "permit",
+                        "command": f"echo {MARKER}_{{target}}",
+                    },
+                ],
+                "field": {"description": "Target"},
+            }
+        }
+    ]
+
+
+@pytest.fixture
+def devices() -> t.Sequence[t.Dict[str, t.Any]]:
+    """One reachable `frr`/linux_ssh device and one with bad credentials."""
+    base = {
+        "address": SSH_HOST,
+        "port": int(SSH_PORT),
+        "platform": "frr",
+        "attrs": {},
+        "directives": ["echo_ssh"],
+    }
+    return [
+        {**base, "name": "ssh_ok", "credential": {"username": SSH_USER, "password": SSH_PASS}},
+        {
+            **base,
+            "name": "ssh_badauth",
+            "credential": {"username": SSH_USER, "password": "definitely-wrong-password"},
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_netmiko_collects_over_real_ssh(state):
+    """A query runs end-to-end over a real SSH channel and returns its output."""
+    query = Query(queryLocation="ssh_ok", queryTarget="192.0.2.1", queryType="echo_ssh")
+    conn = NetmikoConnection(device=state.devices["ssh_ok"], query_data=query)
+
+    responses = await conn.collect()
+
+    assert responses, "expected at least one command response"
+    assert any(f"{MARKER}_192.0.2.1" in r for r in responses), responses
+
+
+@pytest.mark.asyncio
+async def test_netmiko_bad_credentials_raise_autherror(state):
+    """A bad password surfaces as hyperglass AuthError (paramiko auth path)."""
+    query = Query(queryLocation="ssh_badauth", queryTarget="192.0.2.1", queryType="echo_ssh")
+    conn = NetmikoConnection(device=state.devices["ssh_badauth"], query_data=query)
+
+    with pytest.raises(AuthError):
+        await conn.collect()


### PR DESCRIPTION
## Summary

Adds the first real **SSH transport** coverage. Today the suite never exercises the netmiko/paramiko stack — it relies on `fake_output` — so dependency bumps to those libraries (auth, prompt detection, channel read/write, timeouts) ship unvalidated. This is the gap that made #127's netmiko/paramiko bumps unmergeable on faith.

- New `hyperglass/execution/drivers/tests/test_ssh_integration.py` drives the **real `NetmikoConnection`** against an actual OpenSSH server:
  - success path: a query runs end-to-end over a real SSH channel and returns its output;
  - failure path: a bad password surfaces as hyperglass `AuthError` (the paramiko auth path).
- `frr` maps to Netmiko's `linux_ssh` (`Device.get_device_type`), so a plain sshd is a *representative* target for the linux-based platforms hyperglass supports (FRR/BIRD/OpenBGPD), not a synthetic stand-in.
- Gated by `HYPERGLASS_TEST_SSH_HOST`/`_PORT` env — **skips** when unset, so `task test` and existing CI are unaffected.
- New `.github/workflows/ssh-integration.yml` runs it with an `openssh-server` **service container** (+ Redis, like backend CI), waits for sshd, and points the env at it.

Validated locally against a real `lscr.io/linuxserver/openssh-server` container: both tests pass; both skip cleanly with no env; Ruff clean.

## Test Plan
- [x] Local: 2 passed against a real sshd container; 2 skipped with no env; `ruff check` clean
- [ ] CI: the new **SSH Integration** job goes green (service container + wait + tests)

## Follow-ups
- Once green, consider adding **SSH Integration** to `main`'s required status checks and lifting the temporary `automerge: false` hold on `netmiko`/`paramiko` (renovate.json) so those bumps can flow through validated.
- Tier-2 (a real NOS like VyOS for command/parse coverage) remains optional future work.