### PR TITLE
fix(models): resolve query types by exact id + deterministic ordering (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- [#139](https://github.com/jsenecal/hyperglass/issues/139): A query type whose directive `id` is a substring of another directive's `id` (e.g. a text `<x>` vs. a structured `<x>-table` sibling) could resolve to the wrong directive — returning structured output for a text query, and non-deterministically across restarts. Query types now resolve by exact id (`MultiModel.filter`, not the substring `matching`), and `MultiModel` collections preserve first-seen insertion order (deterministic regardless of hash seed) instead of deriving order from set iteration.
+
 ### Changed
 
 - Timestamps shown to viewers (shared-result snapshot/expiry banners and the cached-result tooltip) are now formatted consistently through a single helper: parsed as UTC (the backend emits naive-UTC values), then rendered in the viewer's locale and timezone — including the locale's own 12-/24-hour convention. Previously these were a mix of raw UTC strings and browser-local times that were not actually timezone-converted.

--- a/hyperglass/models/api/query.py
+++ b/hyperglass/models/api/query.py
@@ -65,7 +65,10 @@ class Query(BaseModel):
         state = use_state()
         self._state = state
 
-        query_directives = self.device.directives.matching(self.query_type)
+        # Resolve by EXACT id, not a substring match: matching() would also
+        # return e.g. `foo-table` for query type `foo`, and then [0] could pick
+        # the wrong directive (issue #139). filter() matches the id exactly.
+        query_directives = self.device.directives.filter(self.query_type)
 
         if len(query_directives) < 1:
             raise QueryTypeNotFound(query_type=self.query_type)

--- a/hyperglass/models/main.py
+++ b/hyperglass/models/main.py
@@ -310,15 +310,15 @@ class MultiModel(RootModel[MultiModelT]):
     def _merge_with(self, *items, unique_by: t.Optional[str] = None) -> Series[MultiModelT]:
         to_add = self._valid_items(*items)
         if unique_by is not None:
-            unique_by_values = {
-                getattr(obj, unique_by) for obj in (*self, *to_add) if hasattr(obj, unique_by)
-            }
-            unique_by_objects = {
-                v: o
-                for v in unique_by_values
-                for o in (*self, *to_add)
-                if getattr(o, unique_by) == v
-            }
+            # Dedupe by `unique_by`, last write wins for the value but first-seen
+            # insertion order is preserved. A dict keyed on the value (rather than
+            # a set) keeps ordering deterministic regardless of hash seed —
+            # otherwise collection order varies per process and id resolution
+            # becomes non-deterministic across restarts.
+            unique_by_objects: t.Dict[t.Any, MultiModelT] = {}
+            for obj in (*self, *to_add):
+                if hasattr(obj, unique_by):
+                    unique_by_objects[getattr(obj, unique_by)] = obj
             return tuple(unique_by_objects.values())
         return (*self.root, *to_add)
 

--- a/hyperglass/models/tests/test_multi_model.py
+++ b/hyperglass/models/tests/test_multi_model.py
@@ -46,3 +46,43 @@ def test_multi_model():
     model.add(*ITEMS_3, unique_by="id")
     assert model.count == 6
     assert model["item1"].name == "Item New One"
+
+
+# Ids where one is a strict prefix of another, to exercise substring resolution.
+SUBSTRING_ITEMS = [
+    {"id": "route", "name": "Route"},
+    {"id": "route_table", "name": "Route Table"},
+]
+
+
+def test_filter_matches_exact_id_only():
+    """filter() must resolve an exact id even when another id is a superstring."""
+    model = Items(*SUBSTRING_ITEMS)
+    result = model.filter("route")
+    assert [item.id for item in result] == ["route"]
+
+
+def test_matching_is_substring_and_overmatches():
+    """matching() is intentionally a partial match — it returns both here.
+
+    Documents why query-type resolution must use filter(), not matching():
+    `matching("route")` also pulls in `route_table`.
+    """
+    model = Items(*SUBSTRING_ITEMS)
+    ids = sorted(item.id for item in model.matching("route"))
+    assert ids == ["route", "route_table"]
+
+
+def test_merge_preserves_first_seen_order():
+    """_merge_with()/add() must keep deterministic insertion (first-seen) order.
+
+    Order previously came from set iteration (hash-seed dependent), which made
+    matching()[0] non-deterministic across process restarts.
+    """
+    model = Items(*[{"id": f"item{n}", "name": str(n)} for n in range(10)])
+    model.add({"id": "item10", "name": "ten"}, unique_by="id")
+    assert [item.id for item in model] == [f"item{n}" for n in range(11)]
+    # Re-adding an existing id updates in place without reordering.
+    model.add({"id": "item3", "name": "three-updated"}, unique_by="id")
+    assert [item.id for item in model] == [f"item{n}" for n in range(11)]
+    assert model["item3"].name == "three-updated"


### PR DESCRIPTION
Fixes #139.

## Problem
A query type whose directive `id` is a **substring** of another directive's `id` could resolve to the wrong directive — e.g. a text `<x>` resolving to its structured `<x>-table` sibling, returning `application/json` for what should be `text/plain`. It was **non-deterministic across restarts**.

Two compounding bugs in `hyperglass/models/main.py` (verified in current code):
1. **`Query.__init__` resolved via `directives.matching(query_type)[0]`** — `matching()` is an unanchored substring regex (`.*{search}.*`), so `matching("x")` also returns `x-table`.
2. **`MultiModel._merge_with()` deduped via a `set`** — collection order tracked the hash seed, so which of the two matches landed at `[0]` varied per process.

## Fix
1. `models/api/query.py`: resolve by **exact id** with `directives.filter(query_type)` instead of `matching()`. (`matching()` is left intact for its other, intentional partial-match caller in `devices.py`.)
2. `models/main.py`: `_merge_with()` dedupes via a **first-seen dict**, preserving deterministic insertion order regardless of hash seed.

Either fix alone resolves the reported case; both together are the robust fix the issue recommends.

## Tests
- `test_filter_matches_exact_id_only` — `filter("route")` returns only `route`, not `route_table`.
- `test_matching_is_substring_and_overmatches` — documents why `matching()` is the wrong tool for resolution (returns both).
- `test_merge_preserves_first_seen_order` — **failed before the fix** (set-ordering scrambled order), passes after; also covers in-place update without reorder.
- Full backend suite: 126 passed, 2 skipped; Ruff clean.

## Note
An end-to-end `Query` regression test was intentionally omitted: `Query.validate_query_type` reads the `lru_cache`d `use_state("devices")`, and clearing that cache per-test (needed for custom directives) breaks unrelated BGP-route plugin tests that free-ride on the import-seeded cache. That test-isolation gap is pre-existing and worth a separate cleanup (e.g. having those plugin tests seed their own state); the unit tests above cover both root causes deterministically.