### PR TITLE
fix(parsing): tolerate missing peer_as/source_as in Juniper responses

### DIFF
--- a/hyperglass/models/parsing/juniper.py
+++ b/hyperglass/models/parsing/juniper.py
@@ -9,6 +9,7 @@ from pydantic import ConfigDict, field_validator, model_validator
 # Project
 from hyperglass.log import log
 from hyperglass.util import deep_convert_keys
+from hyperglass.state import use_state
 from hyperglass.models.data.bgp_route import BGPRouteTable
 
 # Local
@@ -48,8 +49,8 @@ class JuniperRouteTableEntry(JuniperBase):
     validation_state: int = 3
     next_hop: str
     peer_rid: str
-    peer_as: int
-    source_as: int
+    peer_as: int = 0
+    source_as: int = 0
     source_rid: str
     communities: t.List[str] = None
 
@@ -89,7 +90,10 @@ class JuniperRouteTableEntry(JuniperBase):
         _path_attr = values.get("bgp_path_attributes", {})
         _path_attr_agg = _path_attr.get("attr_aggregator", {}).get("attr_value", {})
         values["as_path"] = _path_attr.get("attr_as_path_effective", {}).get("attr_value", "")
-        values["source_as"] = _path_attr_agg.get("aggr_as_number", 0)
+        # Some Juniper devices omit the aggregator AS number. Fall back to the
+        # network's configured primary ASN so source_as is still populated.
+        primary_asn = use_state("params").primary_asn
+        values["source_as"] = _path_attr_agg.get("aggr_as_number") or primary_asn
         values["source_rid"] = _path_attr_agg.get("aggr_router_id", "")
         values["peer_rid"] = values.get("peer_id", "")
 


### PR DESCRIPTION
## What

Some Juniper devices do not return all BGP path attributes in their XML response — specifically the peer AS (`peer-as`) and the aggregator AS number. The strict `JuniperRouteTableEntry` model treated `peer_as` and `source_as` as required `int` fields, so parsing failed outright for those devices.

This change:

- Makes `peer_as` and `source_as` optional with a default of `0`.
- Falls back to the network's configured `primary_asn` (from `config.yaml`) when the aggregator AS number is absent, so `source_as` is still populated with a meaningful value instead of failing or showing `0`.

## Why

Restores route parsing for Juniper devices that omit these attributes, rather than erroring on the whole response.

## Notes for reviewers

- `primary_asn` is resolved at validation time via `use_state("params").primary_asn`, matching how other models access runtime config. It is stored as a string by the params validator and is coerced back to `int` by the `source_as: int` field.
- The fallback uses `... or primary_asn`, so it also applies when the aggregator key is present but empty/`None`, not just when it is missing entirely.